### PR TITLE
Card-centric architecture: typed links & reconciler

### DIFF
--- a/Sources/Kanban/CardDetailView.swift
+++ b/Sources/Kanban/CardDetailView.swift
@@ -36,7 +36,7 @@ struct CardDetailView: View {
         self.onRename = onRename
         self.onFork = onFork
         self.onDismiss = onDismiss
-        _selectedTab = State(initialValue: card.link.tmuxSession == nil ? 1 : 0)
+        _selectedTab = State(initialValue: card.link.tmuxLink == nil ? 1 : 0)
         // Tab 0 = Terminal, Tab 1 = History (Actions tab removed — buttons in header now)
     }
 
@@ -72,12 +72,28 @@ struct CardDetailView: View {
                     }
                 }
 
-                HStack(spacing: 8) {
-                    if let branch = card.link.worktreeBranch {
-                        Label(branch, systemImage: "arrow.triangle.branch")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                // Link pills
+                HStack(spacing: 6) {
+                    CardLabelBadge(label: card.link.cardLabel)
+
+                    if let sessionNum = card.link.sessionLink?.sessionNumber {
+                        linkPill(icon: "terminal", text: "#\(sessionNum)", color: .blue)
                     }
+                    if let tmux = card.link.tmuxLink?.sessionName {
+                        linkPill(icon: "terminal.fill", text: tmux, color: .green)
+                    }
+                    if let branch = card.link.worktreeLink?.branch {
+                        linkPill(icon: "arrow.triangle.branch", text: branch, color: .teal)
+                    }
+                    if let pr = card.link.prLink?.number {
+                        linkPill(icon: "arrow.triangle.pull", text: "#\(pr)", color: .purple)
+                    }
+                    if let issue = card.link.issueLink?.number {
+                        linkPill(icon: "exclamationmark.circle", text: "#\(issue)", color: .orange)
+                    }
+
+                    Spacer()
+
                     Text(card.relativeTime)
                         .font(.caption)
                         .foregroundStyle(.tertiary)
@@ -87,7 +103,7 @@ struct CardDetailView: View {
                     copyableRow(icon: "folder", text: projectPath)
                 }
 
-                if let sessionId = card.link.sessionId {
+                if let sessionId = card.link.sessionLink?.sessionId {
                     copyableRow(icon: "number", text: sessionId)
                 }
             }
@@ -173,7 +189,7 @@ struct CardDetailView: View {
 
     @ViewBuilder
     private var terminalView: some View {
-        if let tmuxSession = card.link.tmuxSession {
+        if let tmuxSession = card.link.tmuxLink?.sessionName {
             TerminalRepresentable.tmuxAttach(sessionName: tmuxSession)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -202,7 +218,7 @@ struct CardDetailView: View {
             Button(action: { showForkConfirm = true }) {
                 Label("Fork Session", systemImage: "arrow.branch")
             }
-            .disabled(card.link.sessionPath == nil)
+            .disabled(card.link.sessionLink?.sessionPath == nil)
 
             Button {
                 checkpointMode = true
@@ -210,7 +226,7 @@ struct CardDetailView: View {
             } label: {
                 Label("Checkpoint / Restore", systemImage: "clock.arrow.circlepath")
             }
-            .disabled(card.link.sessionPath == nil || turns.isEmpty)
+            .disabled(card.link.sessionLink?.sessionPath == nil || turns.isEmpty)
 
             Divider()
 
@@ -218,13 +234,13 @@ struct CardDetailView: View {
                 Label("Copy Resume Command", systemImage: "doc.on.doc")
             }
 
-            if let sessionId = card.link.sessionId {
+            if let sessionId = card.link.sessionLink?.sessionId {
                 Button(action: { copyToClipboard(sessionId) }) {
                     Label("Copy Session ID", systemImage: "number")
                 }
             }
 
-            if let pr = card.link.githubPR {
+            if let pr = card.link.prLink?.number {
                 Divider()
                 Button(action: {}) {
                     Label("Open PR #\(pr)", systemImage: "arrow.up.right.square")
@@ -241,7 +257,7 @@ struct CardDetailView: View {
     // MARK: - History loading
 
     private func loadHistory() async {
-        guard let path = card.link.sessionPath ?? card.session?.jsonlPath else { return }
+        guard let path = card.link.sessionLink?.sessionPath ?? card.session?.jsonlPath else { return }
         if turns.isEmpty { isLoadingHistory = true }
         do {
             turns = try await TranscriptReader.readTurns(from: path)
@@ -255,7 +271,7 @@ struct CardDetailView: View {
 
     private func startHistoryWatcher() {
         stopHistoryWatcher()
-        guard let path = card.link.sessionPath ?? card.session?.jsonlPath else { return }
+        guard let path = card.link.sessionLink?.sessionPath ?? card.session?.jsonlPath else { return }
 
         let fd = open(path, O_EVTONLY)
         guard fd >= 0 else { return }
@@ -291,7 +307,7 @@ struct CardDetailView: View {
     // MARK: - Fork
 
     private func performFork() {
-        guard let path = card.link.sessionPath else { return }
+        guard let path = card.link.sessionLink?.sessionPath else { return }
         Task {
             do {
                 let newId = try await sessionStore.forkSession(sessionPath: path)
@@ -306,7 +322,7 @@ struct CardDetailView: View {
     // MARK: - Checkpoint
 
     private func performCheckpoint() {
-        guard let path = card.link.sessionPath,
+        guard let path = card.link.sessionLink?.sessionPath,
               let turn = checkpointTurn else { return }
         Task {
             do {
@@ -325,12 +341,24 @@ struct CardDetailView: View {
         if let projectPath = card.link.projectPath {
             cmd += "cd \(projectPath) && "
         }
-        if let sessionId = card.link.sessionId {
+        if let sessionId = card.link.sessionLink?.sessionId {
             cmd += "claude --resume \(sessionId)"
         } else {
             cmd += "# no session yet"
         }
         copyToClipboard(cmd)
+    }
+
+    private func linkPill(icon: String, text: String, color: Color) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: icon)
+            Text(text)
+        }
+        .font(.caption2)
+        .foregroundStyle(color)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(color.opacity(0.12), in: Capsule())
     }
 
     private func copyToClipboard(_ text: String) {

--- a/Sources/Kanban/CardView.swift
+++ b/Sources/Kanban/CardView.swift
@@ -20,14 +20,14 @@ struct CardView: View {
                 .lineLimit(2)
                 .foregroundStyle(.primary)
 
-            // Project + branch
+            // Project + branch + link icons
             HStack(spacing: 4) {
                 if let projectName = card.projectName {
                     Label(projectName, systemImage: "folder")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                if let branch = card.link.worktreeBranch {
+                if let branch = card.link.worktreeLink?.branch {
                     Label(branch, systemImage: "arrow.triangle.branch")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -35,19 +35,13 @@ struct CardView: View {
             }
             .lineLimit(1)
 
-            // Bottom row: time + status
-            HStack {
+            // Bottom row: badge + time + link indicators + session number
+            HStack(spacing: 6) {
+                CardLabelBadge(label: card.link.cardLabel)
+
                 Text(card.relativeTime)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
-
-                Spacer()
-
-                if card.link.sessionNumber != nil {
-                    Text("#\(card.link.sessionNumber!)")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
             }
         }
         .padding(10)
@@ -97,7 +91,7 @@ struct CardView: View {
                 Label("Copy Resume Command", systemImage: "doc.on.doc")
             }
             Divider()
-            if let pr = card.link.githubPR {
+            if let pr = card.link.prLink?.number {
                 Button(action: {}) {
                     Label("Open PR #\(pr)", systemImage: "arrow.up.right.square")
                 }
@@ -108,5 +102,30 @@ struct CardView: View {
             }
         }
     }
+}
 
+// MARK: - Card Label Badge
+
+struct CardLabelBadge: View {
+    let label: CardLabel
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Text(label.rawValue)
+            .font(.system(size: 8, weight: .bold, design: .rounded))
+            .foregroundStyle(colorScheme == .dark ? .black : .white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(color, in: Capsule())
+    }
+
+    private var color: Color {
+        switch label {
+        case .session: .orange
+        case .worktree: .teal
+        case .issue: .blue
+        case .pr: .purple
+        case .task: .gray
+        }
+    }
 }

--- a/Sources/Kanban/ContentView.swift
+++ b/Sources/Kanban/ContentView.swift
@@ -10,6 +10,11 @@ struct ContentView: View {
     @AppStorage("appearanceMode") private var appearanceMode: AppearanceMode = .auto
     @State private var showAddFromPath = false
     @State private var addFromPathText = ""
+    @State private var showLaunchConfirmation = false
+    @State private var launchCardId: String?
+    @State private var launchPrompt: String = ""
+    @State private var launchProjectPath: String = ""
+    @State private var launchWorktreeName: String?
     @AppStorage("selectedProject") private var selectedProjectPersisted: String = ""
     private let coordinationStore: CoordinationStore
     private let settingsStore: SettingsStore
@@ -124,12 +129,25 @@ struct ContentView: View {
                     isPresented: $showNewTask,
                     projects: boardState.configuredProjects,
                     defaultProjectPath: boardState.selectedProjectPath
-                ) { title, description, projectPath, startImmediately in
-                    createManualTask(title: title, description: description, projectPath: projectPath, startImmediately: startImmediately)
+                ) { prompt, projectPath, startImmediately in
+                    createManualTask(prompt: prompt, projectPath: projectPath, startImmediately: startImmediately)
                 }
             }
             .sheet(isPresented: $showAddFromPath) {
                 addFromPathSheet
+            }
+            .sheet(isPresented: $showLaunchConfirmation) {
+                LaunchConfirmationDialog(
+                    cardId: launchCardId ?? "",
+                    projectPath: launchProjectPath,
+                    initialPrompt: launchPrompt,
+                    worktreeName: launchWorktreeName,
+                    isPresented: $showLaunchConfirmation
+                ) { editedPrompt, createWorktree in
+                    if let cardId = launchCardId {
+                        executeLaunch(cardId: cardId, prompt: editedPrompt, projectPath: launchProjectPath, worktreeName: createWorktree ? launchWorktreeName : nil)
+                    }
+                }
             }
             .sheet(isPresented: $showOnboarding) {
                 OnboardingWizard(
@@ -497,13 +515,16 @@ struct ContentView: View {
         }
     }
 
-    private func createManualTask(title: String, description: String, projectPath: String?, startImmediately: Bool = false) {
+    private func createManualTask(prompt: String, projectPath: String?, startImmediately: Bool = false) {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let firstLine = trimmed.components(separatedBy: .newlines).first ?? trimmed
+        let name = String(firstLine.prefix(100))
         let link = Link(
+            name: name,
             projectPath: projectPath,
             column: startImmediately ? .inProgress : .backlog,
-            name: title,
             source: .manual,
-            issueBody: description.isEmpty ? nil : description
+            promptBody: trimmed
         )
         let linkId = link.id
         Task {
@@ -521,29 +542,32 @@ struct ContentView: View {
         guard let card = boardState.cards.first(where: { $0.id == cardId }) else { return }
         let projectPath = card.link.projectPath ?? NSHomeDirectory()
 
+        // Build prompt using PromptBuilder
+        Task {
+            let settings = try? await settingsStore.read()
+            let project = settings?.projects.first(where: { $0.path == projectPath })
+            let prompt = PromptBuilder.buildPrompt(card: card.link, project: project, settings: settings)
+
+            // Determine worktree name
+            let worktreeName: String?
+            if let issueNum = card.link.issueLink?.number {
+                worktreeName = "issue-\(issueNum)"
+            } else {
+                worktreeName = nil
+            }
+
+            // Show launch confirmation dialog
+            launchCardId = cardId
+            launchPrompt = prompt
+            launchProjectPath = projectPath
+            launchWorktreeName = worktreeName
+            showLaunchConfirmation = true
+        }
+    }
+
+    private func executeLaunch(cardId: String, prompt: String, projectPath: String, worktreeName: String?) {
         Task {
             do {
-                // Load skill prefix from settings
-                let settings = try? await settingsStore.read()
-                let skillPrefix = settings?.skill.isEmpty == false ? settings?.skill : nil
-
-                // Build prompt from card name + issue body
-                var prompt = card.displayTitle
-                if let body = card.link.issueBody, !body.isEmpty {
-                    prompt += "\n\n" + body
-                }
-                if let skillPrefix {
-                    prompt = skillPrefix + " " + prompt
-                }
-
-                // Determine worktree name
-                let worktreeName: String?
-                if let issueNum = card.link.githubIssue {
-                    worktreeName = "issue-\(issueNum)"
-                } else {
-                    worktreeName = nil // let claude auto-generate
-                }
-
                 let tmuxName = try await launcher.launch(
                     projectPath: projectPath,
                     prompt: prompt,
@@ -553,7 +577,7 @@ struct ContentView: View {
 
                 // Update the EXISTING link (by link.id) — no new link created
                 try? await coordinationStore.updateLink(id: cardId) { @Sendable link in
-                    link.tmuxSession = tmuxName
+                    link.tmuxLink = TmuxLink(sessionName: tmuxName)
                     link.column = .inProgress
                 }
                 boardState.setCardColumn(cardId: cardId, to: .inProgress)
@@ -566,7 +590,7 @@ struct ContentView: View {
 
     private func resumeCard(cardId: String) {
         guard let card = boardState.cards.first(where: { $0.id == cardId }) else { return }
-        let sessionId = card.link.sessionId ?? card.link.id
+        let sessionId = card.link.sessionLink?.sessionId ?? card.link.id
         let projectPath = card.link.projectPath ?? NSHomeDirectory()
 
         Task {
@@ -579,7 +603,7 @@ struct ContentView: View {
 
                 // Update link with tmux session (by link.id)
                 try? await coordinationStore.updateLink(id: cardId) { @Sendable link in
-                    link.tmuxSession = tmuxName
+                    link.tmuxLink = TmuxLink(sessionName: tmuxName)
                     if link.column != .inProgress {
                         link.column = .inProgress
                     }

--- a/Sources/Kanban/LaunchConfirmationDialog.swift
+++ b/Sources/Kanban/LaunchConfirmationDialog.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import KanbanCore
+
+/// Pre-launch confirmation dialog showing editable prompt and options.
+struct LaunchConfirmationDialog: View {
+    let cardId: String
+    let projectPath: String
+    let initialPrompt: String
+    var worktreeName: String?
+    @Binding var isPresented: Bool
+    var onLaunch: (String, Bool) -> Void = { _, _ in } // (editedPrompt, createWorktree)
+
+    @State private var prompt: String = ""
+    @AppStorage("createWorktree") private var createWorktree = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Launch Session")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            // Project path (read-only)
+            HStack(spacing: 6) {
+                Image(systemName: "folder")
+                    .foregroundStyle(.secondary)
+                Text(projectPath)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            // Worktree name (if applicable)
+            if let name = worktreeName {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .foregroundStyle(.secondary)
+                    Text(name)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Editable prompt
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Prompt")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                TextEditor(text: $prompt)
+                    .font(.body.monospaced())
+                    .frame(minHeight: 120, maxHeight: 300)
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+            }
+
+            // Create worktree checkbox
+            Toggle("Create worktree", isOn: $createWorktree)
+                .font(.callout)
+
+            // Buttons
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    isPresented = false
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Launch") {
+                    onLaunch(prompt, createWorktree)
+                    isPresented = false
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 500)
+        .onAppear {
+            prompt = initialPrompt
+        }
+    }
+}

--- a/Sources/Kanban/NewTaskDialog.swift
+++ b/Sources/Kanban/NewTaskDialog.swift
@@ -5,10 +5,9 @@ struct NewTaskDialog: View {
     @Binding var isPresented: Bool
     var projects: [Project] = []
     var defaultProjectPath: String?
-    var onCreate: (String, String, String?, Bool) -> Void = { _, _, _, _ in }
+    var onCreate: (String, String?, Bool) -> Void = { _, _, _ in }
 
-    @State private var title = ""
-    @State private var description = ""
+    @State private var prompt = ""
     @State private var selectedProjectPath: String = ""
     @State private var customPath = ""
     @AppStorage("startTaskImmediately") private var startImmediately = true
@@ -21,12 +20,22 @@ struct NewTaskDialog: View {
                 .font(.title3)
                 .fontWeight(.semibold)
 
-            TextField("Task title", text: $title)
-                .textFieldStyle(.roundedBorder)
-
-            TextField("Description (optional)", text: $description, axis: .vertical)
-                .textFieldStyle(.roundedBorder)
-                .lineLimit(3...6)
+            TextEditor(text: $prompt)
+                .font(.body.monospaced())
+                .frame(minHeight: 80, maxHeight: 200)
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+                .overlay(alignment: .topLeading) {
+                    if prompt.isEmpty {
+                        Text("Describe what you want Claude to do...")
+                            .font(.body.monospaced())
+                            .foregroundStyle(.tertiary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 16)
+                            .allowsHitTesting(false)
+                    }
+                }
 
             if projects.isEmpty {
                 TextField("Project path (optional)", text: $customPath)
@@ -60,18 +69,17 @@ struct NewTaskDialog: View {
 
                 Button(startImmediately ? "Create & Start" : "Create") {
                     let proj = resolvedProjectPath
-                    onCreate(title, description, proj, startImmediately)
+                    onCreate(prompt, proj, startImmediately)
                     isPresented = false
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(title.isEmpty)
+                .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .buttonStyle(.borderedProminent)
             }
         }
         .padding(20)
-        .frame(width: 400)
+        .frame(width: 450)
         .onAppear {
-            // Default to the currently selected project, or first project
             if let defaultPath = defaultProjectPath,
                projects.contains(where: { $0.path == defaultPath }) {
                 selectedProjectPath = defaultPath

--- a/Sources/Kanban/SearchOverlay.swift
+++ b/Sources/Kanban/SearchOverlay.swift
@@ -181,7 +181,7 @@ struct SearchOverlay: View {
         let terms = queryTerms
         guard !terms.isEmpty else { return [] }
         return cards.filter { card in
-            let text = "\(card.displayTitle) \(card.projectName ?? "") \(card.link.worktreeBranch ?? "")".lowercased()
+            let text = "\(card.displayTitle) \(card.projectName ?? "") \(card.link.worktreeLink?.branch ?? "")".lowercased()
             return terms.allSatisfy { text.contains($0) }
         }
     }
@@ -195,13 +195,13 @@ struct SearchOverlay: View {
         isDeepSearching = true
         defer { isDeepSearching = false }
 
-        let paths = cards.compactMap { $0.link.sessionPath ?? $0.session?.jsonlPath }
+        let paths = cards.compactMap { $0.link.sessionLink?.sessionPath ?? $0.session?.jsonlPath }
         let store = ClaudeCodeSessionStore()
 
         do {
             let results = try await store.searchSessions(query: query, paths: paths)
             searchResults = results.map { result in
-                let card = cards.first { ($0.link.sessionPath ?? $0.session?.jsonlPath) == result.sessionPath }
+                let card = cards.first { ($0.link.sessionLink?.sessionPath ?? $0.session?.jsonlPath) == result.sessionPath }
                 return SearchResultItem(
                     id: result.sessionPath,
                     card: card,

--- a/Sources/KanbanCore/Domain/Entities/Link.swift
+++ b/Sources/KanbanCore/Domain/Entities/Link.swift
@@ -1,68 +1,274 @@
 import Foundation
 
-/// The coordination record linking a session to its worktree, tmux session, PR, and board position.
+// MARK: - Typed Link Sub-Structs
+
+/// Link to a Claude Code session.
+public struct SessionLink: Codable, Sendable, Equatable {
+    public var sessionId: String
+    public var sessionPath: String?
+    public var sessionNumber: Int?
+
+    public init(sessionId: String, sessionPath: String? = nil, sessionNumber: Int? = nil) {
+        self.sessionId = sessionId
+        self.sessionPath = sessionPath
+        self.sessionNumber = sessionNumber
+    }
+}
+
+/// Link to a tmux terminal session.
+public struct TmuxLink: Codable, Sendable, Equatable {
+    public var sessionName: String
+
+    public init(sessionName: String) {
+        self.sessionName = sessionName
+    }
+}
+
+/// Link to a git worktree.
+public struct WorktreeLink: Codable, Sendable, Equatable {
+    public var path: String
+    public var branch: String?
+
+    public init(path: String, branch: String? = nil) {
+        self.path = path
+        self.branch = branch
+    }
+}
+
+/// Link to a GitHub pull request.
+public struct PRLink: Codable, Sendable, Equatable {
+    public var number: Int
+
+    public init(number: Int) {
+        self.number = number
+    }
+}
+
+/// Link to a GitHub issue.
+public struct IssueLink: Codable, Sendable, Equatable {
+    public var number: Int
+    public var url: String?
+    public var body: String?
+
+    public init(number: Int, url: String? = nil, body: String? = nil) {
+        self.number = number
+        self.url = url
+        self.body = body
+    }
+}
+
+// MARK: - Card Label
+
+/// The primary label shown on a card, derived from which links are present.
+public enum CardLabel: String, Sendable {
+    case session = "SESSION"
+    case worktree = "WORKTREE"
+    case issue = "ISSUE"
+    case pr = "PR"
+    case task = "TASK"
+}
+
+// MARK: - Link (Card Entity)
+
+/// The coordination record — a card on the board with independently optional typed links.
 /// Stored in ~/.kanban/links.json.
 public struct Link: Identifiable, Codable, Sendable {
     public let id: String
-    public var sessionId: String? // Real Claude session UUID, nil until discovered
-    public var sessionPath: String? // Full path to .jsonl file
-    public var worktreePath: String?
-    public var worktreeBranch: String?
-    public var tmuxSession: String?
-    public var githubIssue: Int?
-    public var githubPR: Int?
+
+    // Card-level properties
+    public var name: String?
     public var projectPath: String?
     public var column: KanbanColumn
-    public var name: String?
     public var createdAt: Date
     public var updatedAt: Date
     public var lastActivity: Date?
     public var manualOverrides: ManualOverrides
     public var manuallyArchived: Bool
     public var source: LinkSource
-    public var sessionNumber: Int?
-    public var issueBody: String?
+    public var promptBody: String?
+
+    // Typed links — each independently optional
+    public var sessionLink: SessionLink?
+    public var tmuxLink: TmuxLink?
+    public var worktreeLink: WorktreeLink?
+    public var prLink: PRLink?
+    public var issueLink: IssueLink?
+
+    // MARK: - Backward-compat computed properties
+
+    /// Claude session UUID. Use `sessionLink?.sessionId` for new code.
+    public var sessionId: String? { sessionLink?.sessionId }
+    /// Path to .jsonl transcript. Use `sessionLink?.sessionPath` for new code.
+    public var sessionPath: String? { sessionLink?.sessionPath }
+    /// Tmux session name. Use `tmuxLink?.sessionName` for new code.
+    public var tmuxSession: String? { tmuxLink?.sessionName }
+    /// Worktree directory path. Use `worktreeLink?.path` for new code.
+    public var worktreePath: String? { worktreeLink?.path }
+    /// Git branch name. Use `worktreeLink?.branch` for new code.
+    public var worktreeBranch: String? { worktreeLink?.branch }
+    /// GitHub issue number. Use `issueLink?.number` for new code.
+    public var githubIssue: Int? { issueLink?.number }
+    /// GitHub PR number. Use `prLink?.number` for new code.
+    public var githubPR: Int? { prLink?.number }
+    /// Session display number. Use `sessionLink?.sessionNumber` for new code.
+    public var sessionNumber: Int? { sessionLink?.sessionNumber }
+    /// Issue body or manual prompt. Use `issueLink?.body ?? promptBody` for new code.
+    public var issueBody: String? { issueLink?.body ?? promptBody }
+
+    /// The primary label for this card based on which links are present.
+    public var cardLabel: CardLabel {
+        if sessionLink != nil { return .session }
+        if worktreeLink != nil { return .worktree }
+        if issueLink != nil { return .issue }
+        if prLink != nil { return .pr }
+        return .task
+    }
+
+    // MARK: - Init
 
     public init(
-        id: String = UUID().uuidString,
-        sessionId: String? = nil,
-        sessionPath: String? = nil,
-        worktreePath: String? = nil,
-        worktreeBranch: String? = nil,
-        tmuxSession: String? = nil,
-        githubIssue: Int? = nil,
-        githubPR: Int? = nil,
+        id: String = KSUID.generate(prefix: "card"),
+        name: String? = nil,
         projectPath: String? = nil,
         column: KanbanColumn = .allSessions,
-        name: String? = nil,
         createdAt: Date = .now,
         updatedAt: Date = .now,
         lastActivity: Date? = nil,
         manualOverrides: ManualOverrides = ManualOverrides(),
         manuallyArchived: Bool = false,
         source: LinkSource = .discovered,
-        sessionNumber: Int? = nil,
-        issueBody: String? = nil
+        promptBody: String? = nil,
+        sessionLink: SessionLink? = nil,
+        tmuxLink: TmuxLink? = nil,
+        worktreeLink: WorktreeLink? = nil,
+        prLink: PRLink? = nil,
+        issueLink: IssueLink? = nil
     ) {
         self.id = id
-        self.sessionId = sessionId
-        self.sessionPath = sessionPath
-        self.worktreePath = worktreePath
-        self.worktreeBranch = worktreeBranch
-        self.tmuxSession = tmuxSession
-        self.githubIssue = githubIssue
-        self.githubPR = githubPR
+        self.name = name
         self.projectPath = projectPath
         self.column = column
-        self.name = name
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.lastActivity = lastActivity
         self.manualOverrides = manualOverrides
         self.manuallyArchived = manuallyArchived
         self.source = source
-        self.sessionNumber = sessionNumber
-        self.issueBody = issueBody
+        self.promptBody = promptBody
+        self.sessionLink = sessionLink
+        self.tmuxLink = tmuxLink
+        self.worktreeLink = worktreeLink
+        self.prLink = prLink
+        self.issueLink = issueLink
+    }
+
+    // MARK: - Backward-compatible Codable
+
+    private enum CodingKeys: String, CodingKey {
+        // Card-level
+        case id, name, projectPath, column, createdAt, updatedAt, lastActivity
+        case manualOverrides, manuallyArchived, source, promptBody
+        // Typed links (new nested format)
+        case sessionLink, tmuxLink, worktreeLink, prLink, issueLink
+        // Old flat keys (for reading legacy format)
+        case sessionId, sessionPath, worktreePath, worktreeBranch
+        case tmuxSession, githubIssue, githubPR, sessionNumber, issueBody
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decodeIfPresent(String.self, forKey: .name)
+        projectPath = try c.decodeIfPresent(String.self, forKey: .projectPath)
+        column = try c.decodeIfPresent(KanbanColumn.self, forKey: .column) ?? .allSessions
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? .now
+        updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? .now
+        lastActivity = try c.decodeIfPresent(Date.self, forKey: .lastActivity)
+        manualOverrides = try c.decodeIfPresent(ManualOverrides.self, forKey: .manualOverrides) ?? ManualOverrides()
+        manuallyArchived = try c.decodeIfPresent(Bool.self, forKey: .manuallyArchived) ?? false
+        source = try c.decodeIfPresent(LinkSource.self, forKey: .source) ?? .discovered
+        promptBody = try c.decodeIfPresent(String.self, forKey: .promptBody)
+
+        // Session link: try nested first, fallback to flat
+        if let sl = try c.decodeIfPresent(SessionLink.self, forKey: .sessionLink) {
+            sessionLink = sl
+        } else {
+            let sid = try c.decodeIfPresent(String.self, forKey: .sessionId)
+            let sp = try c.decodeIfPresent(String.self, forKey: .sessionPath)
+            let sn = try c.decodeIfPresent(Int.self, forKey: .sessionNumber)
+            sessionLink = sid.map { SessionLink(sessionId: $0, sessionPath: sp, sessionNumber: sn) }
+        }
+
+        // Tmux link
+        if let tl = try c.decodeIfPresent(TmuxLink.self, forKey: .tmuxLink) {
+            tmuxLink = tl
+        } else if let ts = try c.decodeIfPresent(String.self, forKey: .tmuxSession) {
+            tmuxLink = TmuxLink(sessionName: ts)
+        } else {
+            tmuxLink = nil
+        }
+
+        // Worktree link
+        if let wl = try c.decodeIfPresent(WorktreeLink.self, forKey: .worktreeLink) {
+            worktreeLink = wl
+        } else {
+            let wp = try c.decodeIfPresent(String.self, forKey: .worktreePath)
+            let wb = try c.decodeIfPresent(String.self, forKey: .worktreeBranch)
+            if let wp {
+                worktreeLink = WorktreeLink(path: wp, branch: wb)
+            } else if let wb {
+                worktreeLink = WorktreeLink(path: "", branch: wb)
+            } else {
+                worktreeLink = nil
+            }
+        }
+
+        // PR link
+        if let pl = try c.decodeIfPresent(PRLink.self, forKey: .prLink) {
+            prLink = pl
+        } else if let pn = try c.decodeIfPresent(Int.self, forKey: .githubPR) {
+            prLink = PRLink(number: pn)
+        } else {
+            prLink = nil
+        }
+
+        // Issue link
+        if let il = try c.decodeIfPresent(IssueLink.self, forKey: .issueLink) {
+            issueLink = il
+        } else if let issueNum = try c.decodeIfPresent(Int.self, forKey: .githubIssue) {
+            let body = try c.decodeIfPresent(String.self, forKey: .issueBody)
+            issueLink = IssueLink(number: issueNum, body: body)
+        } else {
+            issueLink = nil
+            // Migrate issueBody to promptBody for manual tasks
+            if promptBody == nil {
+                promptBody = try c.decodeIfPresent(String.self, forKey: .issueBody)
+            }
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+
+        try c.encode(id, forKey: .id)
+        try c.encodeIfPresent(name, forKey: .name)
+        try c.encodeIfPresent(projectPath, forKey: .projectPath)
+        try c.encode(column, forKey: .column)
+        try c.encode(createdAt, forKey: .createdAt)
+        try c.encode(updatedAt, forKey: .updatedAt)
+        try c.encodeIfPresent(lastActivity, forKey: .lastActivity)
+        try c.encode(manualOverrides, forKey: .manualOverrides)
+        try c.encode(manuallyArchived, forKey: .manuallyArchived)
+        try c.encode(source, forKey: .source)
+        try c.encodeIfPresent(promptBody, forKey: .promptBody)
+
+        // Always write new nested format
+        try c.encodeIfPresent(sessionLink, forKey: .sessionLink)
+        try c.encodeIfPresent(tmuxLink, forKey: .tmuxLink)
+        try c.encodeIfPresent(worktreeLink, forKey: .worktreeLink)
+        try c.encodeIfPresent(prLink, forKey: .prLink)
+        try c.encodeIfPresent(issueLink, forKey: .issueLink)
     }
 }
 
@@ -83,6 +289,14 @@ public struct ManualOverrides: Codable, Sendable {
         self.tmuxSession = tmuxSession
         self.name = name
         self.column = column
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        worktreePath = try c.decodeIfPresent(Bool.self, forKey: .worktreePath) ?? false
+        tmuxSession = try c.decodeIfPresent(Bool.self, forKey: .tmuxSession) ?? false
+        name = try c.decodeIfPresent(Bool.self, forKey: .name) ?? false
+        column = try c.decodeIfPresent(Bool.self, forKey: .column) ?? false
     }
 }
 

--- a/Sources/KanbanCore/Domain/Entities/Project.swift
+++ b/Sources/KanbanCore/Domain/Entities/Project.swift
@@ -9,6 +9,8 @@ public struct Project: Identifiable, Codable, Sendable {
     public var visible: Bool
     public var githubFilter: String? // Per-project gh filter, nil = inherit global default
     public var remoteConfig: RemoteSettings? // Per-project remote execution config
+    public var promptTemplate: String? // Per-project template, nil = inherit global
+    public var githubIssuePromptTemplate: String? // Per-project issue template, nil = inherit global
 
     public init(
         path: String,
@@ -16,7 +18,9 @@ public struct Project: Identifiable, Codable, Sendable {
         repoRoot: String? = nil,
         visible: Bool = true,
         githubFilter: String? = nil,
-        remoteConfig: RemoteSettings? = nil
+        remoteConfig: RemoteSettings? = nil,
+        promptTemplate: String? = nil,
+        githubIssuePromptTemplate: String? = nil
     ) {
         self.path = path
         self.name = name ?? (path as NSString).lastPathComponent
@@ -24,6 +28,8 @@ public struct Project: Identifiable, Codable, Sendable {
         self.visible = visible
         self.githubFilter = githubFilter
         self.remoteConfig = remoteConfig
+        self.promptTemplate = promptTemplate
+        self.githubIssuePromptTemplate = githubIssuePromptTemplate
     }
 
     /// The effective git repository root (repoRoot if set, otherwise path).

--- a/Sources/KanbanCore/Infrastructure/CoordinationStore.swift
+++ b/Sources/KanbanCore/Infrastructure/CoordinationStore.swift
@@ -67,7 +67,7 @@ public actor CoordinationStore {
 
     /// Get a single link by session ID.
     public func linkForSession(_ sessionId: String) throws -> Link? {
-        try readLinks().first { $0.sessionId == sessionId }
+        try readLinks().first { $0.sessionLink?.sessionId == sessionId }
     }
 
     /// Upsert a link: update if exists (by link.id), insert if new.
@@ -93,7 +93,7 @@ public actor CoordinationStore {
     /// Update specific fields of a link by session ID.
     public func updateLink(sessionId: String, update: (inout Link) -> Void) throws {
         var links = try readLinks()
-        guard let index = links.firstIndex(where: { $0.sessionId == sessionId }) else { return }
+        guard let index = links.firstIndex(where: { $0.sessionLink?.sessionId == sessionId }) else { return }
         update(&links[index])
         links[index].updatedAt = .now
         try writeLinks(links)
@@ -109,7 +109,7 @@ public actor CoordinationStore {
     /// Remove a link by session ID.
     public func removeLink(sessionId: String) throws {
         var links = try readLinks()
-        links.removeAll { $0.sessionId == sessionId }
+        links.removeAll { $0.sessionLink?.sessionId == sessionId }
         try writeLinks(links)
     }
 
@@ -119,7 +119,7 @@ public actor CoordinationStore {
         var links = try readLinks()
         let before = links.count
         links.removeAll { link in
-            guard let path = link.sessionPath else { return false }
+            guard let path = link.sessionLink?.sessionPath else { return false }
             return !fileManager.fileExists(atPath: path)
         }
         if links.count != before {

--- a/Sources/KanbanCore/Infrastructure/KSUID.swift
+++ b/Sources/KanbanCore/Infrastructure/KSUID.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Lightweight KSUID (K-Sortable Unique Identifier) generator.
+///
+/// Format: 4-byte timestamp (seconds since epoch 2014-05-13) + 16-byte random payload,
+/// base62-encoded to 27 characters. Naturally sortable by creation time.
+///
+/// Usage:
+/// ```swift
+/// let id = KSUID.generate(prefix: "card") // "card_2MtCMwXZOHPSlEMDe7OYW6bRfXX"
+/// let raw = KSUID.generate()               // "2MtCMwXZOHPSlEMDe7OYW6bRfXX"
+/// ```
+public enum KSUID {
+    /// KSUID epoch: 2014-05-13T16:53:20Z (1400000000 unix seconds)
+    private static let epoch: UInt32 = 1_400_000_000
+
+    private static let base62Chars = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+    private static let encodedLength = 27
+
+    /// Generate a new KSUID, optionally with a prefix (e.g., "card" → "card_...").
+    public static func generate(prefix: String? = nil) -> String {
+        let timestamp = UInt32(Date().timeIntervalSince1970) - epoch
+
+        // 4-byte timestamp (big-endian) + 16-byte random payload = 20 bytes
+        var bytes = [UInt8](repeating: 0, count: 20)
+        bytes[0] = UInt8((timestamp >> 24) & 0xFF)
+        bytes[1] = UInt8((timestamp >> 16) & 0xFF)
+        bytes[2] = UInt8((timestamp >> 8) & 0xFF)
+        bytes[3] = UInt8(timestamp & 0xFF)
+
+        // Fill 16 random bytes
+        for i in 4..<20 {
+            bytes[i] = UInt8.random(in: 0...255)
+        }
+
+        let encoded = base62Encode(bytes)
+        if let prefix {
+            return "\(prefix)_\(encoded)"
+        }
+        return encoded
+    }
+
+    /// Base62-encode a 20-byte array into a 27-character string.
+    /// Uses big-endian arithmetic division to produce a fixed-width output.
+    private static func base62Encode(_ bytes: [UInt8]) -> String {
+        // Convert bytes to a big integer (array of UInt8), then repeatedly divide by 62
+        var number = bytes
+        var result = [Character](repeating: "0", count: encodedLength)
+
+        for i in stride(from: encodedLength - 1, through: 0, by: -1) {
+            var remainder: UInt16 = 0
+            for j in 0..<number.count {
+                let value = UInt16(number[j]) + remainder * 256
+                number[j] = UInt8(value / 62)
+                remainder = value % 62
+            }
+            result[i] = base62Chars[Int(remainder)]
+        }
+
+        return String(result)
+    }
+}

--- a/Sources/KanbanCore/Infrastructure/SettingsStore.swift
+++ b/Sources/KanbanCore/Infrastructure/SettingsStore.swift
@@ -8,7 +8,8 @@ public struct Settings: Codable, Sendable {
     public var notifications: NotificationSettings
     public var remote: RemoteSettings?
     public var sessionTimeout: SessionTimeoutSettings
-    public var skill: String
+    public var promptTemplate: String
+    public var githubIssuePromptTemplate: String
     public var columnOrder: [KanbanColumn]
     public var hasCompletedOnboarding: Bool
 
@@ -19,7 +20,8 @@ public struct Settings: Codable, Sendable {
         notifications: NotificationSettings = NotificationSettings(),
         remote: RemoteSettings? = nil,
         sessionTimeout: SessionTimeoutSettings = SessionTimeoutSettings(),
-        skill: String = "",
+        promptTemplate: String = "",
+        githubIssuePromptTemplate: String = "#${number}: ${title}\n\n${body}",
         columnOrder: [KanbanColumn] = KanbanColumn.allCases,
         hasCompletedOnboarding: Bool = false
     ) {
@@ -29,9 +31,16 @@ public struct Settings: Codable, Sendable {
         self.notifications = notifications
         self.remote = remote
         self.sessionTimeout = sessionTimeout
-        self.skill = skill
+        self.promptTemplate = promptTemplate
+        self.githubIssuePromptTemplate = githubIssuePromptTemplate
         self.columnOrder = columnOrder
         self.hasCompletedOnboarding = hasCompletedOnboarding
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case projects, globalView, github, notifications, remote, sessionTimeout
+        case promptTemplate, githubIssuePromptTemplate, columnOrder, hasCompletedOnboarding
+        case skill // backward-compat: old name for promptTemplate
     }
 
     // Backward-compatible decoding — new fields default gracefully
@@ -43,9 +52,28 @@ public struct Settings: Codable, Sendable {
         notifications = try container.decodeIfPresent(NotificationSettings.self, forKey: .notifications) ?? NotificationSettings()
         remote = try container.decodeIfPresent(RemoteSettings.self, forKey: .remote)
         sessionTimeout = try container.decodeIfPresent(SessionTimeoutSettings.self, forKey: .sessionTimeout) ?? SessionTimeoutSettings()
-        skill = try container.decodeIfPresent(String.self, forKey: .skill) ?? ""
+        // Backward-compat: try "promptTemplate" first, fall back to "skill"
+        promptTemplate = try container.decodeIfPresent(String.self, forKey: .promptTemplate)
+            ?? container.decodeIfPresent(String.self, forKey: .skill) ?? ""
+        githubIssuePromptTemplate = try container.decodeIfPresent(String.self, forKey: .githubIssuePromptTemplate)
+            ?? "#${number}: ${title}\n\n${body}"
         columnOrder = try container.decodeIfPresent([KanbanColumn].self, forKey: .columnOrder) ?? KanbanColumn.allCases
         hasCompletedOnboarding = try container.decodeIfPresent(Bool.self, forKey: .hasCompletedOnboarding) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(projects, forKey: .projects)
+        try container.encode(globalView, forKey: .globalView)
+        try container.encode(github, forKey: .github)
+        try container.encode(notifications, forKey: .notifications)
+        try container.encodeIfPresent(remote, forKey: .remote)
+        try container.encode(sessionTimeout, forKey: .sessionTimeout)
+        try container.encode(promptTemplate, forKey: .promptTemplate)
+        try container.encode(githubIssuePromptTemplate, forKey: .githubIssuePromptTemplate)
+        try container.encode(columnOrder, forKey: .columnOrder)
+        try container.encode(hasCompletedOnboarding, forKey: .hasCompletedOnboarding)
+        // Note: "skill" is NOT encoded — only read for backward-compat
     }
 }
 

--- a/Sources/KanbanCore/UseCases/AssignColumn.swift
+++ b/Sources/KanbanCore/UseCases/AssignColumn.swift
@@ -52,12 +52,12 @@ public enum AssignColumn {
         }
 
         // GitHub issue source without a session yet → backlog
-        if link.source == .githubIssue && link.sessionId == nil {
+        if link.source == .githubIssue && link.sessionLink == nil {
             return .backlog
         }
 
         // Manual task without a session yet → backlog
-        if link.source == .manual && link.sessionId == nil {
+        if link.source == .manual && link.sessionLink == nil {
             return .backlog
         }
 

--- a/Sources/KanbanCore/UseCases/BackgroundOrchestrator.swift
+++ b/Sources/KanbanCore/UseCases/BackgroundOrchestrator.swift
@@ -117,7 +117,7 @@ public final class BackgroundOrchestrator: @unchecked Sendable {
         var message = "Waiting for input"
         var imageData: Data?
 
-        if let transcriptPath = link?.sessionPath {
+        if let transcriptPath = link?.sessionLink?.sessionPath {
             if let lastText = await TranscriptNotificationReader.lastAssistantText(transcriptPath: transcriptPath) {
                 let lineCount = lastText.components(separatedBy: "\n").count
                 if lineCount > 1 {
@@ -143,8 +143,8 @@ public final class BackgroundOrchestrator: @unchecked Sendable {
             let links = try await coordinationStore.readLinks()
             let sessionPaths = Dictionary(
                 links.compactMap { link -> (String, String)? in
-                    guard let sessionId = link.sessionId,
-                          let path = link.sessionPath else { return nil }
+                    guard let sessionId = link.sessionLink?.sessionId,
+                          let path = link.sessionLink?.sessionPath else { return nil }
                     return (sessionId, path)
                 },
                 uniquingKeysWith: { a, _ in a }
@@ -179,11 +179,11 @@ public final class BackgroundOrchestrator: @unchecked Sendable {
             let tmuxNames = Set(tmuxSessions.map(\.name))
 
             for i in links.indices {
-                guard let sessionId = links[i].sessionId else { continue }
+                guard let sessionId = links[i].sessionLink?.sessionId else { continue }
                 let activityState = await activityDetector.activityState(for: sessionId)
-                let pr = links[i].worktreeBranch.flatMap { allPRs[$0] }
-                let hasWorktree = links[i].worktreeBranch != nil
-                let hasTmux = links[i].tmuxSession.map { tmuxNames.contains($0) } ?? false
+                let pr = links[i].worktreeLink?.branch.flatMap { allPRs[$0] }
+                let hasWorktree = links[i].worktreeLink?.branch != nil
+                let hasTmux = links[i].tmuxLink.map { tmuxNames.contains($0.sessionName) } ?? false
 
                 // Clear manual column override when we have definitive activity data
                 // (hooks fired, or tmux session gone). Manual override is only for user drags.
@@ -191,9 +191,9 @@ public final class BackgroundOrchestrator: @unchecked Sendable {
                     if activityState != .stale {
                         // Hooks provided real data — let auto-assignment take over
                         links[i].manualOverrides.column = false
-                    } else if links[i].tmuxSession != nil && !hasTmux {
+                    } else if links[i].tmuxLink != nil && !hasTmux {
                         // Had a tmux session but it's gone now
-                        links[i].tmuxSession = nil
+                        links[i].tmuxLink = nil
                         links[i].manualOverrides.column = false
                     }
                 }

--- a/Sources/KanbanCore/UseCases/BoardState.swift
+++ b/Sources/KanbanCore/UseCases/BoardState.swift
@@ -23,7 +23,7 @@ public struct KanbanCard: Identifiable, Sendable {
     public var displayTitle: String {
         if let name = link.name, !name.isEmpty { return name }
         if let session { return session.displayTitle }
-        if let sid = link.sessionId { return String(sid.prefix(8)) + "..." }
+        if let sid = link.sessionLink?.sessionId { return String(sid.prefix(8)) + "..." }
         return String(link.id.prefix(8)) + "..."
     }
 
@@ -173,7 +173,7 @@ public final class BoardState: @unchecked Sendable {
             // Persist to our coordination store
             try? await coordinationStore.upsertLink(link)
             // Also update Claude's sessions-index.json so other tools see the rename
-            if let sessionId = link.sessionId {
+            if let sessionId = link.sessionLink?.sessionId {
                 try? SessionIndexReader.updateSummary(sessionId: sessionId, summary: name)
             }
         }
@@ -232,52 +232,19 @@ public final class BoardState: @unchecked Sendable {
             }
 
             let sessions = try await discovery.discoverSessions()
-            var links = try await coordinationStore.readLinks()
+            let existingLinks = try await coordinationStore.readLinks()
             let sessionsById = Dictionary(sessions.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
 
-            // Index links by link.id (primary key) and build reverse sessionId → linkId map
-            var linksById = Dictionary(links.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
-            var linkIdBySessionId: [String: String] = [:]
-            for link in links {
-                if let sid = link.sessionId {
-                    linkIdBySessionId[sid] = link.id
-                }
-            }
-
-            for session in sessions {
-                if let linkId = linkIdBySessionId[session.id], var link = linksById[linkId] {
-                    // Update existing link with latest session data (non-override fields)
-                    link.sessionPath = session.jsonlPath
-                    link.lastActivity = session.modifiedTime
-                    if !link.manualOverrides.column {
-                        let activity = await activityDetector?.activityState(for: session.id)
-                        link.column = AssignColumn.assign(link: link, activityState: activity)
-                    }
-                    linksById[linkId] = link
-                } else {
-                    // New session not referenced by any link — create discovered link
-                    let newLink = Link(
-                        sessionId: session.id,
-                        sessionPath: session.jsonlPath,
-                        projectPath: session.projectPath,
-                        column: .allSessions,
-                        lastActivity: session.modifiedTime,
-                        source: .discovered
-                    )
-                    linksById[newLink.id] = newLink
-                    linkIdBySessionId[session.id] = newLink.id
-                }
-            }
-
-            // Build cards with activity states
-            let mergedLinks = Array(linksById.values)
+            // Reconcile: match sessions/worktrees/PRs to existing cards
+            let snapshot = CardReconciler.DiscoverySnapshot(sessions: sessions)
+            let mergedLinks = CardReconciler.reconcile(existing: existingLinks, snapshot: snapshot)
             var newCards: [KanbanCard] = []
             for link in mergedLinks {
-                let sessionId = link.sessionId ?? link.id
+                let sessionId = link.sessionLink?.sessionId ?? link.id
                 let activity = await activityDetector?.activityState(for: sessionId)
                 newCards.append(KanbanCard(
                     link: link,
-                    session: link.sessionId.flatMap { sessionsById[$0] },
+                    session: link.sessionLink.flatMap { sessionsById[$0.sessionId] },
                     activityState: activity
                 ))
             }
@@ -363,16 +330,15 @@ public final class BoardState: @unchecked Sendable {
 
                     // Check if link already exists
                     let existing = links.first(where: {
-                        $0.githubIssue == issue.number && $0.projectPath == project.path
+                        $0.issueLink?.number == issue.number && $0.projectPath == project.path
                     })
                     if existing == nil {
                         let link = Link(
-                            githubIssue: issue.number,
+                            name: "#\(issue.number): \(issue.title)",
                             projectPath: project.path,
                             column: .backlog,
-                            name: "#\(issue.number): \(issue.title)",
                             source: .githubIssue,
-                            issueBody: issue.body
+                            issueLink: IssueLink(number: issue.number, body: issue.body)
                         )
                         links.append(link)
                         changed = true
@@ -388,7 +354,7 @@ public final class BoardState: @unchecked Sendable {
         links.removeAll { link in
             guard link.source == .githubIssue,
                   link.column == .backlog,
-                  let issueNum = link.githubIssue,
+                  let issueNum = link.issueLink?.number,
                   let projPath = link.projectPath else { return false }
             let key = "\(projPath):\(issueNum)"
             return !fetchedIssueKeys.contains(key)
@@ -403,14 +369,14 @@ public final class BoardState: @unchecked Sendable {
             var newCards: [KanbanCard] = []
             for link in links {
                 let activity: ActivityState?
-                if let sessionId = link.sessionId {
+                if let sessionId = link.sessionLink?.sessionId {
                     activity = await activityDetector?.activityState(for: sessionId)
                 } else {
                     activity = nil
                 }
                 newCards.append(KanbanCard(
                     link: link,
-                    session: link.sessionId.flatMap { sessionsById[$0] },
+                    session: link.sessionLink.flatMap { sessionsById[$0.sessionId] },
                     activityState: activity
                 ))
             }

--- a/Sources/KanbanCore/UseCases/CardReconciler.swift
+++ b/Sources/KanbanCore/UseCases/CardReconciler.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+/// Pure reconciliation logic: matches discovered resources to existing cards,
+/// preventing duplicate card creation (the "triplication bug").
+///
+/// Responsibilities:
+/// - Match discovered sessions to existing cards (by sessionId → tmux name → worktree branch)
+/// - Create new cards for truly unmatched sessions
+/// - Match discovered worktrees to existing cards (by branch)
+/// - Create orphan worktree cards for unmatched worktrees
+/// - Add/update PR links via branch matching
+/// - Clear dead tmux and worktree links
+///
+/// NOT responsible for: column assignment, activity detection, GitHub issue syncing.
+public enum CardReconciler {
+
+    /// A point-in-time snapshot of all discovered external resources.
+    public struct DiscoverySnapshot: Sendable {
+        public let sessions: [Session]
+        public let tmuxSessions: [TmuxSession]
+        public let worktrees: [String: [Worktree]]     // repoRoot → worktrees
+        public let pullRequests: [String: PullRequest]  // branch → PR
+
+        public init(
+            sessions: [Session] = [],
+            tmuxSessions: [TmuxSession] = [],
+            worktrees: [String: [Worktree]] = [:],
+            pullRequests: [String: PullRequest] = [:]
+        ) {
+            self.sessions = sessions
+            self.tmuxSessions = tmuxSessions
+            self.worktrees = worktrees
+            self.pullRequests = pullRequests
+        }
+    }
+
+    /// Reconcile existing cards with discovered resources.
+    /// Returns the merged list of links (some updated, some new, some with cleared links).
+    public static func reconcile(existing: [Link], snapshot: DiscoverySnapshot) -> [Link] {
+        var linksById: [String: Link] = [:]
+        for link in existing {
+            linksById[link.id] = link
+        }
+
+        // Build reverse indexes for matching
+        var cardIdBySessionId: [String: String] = [:]
+        var cardIdByTmuxName: [String: String] = [:]
+        var cardIdsByBranch: [String: [String]] = [:]
+
+        for link in existing {
+            if let sid = link.sessionLink?.sessionId {
+                cardIdBySessionId[sid] = link.id
+            }
+            if let tmux = link.tmuxLink?.sessionName {
+                cardIdByTmuxName[tmux] = link.id
+            }
+            if let branch = link.worktreeLink?.branch {
+                cardIdsByBranch[branch, default: []].append(link.id)
+            }
+        }
+
+        // Track which sessions we've matched so we can detect new ones
+        var matchedSessionIds: Set<String> = []
+
+        // A. Match sessions to existing cards
+        for session in snapshot.sessions {
+            let cardId = findCardForSession(
+                session: session,
+                cardIdBySessionId: cardIdBySessionId,
+                cardIdByTmuxName: cardIdByTmuxName,
+                cardIdsByBranch: cardIdsByBranch,
+                linksById: linksById
+            )
+
+            if let cardId, var link = linksById[cardId] {
+                // Update existing card with session data
+                if link.sessionLink == nil {
+                    // First time linking session to this card
+                    link.sessionLink = SessionLink(
+                        sessionId: session.id,
+                        sessionPath: session.jsonlPath
+                    )
+                    cardIdBySessionId[session.id] = link.id
+                } else {
+                    // Update existing session link
+                    link.sessionLink?.sessionPath = session.jsonlPath
+                }
+                link.lastActivity = session.modifiedTime
+                if link.projectPath == nil, let pp = session.projectPath {
+                    link.projectPath = pp
+                }
+                linksById[cardId] = link
+                matchedSessionIds.insert(session.id)
+            } else {
+                // Truly new session — create discovered card
+                let newLink = Link(
+                    projectPath: session.projectPath,
+                    column: .allSessions,
+                    lastActivity: session.modifiedTime,
+                    source: .discovered,
+                    sessionLink: SessionLink(
+                        sessionId: session.id,
+                        sessionPath: session.jsonlPath
+                    )
+                )
+                linksById[newLink.id] = newLink
+                cardIdBySessionId[session.id] = newLink.id
+                matchedSessionIds.insert(session.id)
+            }
+        }
+
+        // B. Match worktrees to existing cards
+        let liveTmuxNames = Set(snapshot.tmuxSessions.map(\.name))
+        var liveWorktreePaths: Set<String> = []
+        let didScanWorktrees = !snapshot.worktrees.isEmpty
+
+        for (_, worktrees) in snapshot.worktrees {
+            for worktree in worktrees {
+                guard !worktree.isBare else { continue }
+                liveWorktreePaths.insert(worktree.path)
+
+                guard let branch = worktree.branch else { continue }
+                // Skip main/master branches — they're not worktrees we track
+                let baseName = branch.replacingOccurrences(of: "refs/heads/", with: "")
+                if baseName == "main" || baseName == "master" { continue }
+
+                let existingCardIds = cardIdsByBranch[baseName] ?? []
+                if existingCardIds.isEmpty {
+                    // Orphan worktree — create a new card
+                    let newLink = Link(
+                        column: .allSessions,
+                        source: .discovered,
+                        worktreeLink: WorktreeLink(path: worktree.path, branch: baseName)
+                    )
+                    linksById[newLink.id] = newLink
+                    cardIdsByBranch[baseName, default: []].append(newLink.id)
+                } else {
+                    // Update existing card's worktree path
+                    for cardId in existingCardIds {
+                        if var link = linksById[cardId] {
+                            link.worktreeLink?.path = worktree.path
+                            linksById[cardId] = link
+                        }
+                    }
+                }
+            }
+        }
+
+        // C. Match PRs to existing cards via branch
+        for (branch, pr) in snapshot.pullRequests {
+            let cardIds = cardIdsByBranch[branch] ?? []
+            for cardId in cardIds {
+                if var link = linksById[cardId] {
+                    link.prLink = PRLink(number: pr.number)
+                    linksById[cardId] = link
+                }
+            }
+        }
+
+        // D. Clear dead links
+        for (id, var link) in linksById {
+            var changed = false
+
+            // Clear dead tmux links (tmux session no longer exists)
+            if let tmuxName = link.tmuxLink?.sessionName,
+               !link.manualOverrides.tmuxSession,
+               !liveTmuxNames.contains(tmuxName) {
+                link.tmuxLink = nil
+                changed = true
+            }
+
+            // Clear dead worktree links (path no longer exists on disk)
+            if let wtPath = link.worktreeLink?.path,
+               !wtPath.isEmpty,
+               !link.manualOverrides.worktreePath,
+               didScanWorktrees, // only clear if we actually scanned worktrees
+               !liveWorktreePaths.contains(wtPath) {
+                link.worktreeLink = nil
+                changed = true
+            }
+
+            if changed {
+                linksById[id] = link
+            }
+        }
+
+        return Array(linksById.values)
+    }
+
+    // MARK: - Private
+
+    /// Find an existing card that should own this session.
+    /// Match priority: exact sessionId → tmux name → worktree branch.
+    private static func findCardForSession(
+        session: Session,
+        cardIdBySessionId: [String: String],
+        cardIdByTmuxName: [String: String],
+        cardIdsByBranch: [String: [String]],
+        linksById: [String: Link]
+    ) -> String? {
+        // 1. Exact match by sessionId
+        if let cardId = cardIdBySessionId[session.id] {
+            return cardId
+        }
+
+        // 2. Match by worktree branch (session has gitBranch matching a card's worktreeLink)
+        if let branch = session.gitBranch {
+            let baseName = branch.replacingOccurrences(of: "refs/heads/", with: "")
+            if let cardIds = cardIdsByBranch[baseName] {
+                // Prefer cards that don't already have a session (pending cards)
+                let pendingCards = cardIds.filter { linksById[$0]?.sessionLink == nil }
+                if let cardId = pendingCards.first { return cardId }
+                // Otherwise use the first match
+                if let cardId = cardIds.first { return cardId }
+            }
+        }
+
+        // 3. Match by project path + tmux (card has tmuxLink, same project, no sessionLink yet)
+        if let projectPath = session.projectPath {
+            for (_, link) in linksById {
+                if link.tmuxLink != nil,
+                   link.sessionLink == nil,
+                   link.projectPath == projectPath {
+                    return link.id
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/KanbanCore/UseCases/PromptBuilder.swift
+++ b/Sources/KanbanCore/UseCases/PromptBuilder.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Builds the final prompt to send to Claude, applying templates from settings and project config.
+public enum PromptBuilder {
+
+    /// Build the full prompt for a card, applying appropriate templates.
+    ///
+    /// For issue cards: applies `githubIssuePromptTemplate` then wraps with `promptTemplate`.
+    /// For manual tasks: wraps `promptBody` with `promptTemplate`.
+    /// For session cards: uses card name as-is (no template needed).
+    public static func buildPrompt(
+        card link: Link,
+        project: Project? = nil,
+        settings: Settings? = nil
+    ) -> String {
+        var prompt: String
+
+        if let issueLink = link.issueLink {
+            // GitHub issue: apply issue template
+            let issueTemplate = project?.githubIssuePromptTemplate
+                ?? settings?.githubIssuePromptTemplate
+                ?? "#${number}: ${title}\n\n${body}"
+            prompt = applyTemplate(issueTemplate, variables: [
+                "number": String(issueLink.number),
+                "title": link.name?.replacingOccurrences(of: "#\(issueLink.number): ", with: "") ?? "",
+                "body": issueLink.body ?? "",
+                "url": issueLink.url ?? "",
+            ])
+        } else if let promptBody = link.promptBody {
+            prompt = promptBody
+        } else {
+            prompt = link.name ?? ""
+        }
+
+        // Wrap with prompt template (prefix/suffix)
+        let template = project?.promptTemplate ?? settings?.promptTemplate ?? ""
+        if !template.isEmpty {
+            prompt = applyTemplate(template, variables: [
+                "prompt": prompt,
+            ])
+            // If template doesn't contain ${prompt}, prepend it
+            if !template.contains("${prompt}") {
+                prompt = template + " " + prompt
+            }
+        }
+
+        return prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Replace `${key}` placeholders with values from the variables dictionary.
+    public static func applyTemplate(_ template: String, variables: [String: String]) -> String {
+        var result = template
+        for (key, value) in variables {
+            result = result.replacingOccurrences(of: "${\(key)}", with: value)
+        }
+        return result
+    }
+}

--- a/Sources/KanbanCore/UseCases/UpdateCardColumn.swift
+++ b/Sources/KanbanCore/UseCases/UpdateCardColumn.swift
@@ -36,10 +36,10 @@ public enum UpdateCardColumn {
         worktreeBranches: Set<String>
     ) {
         for i in links.indices {
-            guard let sessionId = links[i].sessionId else { continue }
+            guard let sessionId = links[i].sessionLink?.sessionId else { continue }
             let activityState = activityStates[sessionId]
-            let pr = links[i].worktreeBranch.flatMap { prs[$0] }
-            let hasWorktree = links[i].worktreeBranch != nil && worktreeBranches.contains(links[i].worktreeBranch!)
+            let pr = links[i].worktreeLink?.branch.flatMap { prs[$0] }
+            let hasWorktree = links[i].worktreeLink?.branch != nil && worktreeBranches.contains(links[i].worktreeLink!.branch!)
 
             update(
                 link: &links[i],

--- a/Tests/KanbanCoreTests/AssignColumnTests.swift
+++ b/Tests/KanbanCoreTests/AssignColumnTests.swift
@@ -7,7 +7,7 @@ struct AssignColumnTests {
 
     @Test("Manual column override is respected")
     func manualOverride() {
-        var link = Link(sessionId: "s1", column: .done)
+        var link = Link(column: .done, sessionLink: SessionLink(sessionId: "s1"))
         link.manualOverrides.column = true
         let col = AssignColumn.assign(link: link, activityState: .activelyWorking)
         #expect(col == .done)
@@ -15,98 +15,98 @@ struct AssignColumnTests {
 
     @Test("Manually archived goes to allSessions")
     func manuallyArchived() {
-        let link = Link(sessionId: "s1", column: .inProgress, manuallyArchived: true)
+        let link = Link(column: .inProgress, manuallyArchived: true, sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .activelyWorking)
         #expect(col == .allSessions)
     }
 
     @Test("PR merged → done")
     func prMerged() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, prMerged: true)
         #expect(col == .done)
     }
 
     @Test("PR exists + idle → inReview")
     func prExistsIdle() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .idleWaiting, hasPR: true)
         #expect(col == .inReview)
     }
 
     @Test("PR exists + actively working → inProgress (not inReview)")
     func prExistsActive() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .activelyWorking, hasPR: true)
         #expect(col == .inProgress)
     }
 
     @Test("Actively working → inProgress")
     func activelyWorking() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .activelyWorking)
         #expect(col == .inProgress)
     }
 
     @Test("Needs attention → requiresAttention")
     func needsAttention() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .needsAttention)
         #expect(col == .requiresAttention)
     }
 
     @Test("Idle with worktree → inProgress")
     func idleWithWorktree() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .idleWaiting, hasWorktree: true)
         #expect(col == .inProgress)
     }
 
     @Test("Idle without worktree, recent → requiresAttention")
     func idleNoWorktreeRecent() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-3600))
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-3600), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .idleWaiting)
         #expect(col == .requiresAttention)
     }
 
     @Test("Idle without worktree, old → allSessions")
     func idleNoWorktreeOld() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-90000))
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-90000), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .idleWaiting)
         #expect(col == .allSessions)
     }
 
     @Test("Ended with worktree → requiresAttention")
     func endedWithWorktree() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .ended, hasWorktree: true)
         #expect(col == .requiresAttention)
     }
 
     @Test("Stale + recent → requiresAttention (falls through to recency check)")
     func staleRecent() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-3600))
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-3600), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .stale)
         #expect(col == .requiresAttention)
     }
 
     @Test("Stale + old → allSessions")
     func staleOld() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-90000))
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-90000), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .stale)
         #expect(col == .allSessions)
     }
 
     @Test("Ended without worktree, recent → requiresAttention")
     func endedNoWorktreeRecent() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-3600))
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-3600), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .ended)
         #expect(col == .requiresAttention)
     }
 
     @Test("Ended without worktree, old → allSessions")
     func endedNoWorktreeOld() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-90000))
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-90000), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .ended)
         #expect(col == .allSessions)
     }
@@ -127,21 +127,21 @@ struct AssignColumnTests {
 
     @Test("No signals → allSessions")
     func noSignals() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link)
         #expect(col == .allSessions)
     }
 
     @Test("Recently active session (within 24h) → requiresAttention (not inProgress)")
     func recentlyActive() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-3600)) // 1h ago
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-3600), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link)
         #expect(col == .requiresAttention)
     }
 
     @Test("Session active 2h ago → requiresAttention")
     func activeToday() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-7200)) // 2h ago
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-7200), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link)
         #expect(col == .requiresAttention)
     }
@@ -149,7 +149,7 @@ struct AssignColumnTests {
     @Test("Only activelyWorking activity state → inProgress")
     func onlyActivelyWorkingIsInProgress() {
         // Without activityState, recent sessions should NOT be inProgress
-        let recentLink = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-60)) // 1 min ago
+        let recentLink = Link(lastActivity: Date.now.addingTimeInterval(-60), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: recentLink)
         #expect(col == .requiresAttention)
 
@@ -160,14 +160,14 @@ struct AssignColumnTests {
 
     @Test("Archive sets manuallyArchived → allSessions regardless of recency")
     func archivedRecentSession() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-300), manuallyArchived: true)
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-300), manuallyArchived: true, sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link)
         #expect(col == .allSessions)
     }
 
     @Test("Session active 25h ago → allSessions (stale)")
     func staleSession() {
-        let link = Link(sessionId: "s1", lastActivity: Date.now.addingTimeInterval(-90000)) // 25h ago
+        let link = Link(lastActivity: Date.now.addingTimeInterval(-90000), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link)
         #expect(col == .allSessions)
     }

--- a/Tests/KanbanCoreTests/BoardStateIntegrationTests.swift
+++ b/Tests/KanbanCoreTests/BoardStateIntegrationTests.swift
@@ -70,7 +70,7 @@ struct BoardStateIntegrationTests {
         // Card ID is the link's UUID, not the session's UUID
         let card = state.cards[0]
         #expect(card.id == card.link.id)
-        #expect(card.link.sessionId == "my-session-uuid")
+        #expect(card.link.sessionLink?.sessionId == "my-session-uuid")
     }
 
     @Test("selectedCardId survives refresh when card still exists")
@@ -86,7 +86,7 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.selectedCardId = cardId
 
         await state.refresh()
@@ -107,7 +107,7 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.selectedCardId = cardId
 
         // Session disappears from discovery AND we clear it from the store
@@ -132,7 +132,7 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.selectedCardId = cardId
 
         // Session temporarily disappears from discovery (e.g. file locked)
@@ -164,7 +164,7 @@ struct BoardStateIntegrationTests {
         #expect(state.cards.count == 1)
 
         // Find card by sessionId to get its actual link.id
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
 
         // Rename the card
         state.renameCard(cardId: cardId, name: "My Custom Name")
@@ -179,7 +179,7 @@ struct BoardStateIntegrationTests {
         await state.refresh()
 
         // Name should survive
-        let card = state.cards.first(where: { $0.link.sessionId == "s1" })
+        let card = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })
         #expect(card?.link.name == "My Custom Name")
         #expect(card?.link.manualOverrides.name == true)
         #expect(card?.displayTitle == "My Custom Name")
@@ -198,7 +198,7 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.renameCard(cardId: cardId, name: "Renamed")
         try await Task.sleep(for: .milliseconds(100))
 
@@ -223,14 +223,14 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.moveCard(cardId: cardId, to: .inProgress)
         try await Task.sleep(for: .milliseconds(100))
 
         // Refresh
         await state.refresh()
 
-        let card = state.cards.first(where: { $0.link.sessionId == "s1" })
+        let card = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })
         #expect(card?.link.column == .inProgress)
         #expect(card?.link.manualOverrides.column == true)
     }
@@ -279,7 +279,7 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let cardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let cardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.archiveCard(cardId: cardId)
 
         // In-memory: card should be allSessions and manuallyArchived
@@ -292,7 +292,7 @@ struct BoardStateIntegrationTests {
 
         // Persists through refresh
         await state.refresh()
-        let refreshed = state.cards.first(where: { $0.link.sessionId == "s1" })
+        let refreshed = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })
         #expect(refreshed?.link.manuallyArchived == true)
         #expect(refreshed?.link.column == .allSessions)
     }
@@ -367,7 +367,7 @@ struct BoardStateIntegrationTests {
         await state.refresh()
         state.selectedProjectPath = "/projects/foo"
         #expect(state.filteredCards.count == 1)
-        #expect(state.filteredCards[0].link.sessionId == "s1")
+        #expect(state.filteredCards[0].link.sessionLink?.sessionId == "s1")
     }
 
     @Test("New sessions merge with existing persisted links")
@@ -383,7 +383,7 @@ struct BoardStateIntegrationTests {
         let state = BoardState(discovery: discovery, coordinationStore: store)
 
         await state.refresh()
-        let s1CardId = state.cards.first(where: { $0.link.sessionId == "s1" })!.id
+        let s1CardId = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })!.id
         state.renameCard(cardId: s1CardId, name: "Custom")
         try await Task.sleep(for: .milliseconds(100))
 
@@ -395,7 +395,7 @@ struct BoardStateIntegrationTests {
 
         // Both should exist, s1 should keep its name
         #expect(state.cards.count == 2)
-        let s1 = state.cards.first(where: { $0.link.sessionId == "s1" })
+        let s1 = state.cards.first(where: { $0.link.sessionLink?.sessionId == "s1" })
         #expect(s1?.link.name == "Custom")
     }
 }

--- a/Tests/KanbanCoreTests/CardLifecycleTests.swift
+++ b/Tests/KanbanCoreTests/CardLifecycleTests.swift
@@ -7,21 +7,25 @@ struct CardLifecycleTests {
 
     @Test("Active session moves to inProgress")
     func activeToInProgress() {
-        var link = Link(sessionId: "s1", column: .allSessions)
+        var link = Link(column: .allSessions, sessionLink: SessionLink(sessionId: "s1"))
         UpdateCardColumn.update(link: &link, activityState: .activelyWorking, pr: nil, hasWorktree: false)
         #expect(link.column == .inProgress)
     }
 
     @Test("Stop with no follow-up moves to requiresAttention")
     func stopToRequiresAttention() {
-        var link = Link(sessionId: "s1", column: .inProgress)
+        var link = Link(column: .inProgress, sessionLink: SessionLink(sessionId: "s1"))
         UpdateCardColumn.update(link: &link, activityState: .needsAttention, pr: nil, hasWorktree: false)
         #expect(link.column == .requiresAttention)
     }
 
     @Test("PR exists + idle → inReview")
     func prIdleToInReview() {
-        var link = Link(sessionId: "s1", worktreeBranch: "feature-x", column: .inProgress)
+        var link = Link(
+            column: .inProgress,
+            sessionLink: SessionLink(sessionId: "s1"),
+            worktreeLink: WorktreeLink(path: "", branch: "feature-x")
+        )
         let pr = PullRequest(number: 42, title: "Add feature", state: "open", url: "https://github.com/test/pr/42", headRefName: "feature-x")
         UpdateCardColumn.update(link: &link, activityState: .idleWaiting, pr: pr, hasWorktree: true)
         #expect(link.column == .inReview)
@@ -29,7 +33,7 @@ struct CardLifecycleTests {
 
     @Test("PR merged → done")
     func prMergedToDone() {
-        var link = Link(sessionId: "s1", column: .inReview)
+        var link = Link(column: .inReview, sessionLink: SessionLink(sessionId: "s1"))
         let pr = PullRequest(number: 42, title: "Add feature", state: "merged", url: "https://github.com/test/pr/42", headRefName: "feature-x")
         UpdateCardColumn.update(link: &link, activityState: .ended, pr: pr, hasWorktree: false)
         #expect(link.column == .done)
@@ -37,7 +41,7 @@ struct CardLifecycleTests {
 
     @Test("Manual override is respected even with conflicting state")
     func manualOverride() {
-        var link = Link(sessionId: "s1", column: .done)
+        var link = Link(column: .done, sessionLink: SessionLink(sessionId: "s1"))
         link.manualOverrides.column = true
         UpdateCardColumn.update(link: &link, activityState: .activelyWorking, pr: nil, hasWorktree: true)
         #expect(link.column == .done)
@@ -45,14 +49,18 @@ struct CardLifecycleTests {
 
     @Test("Ended session with worktree → requiresAttention")
     func endedWithWorktree() {
-        var link = Link(sessionId: "s1", worktreeBranch: "feature-x", column: .inProgress)
+        var link = Link(
+            column: .inProgress,
+            sessionLink: SessionLink(sessionId: "s1"),
+            worktreeLink: WorktreeLink(path: "", branch: "feature-x")
+        )
         UpdateCardColumn.update(link: &link, activityState: .ended, pr: nil, hasWorktree: true)
         #expect(link.column == .requiresAttention)
     }
 
     @Test("Stale session → allSessions")
     func staleToAllSessions() {
-        var link = Link(sessionId: "s1", column: .inProgress)
+        var link = Link(column: .inProgress, sessionLink: SessionLink(sessionId: "s1"))
         UpdateCardColumn.update(link: &link, activityState: .stale, pr: nil, hasWorktree: false)
         #expect(link.column == .allSessions)
     }
@@ -60,8 +68,8 @@ struct CardLifecycleTests {
     @Test("Batch update processes all links")
     func batchUpdate() {
         var links = [
-            Link(sessionId: "s1", column: .allSessions),
-            Link(sessionId: "s2", column: .allSessions),
+            Link(column: .allSessions, sessionLink: SessionLink(sessionId: "s1")),
+            Link(column: .allSessions, sessionLink: SessionLink(sessionId: "s2")),
         ]
         let states: [String: ActivityState] = [
             "s1": .activelyWorking,
@@ -74,7 +82,7 @@ struct CardLifecycleTests {
 
     @Test("Column doesn't change when state results in same column")
     func noUnnecessaryUpdate() {
-        var link = Link(sessionId: "s1", column: .inProgress)
+        var link = Link(column: .inProgress, sessionLink: SessionLink(sessionId: "s1"))
         let originalUpdatedAt = link.updatedAt
         UpdateCardColumn.update(link: &link, activityState: .activelyWorking, pr: nil, hasWorktree: false)
         // Column is already inProgress, so updatedAt should not change

--- a/Tests/KanbanCoreTests/CardReconcilerTests.swift
+++ b/Tests/KanbanCoreTests/CardReconcilerTests.swift
@@ -1,0 +1,393 @@
+import Testing
+import Foundation
+@testable import KanbanCore
+
+@Suite("CardReconciler")
+struct CardReconcilerTests {
+
+    // MARK: - Session matching
+
+    @Test("New session creates a discovered card")
+    func newSessionCreatesCard() {
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", messageCount: 1, modifiedTime: .now)]
+        )
+        let result = CardReconciler.reconcile(existing: [], snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].sessionLink?.sessionId == "s1")
+        #expect(result[0].source == .discovered)
+        #expect(result[0].column == .allSessions)
+    }
+
+    @Test("Existing card matched by sessionId is updated, not duplicated")
+    func matchBySessionId() {
+        let existing = [
+            Link(
+                column: .inProgress,
+                lastActivity: Date.now.addingTimeInterval(-3600),
+                sessionLink: SessionLink(sessionId: "s1", sessionPath: "/old/path.jsonl")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", messageCount: 5, modifiedTime: .now, jsonlPath: "/new/path.jsonl")]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].id == existing[0].id) // Same card
+        #expect(result[0].sessionLink?.sessionPath == "/new/path.jsonl") // Updated path
+    }
+
+    @Test("Session matched to pending card by worktree branch")
+    func matchByWorktreeBranch() {
+        let existing = [
+            Link(
+                name: "#42: Fix login",
+                projectPath: "/project",
+                column: .backlog,
+                source: .githubIssue,
+                worktreeLink: WorktreeLink(path: "/worktree", branch: "fix-login"),
+                issueLink: IssueLink(number: 42)
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", projectPath: "/project", gitBranch: "fix-login", messageCount: 1, modifiedTime: .now)]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].id == existing[0].id) // Reused existing card
+        #expect(result[0].sessionLink?.sessionId == "s1") // Session linked
+        #expect(result[0].issueLink?.number == 42) // Issue still there
+        #expect(result[0].name == "#42: Fix login") // Name preserved
+    }
+
+    @Test("Session matched to pending card by tmux + project path")
+    func matchByTmuxAndProject() {
+        let existing = [
+            Link(
+                name: "My task",
+                projectPath: "/project",
+                column: .inProgress,
+                source: .manual,
+                tmuxLink: TmuxLink(sessionName: "my-task")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", projectPath: "/project", messageCount: 1, modifiedTime: .now)]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].id == existing[0].id)
+        #expect(result[0].sessionLink?.sessionId == "s1")
+        #expect(result[0].name == "My task")
+    }
+
+    // MARK: - Triplication bug
+
+    @Test("Manual task + start + session discovery = 1 card (not 3!)")
+    func noTriplication() {
+        // Step 1: User creates manual task and clicks Start Immediately
+        // This creates a card with tmuxLink + worktreeLink, no sessionLink yet
+        let manualCard = Link(
+            name: "Fix auth bug",
+            projectPath: "/project",
+            column: .inProgress,
+            source: .manual,
+            promptBody: "Fix the authentication bug in the login flow",
+            tmuxLink: TmuxLink(sessionName: "fix-auth"),
+            worktreeLink: WorktreeLink(path: "/project/.claude/worktrees/fix-auth", branch: "fix-auth")
+        )
+
+        // Step 2: Session discovery finds the Claude session running in the worktree
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [
+                Session(
+                    id: "claude-uuid-123",
+                    projectPath: "/project",
+                    gitBranch: "fix-auth",
+                    messageCount: 10,
+                    modifiedTime: .now,
+                    jsonlPath: "/path/to/session.jsonl"
+                )
+            ],
+            tmuxSessions: [
+                TmuxSession(name: "fix-auth", path: "/project/.claude/worktrees/fix-auth", attached: false)
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: [manualCard], snapshot: snapshot)
+
+        // Should be exactly 1 card — the manual card, now with a sessionLink attached
+        #expect(result.count == 1)
+        #expect(result[0].id == manualCard.id)
+        #expect(result[0].name == "Fix auth bug")
+        #expect(result[0].source == .manual)
+        #expect(result[0].sessionLink?.sessionId == "claude-uuid-123")
+        #expect(result[0].tmuxLink?.sessionName == "fix-auth")
+        #expect(result[0].worktreeLink?.branch == "fix-auth")
+    }
+
+    @Test("GitHub issue + start work = 1 card (issue gains sessionLink)")
+    func issueGainsSession() {
+        let issueCard = Link(
+            name: "#123: Fix the bug",
+            projectPath: "/project",
+            column: .backlog,
+            source: .githubIssue,
+            tmuxLink: TmuxLink(sessionName: "issue-123"),
+            worktreeLink: WorktreeLink(path: "/worktree", branch: "issue-123"),
+            issueLink: IssueLink(number: 123, body: "Fix the bug")
+        )
+
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [
+                Session(id: "s1", projectPath: "/project", gitBranch: "issue-123", messageCount: 5, modifiedTime: .now)
+            ],
+            tmuxSessions: [
+                TmuxSession(name: "issue-123", path: "/worktree", attached: false)
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: [issueCard], snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].id == issueCard.id)
+        #expect(result[0].sessionLink?.sessionId == "s1")
+        #expect(result[0].issueLink?.number == 123)
+    }
+
+    // MARK: - Worktree handling
+
+    @Test("Orphan worktree creates new card with just worktreeLink")
+    func orphanWorktree() {
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            worktrees: [
+                "/project": [
+                    Worktree(path: "/project/.worktrees/fix-auth", branch: "fix-auth", isBare: false)
+                ]
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: [], snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].worktreeLink?.branch == "fix-auth")
+        #expect(result[0].worktreeLink?.path == "/project/.worktrees/fix-auth")
+        #expect(result[0].sessionLink == nil)
+        #expect(result[0].source == .discovered)
+    }
+
+    @Test("Bare worktree is skipped")
+    func bareWorktreeSkipped() {
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            worktrees: [
+                "/project": [
+                    Worktree(path: "/project", branch: "main", isBare: true)
+                ]
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: [], snapshot: snapshot)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Main branch worktree is skipped")
+    func mainBranchSkipped() {
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            worktrees: [
+                "/project": [
+                    Worktree(path: "/project/.worktrees/main", branch: "main", isBare: false),
+                    Worktree(path: "/project/.worktrees/master", branch: "master", isBare: false),
+                ]
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: [], snapshot: snapshot)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Existing card's worktree path is updated")
+    func worktreePathUpdated() {
+        let existing = [
+            Link(
+                column: .inProgress,
+                sessionLink: SessionLink(sessionId: "s1"),
+                worktreeLink: WorktreeLink(path: "/old/path", branch: "feat-x")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", gitBranch: "feat-x", messageCount: 1, modifiedTime: .now)],
+            worktrees: [
+                "/project": [
+                    Worktree(path: "/new/path", branch: "feat-x", isBare: false)
+                ]
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].worktreeLink?.path == "/new/path")
+    }
+
+    // MARK: - PR matching
+
+    @Test("PR linked to card via branch")
+    func prLinkedViaBranch() {
+        let existing = [
+            Link(
+                column: .inProgress,
+                sessionLink: SessionLink(sessionId: "s1"),
+                worktreeLink: WorktreeLink(path: "/wt", branch: "feat-login")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", gitBranch: "feat-login", messageCount: 1, modifiedTime: .now)],
+            pullRequests: [
+                "feat-login": PullRequest(number: 42, title: "Add login", state: "open", url: "https://github.com/test/pr/42", headRefName: "feat-login")
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].prLink?.number == 42)
+    }
+
+    // MARK: - Dead link cleanup
+
+    @Test("Dead tmux link is cleared")
+    func deadTmuxCleared() {
+        let existing = [
+            Link(
+                column: .inProgress,
+                sessionLink: SessionLink(sessionId: "s1"),
+                tmuxLink: TmuxLink(sessionName: "dead-session")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [Session(id: "s1", messageCount: 1, modifiedTime: .now)],
+            tmuxSessions: [] // No tmux sessions alive
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].tmuxLink == nil) // Cleared
+        #expect(result[0].sessionLink?.sessionId == "s1") // Session still there
+    }
+
+    @Test("Dead worktree link is cleared when worktrees were scanned")
+    func deadWorktreeCleared() {
+        let existing = [
+            Link(
+                column: .done,
+                worktreeLink: WorktreeLink(path: "/deleted/worktree", branch: "old-branch")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            worktrees: [
+                "/project": [
+                    // Only a bare worktree exists (won't create orphan card)
+                    Worktree(path: "/project", branch: "main", isBare: true)
+                ]
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].worktreeLink == nil) // Cleared
+    }
+
+    @Test("Manual tmux override is preserved even when tmux is dead")
+    func manualTmuxOverridePreserved() {
+        var link = Link(
+            column: .inProgress,
+            tmuxLink: TmuxLink(sessionName: "my-session")
+        )
+        link.manualOverrides.tmuxSession = true
+
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            tmuxSessions: [] // Dead
+        )
+
+        let result = CardReconciler.reconcile(existing: [link], snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].tmuxLink?.sessionName == "my-session") // Preserved
+    }
+
+    // MARK: - Multiple sessions
+
+    @Test("Multiple sessions each get their own card")
+    func multipleSessions() {
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [
+                Session(id: "s1", messageCount: 1, modifiedTime: .now),
+                Session(id: "s2", messageCount: 1, modifiedTime: .now),
+                Session(id: "s3", messageCount: 1, modifiedTime: .now),
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: [], snapshot: snapshot)
+        #expect(result.count == 3)
+        let sessionIds = Set(result.compactMap(\.sessionLink?.sessionId))
+        #expect(sessionIds == ["s1", "s2", "s3"])
+    }
+
+    @Test("Existing cards without matching sessions are preserved")
+    func existingCardsPreserved() {
+        let existing = [
+            Link(name: "Manual task", column: .backlog, source: .manual),
+            Link(name: "Issue", column: .backlog, source: .githubIssue, issueLink: IssueLink(number: 42)),
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot() // No sessions
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 2)
+        #expect(result.contains(where: { $0.name == "Manual task" }))
+        #expect(result.contains(where: { $0.name == "Issue" }))
+    }
+
+    @Test("No double reconciliation — running twice produces same result")
+    func idempotent() {
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [
+                Session(id: "s1", projectPath: "/p", gitBranch: "feat-x", messageCount: 5, modifiedTime: .now)
+            ],
+            worktrees: [
+                "/p": [Worktree(path: "/p/.wt/feat-x", branch: "feat-x", isBare: false)]
+            ],
+            pullRequests: [
+                "feat-x": PullRequest(number: 1, title: "PR", state: "open", url: "url", headRefName: "feat-x")
+            ]
+        )
+
+        let first = CardReconciler.reconcile(existing: [], snapshot: snapshot)
+        let second = CardReconciler.reconcile(existing: first, snapshot: snapshot)
+
+        #expect(first.count == second.count)
+        // Same card IDs
+        #expect(Set(first.map(\.id)) == Set(second.map(\.id)))
+    }
+
+    @Test("Project path filled from session when card has none")
+    func projectPathFilledFromSession() {
+        // Card has tmuxLink + matching project path context (same project)
+        let existing = [
+            Link(
+                projectPath: "/my/project",
+                column: .backlog,
+                source: .manual,
+                tmuxLink: TmuxLink(sessionName: "task-1"),
+                worktreeLink: WorktreeLink(path: "/wt", branch: "task-1")
+            )
+        ]
+        let snapshot = CardReconciler.DiscoverySnapshot(
+            sessions: [
+                Session(id: "s1", projectPath: "/my/project", gitBranch: "task-1", messageCount: 1, modifiedTime: .now)
+            ]
+        )
+
+        let result = CardReconciler.reconcile(existing: existing, snapshot: snapshot)
+        #expect(result.count == 1)
+        #expect(result[0].sessionLink?.sessionId == "s1")
+        #expect(result[0].projectPath == "/my/project")
+    }
+}

--- a/Tests/KanbanCoreTests/CoordinationStoreTests.swift
+++ b/Tests/KanbanCoreTests/CoordinationStoreTests.swift
@@ -30,10 +30,10 @@ struct CoordinationStoreTests {
         let store = CoordinationStore(basePath: dir)
 
         let link = Link(
-            sessionId: "abc-123",
+            name: "Test session",
             projectPath: "/test/project",
             column: .inProgress,
-            name: "Test session"
+            sessionLink: SessionLink(sessionId: "abc-123")
         )
         try await store.writeLinks([link])
 
@@ -50,7 +50,7 @@ struct CoordinationStoreTests {
         defer { cleanup(dir) }
         let store = CoordinationStore(basePath: dir)
 
-        let link = Link(sessionId: "new-1", column: .backlog)
+        let link = Link(column: .backlog, sessionLink: SessionLink(sessionId: "new-1"))
         try await store.upsertLink(link)
 
         let links = try await store.readLinks()
@@ -64,7 +64,7 @@ struct CoordinationStoreTests {
         defer { cleanup(dir) }
         let store = CoordinationStore(basePath: dir)
 
-        var link = Link(sessionId: "update-1", column: .backlog, name: "Original")
+        var link = Link(name: "Original", column: .backlog, sessionLink: SessionLink(sessionId: "update-1"))
         try await store.upsertLink(link)
 
         link.name = "Updated"
@@ -84,8 +84,8 @@ struct CoordinationStoreTests {
         let store = CoordinationStore(basePath: dir)
 
         try await store.writeLinks([
-            Link(sessionId: "a", column: .backlog),
-            Link(sessionId: "b", column: .inProgress),
+            Link(column: .backlog, sessionLink: SessionLink(sessionId: "a")),
+            Link(column: .inProgress, sessionLink: SessionLink(sessionId: "b")),
         ])
 
         try await store.removeLink(sessionId: "a")
@@ -118,7 +118,7 @@ struct CoordinationStoreTests {
         defer { cleanup(dir) }
         let store = CoordinationStore(basePath: dir)
 
-        try await store.writeLinks([Link(sessionId: "pretty", column: .done, name: "Test")])
+        try await store.writeLinks([Link(name: "Test", column: .done, sessionLink: SessionLink(sessionId: "pretty"))])
 
         let filePath = (dir as NSString).appendingPathComponent("links.json")
         let content = try String(contentsOfFile: filePath, encoding: .utf8)
@@ -132,15 +132,73 @@ struct CoordinationStoreTests {
         defer { cleanup(dir) }
         let store = CoordinationStore(basePath: dir)
 
-        try await store.upsertLink(Link(sessionId: "upd-1", column: .backlog))
+        try await store.upsertLink(Link(column: .backlog, sessionLink: SessionLink(sessionId: "upd-1")))
 
         try await store.updateLink(sessionId: "upd-1") { link in
             link.column = .inProgress
-            link.tmuxSession = "feat-login"
+            link.tmuxLink = TmuxLink(sessionName: "feat-login")
         }
 
         let link = try await store.linkForSession("upd-1")
         #expect(link?.column == .inProgress)
         #expect(link?.tmuxSession == "feat-login")
+    }
+
+    @Test("Backward-compat: old flat JSON format is decoded correctly")
+    func backwardCompatDecoding() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        // Write old-format JSON directly
+        let filePath = (dir as NSString).appendingPathComponent("links.json")
+        let oldJson = """
+        {
+          "links": [
+            {
+              "id": "old-uuid",
+              "sessionId": "claude-session-1",
+              "sessionPath": "/path/to/session.jsonl",
+              "worktreePath": "/path/to/worktree",
+              "worktreeBranch": "feat/login",
+              "tmuxSession": "feat-login",
+              "githubIssue": 123,
+              "githubPR": 456,
+              "projectPath": "/test/project",
+              "column": "in_progress",
+              "name": "Test session",
+              "createdAt": "2026-02-28T10:00:00Z",
+              "updatedAt": "2026-02-28T10:30:00Z",
+              "manualOverrides": {},
+              "manuallyArchived": false,
+              "source": "discovered",
+              "issueBody": "Fix the bug"
+            }
+          ]
+        }
+        """
+        try oldJson.write(toFile: filePath, atomically: true, encoding: .utf8)
+
+        let store = CoordinationStore(basePath: dir)
+        let links = try await store.readLinks()
+
+        #expect(links.count == 1)
+        let link = links[0]
+        #expect(link.id == "old-uuid")
+        #expect(link.sessionLink?.sessionId == "claude-session-1")
+        #expect(link.sessionLink?.sessionPath == "/path/to/session.jsonl")
+        #expect(link.tmuxLink?.sessionName == "feat-login")
+        #expect(link.worktreeLink?.path == "/path/to/worktree")
+        #expect(link.worktreeLink?.branch == "feat/login")
+        #expect(link.issueLink?.number == 123)
+        #expect(link.issueLink?.body == "Fix the bug")
+        #expect(link.prLink?.number == 456)
+
+        // Backward-compat computed properties still work
+        #expect(link.sessionId == "claude-session-1")
+        #expect(link.tmuxSession == "feat-login")
+        #expect(link.worktreePath == "/path/to/worktree")
+        #expect(link.worktreeBranch == "feat/login")
+        #expect(link.githubIssue == 123)
+        #expect(link.githubPR == 456)
     }
 }

--- a/Tests/KanbanCoreTests/KanbanCardTests.swift
+++ b/Tests/KanbanCoreTests/KanbanCardTests.swift
@@ -7,14 +7,14 @@ struct KanbanCardTests {
 
     @Test("Display title uses link name first")
     func displayTitleLinkName() {
-        let link = Link(sessionId: "s1", name: "Fix login bug")
+        let link = Link(name: "Fix login bug", sessionLink: SessionLink(sessionId: "s1"))
         let card = KanbanCard(link: link)
         #expect(card.displayTitle == "Fix login bug")
     }
 
     @Test("Display title falls back to session")
     func displayTitleSession() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let session = Session(id: "s1", firstPrompt: "Help me debug the auth flow")
         let card = KanbanCard(link: link, session: session)
         #expect(card.displayTitle == "Help me debug the auth flow")
@@ -22,21 +22,21 @@ struct KanbanCardTests {
 
     @Test("Display title falls back to ID prefix")
     func displayTitleFallback() {
-        let link = Link(sessionId: "abcdef01-2345-6789-abcd-ef0123456789")
+        let link = Link(sessionLink: SessionLink(sessionId: "abcdef01-2345-6789-abcd-ef0123456789"))
         let card = KanbanCard(link: link)
         #expect(card.displayTitle == "abcdef01...")
     }
 
     @Test("Project name extracted from path")
     func projectName() {
-        let link = Link(sessionId: "s1", projectPath: "/Users/test/Projects/my-cool-app")
+        let link = Link(projectPath: "/Users/test/Projects/my-cool-app", sessionLink: SessionLink(sessionId: "s1"))
         let card = KanbanCard(link: link)
         #expect(card.projectName == "my-cool-app")
     }
 
     @Test("Project name from session when link has none")
     func projectNameFromSession() {
-        let link = Link(sessionId: "s1")
+        let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let session = Session(id: "s1", projectPath: "/Users/test/Projects/langwatch")
         let card = KanbanCard(link: link, session: session)
         #expect(card.projectName == "langwatch")
@@ -53,7 +53,7 @@ struct KanbanCardTests {
 
     @Test("Column comes from link")
     func column() {
-        let link = Link(sessionId: "s1", column: .inReview)
+        let link = Link(column: .inReview, sessionLink: SessionLink(sessionId: "s1"))
         let card = KanbanCard(link: link)
         #expect(card.column == .inReview)
     }

--- a/Tests/KanbanCoreTests/PromptBuilderTests.swift
+++ b/Tests/KanbanCoreTests/PromptBuilderTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import Foundation
+@testable import KanbanCore
+
+@Suite("PromptBuilder")
+struct PromptBuilderTests {
+
+    @Test("Manual task uses promptBody as-is")
+    func manualTaskPrompt() {
+        let link = Link(
+            name: "Fix the bug",
+            source: .manual,
+            promptBody: "Fix the authentication bug in the login flow"
+        )
+        let prompt = PromptBuilder.buildPrompt(card: link)
+        #expect(prompt == "Fix the authentication bug in the login flow")
+    }
+
+    @Test("GitHub issue applies default template")
+    func githubIssueDefaultTemplate() {
+        let link = Link(
+            name: "#42: Fix login",
+            source: .githubIssue,
+            issueLink: IssueLink(number: 42, body: "The login form crashes")
+        )
+        let prompt = PromptBuilder.buildPrompt(card: link)
+        #expect(prompt.contains("#42:"))
+        #expect(prompt.contains("The login form crashes"))
+    }
+
+    @Test("GitHub issue with custom template")
+    func githubIssueCustomTemplate() {
+        let link = Link(
+            name: "#42: Fix login",
+            source: .githubIssue,
+            issueLink: IssueLink(number: 42, body: "Bug report")
+        )
+        let settings = Settings(githubIssuePromptTemplate: "Issue ${number}: ${body}")
+        let prompt = PromptBuilder.buildPrompt(card: link, settings: settings)
+        #expect(prompt == "Issue 42: Bug report")
+    }
+
+    @Test("Project template overrides global")
+    func projectTemplateOverridesGlobal() {
+        let link = Link(
+            name: "#10: Feature",
+            source: .githubIssue,
+            issueLink: IssueLink(number: 10, body: "Add dark mode")
+        )
+        let settings = Settings(githubIssuePromptTemplate: "GLOBAL: ${body}")
+        let project = Project(path: "/p", githubIssuePromptTemplate: "PROJECT: ${body}")
+        let prompt = PromptBuilder.buildPrompt(card: link, project: project, settings: settings)
+        #expect(prompt == "PROJECT: Add dark mode")
+    }
+
+    @Test("Prompt template wraps the result")
+    func promptTemplateWraps() {
+        let link = Link(
+            name: "Fix bug",
+            source: .manual,
+            promptBody: "Fix the bug"
+        )
+        let settings = Settings(promptTemplate: "You are a senior engineer. ${prompt}")
+        let prompt = PromptBuilder.buildPrompt(card: link, settings: settings)
+        #expect(prompt == "You are a senior engineer. Fix the bug")
+    }
+
+    @Test("Session card uses name as-is")
+    func sessionCardUsesName() {
+        let link = Link(
+            name: "Implement feature X",
+            sessionLink: SessionLink(sessionId: "s1")
+        )
+        let prompt = PromptBuilder.buildPrompt(card: link)
+        #expect(prompt == "Implement feature X")
+    }
+
+    @Test("Card with no name or body returns empty")
+    func emptyCard() {
+        let link = Link(source: .discovered)
+        let prompt = PromptBuilder.buildPrompt(card: link)
+        #expect(prompt.isEmpty)
+    }
+
+    @Test("applyTemplate replaces variables")
+    func templateVariables() {
+        let result = PromptBuilder.applyTemplate(
+            "Hello ${name}, you have ${count} items",
+            variables: ["name": "Alice", "count": "3"]
+        )
+        #expect(result == "Hello Alice, you have 3 items")
+    }
+
+    @Test("applyTemplate handles missing variables")
+    func templateMissingVars() {
+        let result = PromptBuilder.applyTemplate(
+            "Hello ${name}, ${missing} here",
+            variables: ["name": "Bob"]
+        )
+        #expect(result == "Hello Bob, ${missing} here")
+    }
+}

--- a/Tests/KanbanCoreTests/SettingsStoreTests.swift
+++ b/Tests/KanbanCoreTests/SettingsStoreTests.swift
@@ -25,7 +25,7 @@ struct SettingsStoreTests {
         #expect(settings.github.defaultFilter == "assignee:@me is:open")
         #expect(settings.github.pollIntervalSeconds == 60)
         #expect(settings.sessionTimeout.activeThresholdMinutes == 1440)
-        #expect(settings.skill == "")
+        #expect(settings.promptTemplate == "")
 
         // File should exist now
         let filePath = (dir as NSString).appendingPathComponent("settings.json")
@@ -39,14 +39,14 @@ struct SettingsStoreTests {
         let store = SettingsStore(basePath: dir)
 
         var settings = Settings()
-        settings.skill = "/orchestrate"
+        settings.promptTemplate = "/orchestrate"
         settings.projects = [Project(path: "/test/project", name: "Test")]
         settings.notifications.pushoverToken = "tok_123"
 
         try await store.write(settings)
         let read = try await store.read()
 
-        #expect(read.skill == "/orchestrate")
+        #expect(read.promptTemplate == "/orchestrate")
         #expect(read.projects.count == 1)
         #expect(read.projects[0].name == "Test")
         #expect(read.notifications.pushoverToken == "tok_123")

--- a/specs/README.md
+++ b/specs/README.md
@@ -2,6 +2,21 @@
 
 BDD specifications for a native macOS liquid glass Kanban board to control Claude Code.
 
+## Core Concept: Card-Centric Architecture
+
+A **card** is the first-class entity on the board. Each card has **independently optional typed links**:
+
+| Link Type    | What it adds                          | Label if primary |
+|-------------|---------------------------------------|-----------------|
+| SessionLink  | History tab, resume, fork, checkpoint | SESSION (blue)   |
+| TmuxLink     | Terminal tab, live view               | —                |
+| WorktreeLink | Branch info, cleanup action           | WORKTREE (green) |
+| PRLink       | PR status, merge detection            | PR (purple)      |
+| IssueLink    | Issue body, "Open in Browser"         | ISSUE (orange)   |
+
+Cards use **KSUID** IDs (`card_<27-char-base62>`) that are sortable by creation time.
+The **reconciler** matches discovered resources (sessions, worktrees, PRs) to existing cards — preventing duplicates.
+
 ## Spec Structure
 
 ```

--- a/specs/architecture/coordination-file.feature
+++ b/specs/architecture/coordination-file.feature
@@ -1,7 +1,7 @@
 Feature: Coordination File
-  As a developer debugging Kanban's session linking
+  As a developer debugging Kanban's card linking
   I want a clear, human-readable coordination file
-  So that I can inspect and manually fix links when needed
+  So that I can inspect and manually fix cards and their links when needed
 
   Background:
     Given the Kanban application is running
@@ -13,54 +13,143 @@ Feature: Coordination File
     And it should be valid JSON, pretty-printed for readability
     And it should be inspectable with `cat ~/.kanban/links.json | jq`
 
-  Scenario: Link entry structure
-    Given a session is linked to a worktree, tmux session, and PR
-    Then the link entry should look like:
+  Scenario: Card entry with all links attached
+    Given a card has a session, worktree, tmux, PR, and GitHub issue linked
+    Then the entry should use typed link sub-structs:
       """json
       {
-        "id": "uuid-for-this-link",
-        "sessionId": "claude-session-uuid",
-        "sessionPath": "/Users/rchaves/.claude/projects/-Users-rchaves-Projects-remote-langwatch/uuid.jsonl",
-        "worktreePath": "/Users/rchaves/Projects/remote/langwatch-saas/.claude/worktrees/feat-login",
-        "worktreeBranch": "feat/login",
-        "tmuxSession": "feat-login",
-        "githubIssue": 123,
-        "githubPR": 456,
+        "id": "card_2MtCMwXZOHPSlEMDe7OYW6bRfXX",
+        "name": "Implement login flow",
         "projectPath": "/Users/rchaves/Projects/remote/langwatch-saas",
         "column": "in_progress",
-        "name": "Implement login flow",
         "createdAt": "2026-02-28T10:00:00.000Z",
         "updatedAt": "2026-02-28T10:30:00.000Z",
         "lastActivity": "2026-02-28T10:30:00.000Z",
         "manualOverrides": {
           "worktreePath": false,
           "tmuxSession": false,
-          "name": true
+          "name": true,
+          "column": false
         },
         "manuallyArchived": false,
-        "source": "github_issue"
+        "source": "github_issue",
+        "sessionLink": {
+          "sessionId": "claude-session-uuid",
+          "sessionPath": "/Users/rchaves/.claude/projects/-Users-rchaves-Projects-remote-langwatch/uuid.jsonl",
+          "sessionNumber": 3
+        },
+        "tmuxLink": {
+          "sessionName": "issue-123"
+        },
+        "worktreeLink": {
+          "path": "/Users/rchaves/Projects/remote/langwatch-saas/.claude/worktrees/issue-123",
+          "branch": "feat/issue-123"
+        },
+        "prLink": {
+          "number": 456
+        },
+        "issueLink": {
+          "number": 123,
+          "url": "https://github.com/langwatch/langwatch/issues/123",
+          "body": "Fix the login bug where users get redirected..."
+        }
       }
       """
 
-  Scenario: Partial links are valid
-    Given a session exists without a worktree or tmux session
-    Then the link entry should have null for unlinked fields:
+  Scenario: Card with only a GitHub issue (backlog)
+    Given a GitHub issue was fetched but no work has started
+    Then the card should have only an issueLink:
       """json
       {
-        "id": "uuid",
-        "sessionId": "abc-123",
-        "worktreePath": null,
-        "worktreeBranch": null,
-        "tmuxSession": null,
-        "githubIssue": null,
-        "githubPR": null,
-        "column": "all_sessions",
+        "id": "card_2MtBXe1kP7nRQZ4J5aYjL9mhTvW",
+        "name": "#42: Add dark mode support",
+        "projectPath": "/Users/rchaves/Projects/remote/langwatch-saas",
+        "column": "backlog",
+        "source": "github_issue",
+        "issueLink": {
+          "number": 42,
+          "url": "https://github.com/langwatch/langwatch/issues/42",
+          "body": "Users have requested dark mode..."
+        }
+      }
+      """
+    And sessionLink, tmuxLink, worktreeLink, prLink should all be absent (not null)
+
+  Scenario: Card with only an orphan worktree
+    Given a worktree exists on disk but no session references it
+    Then a card should be created with only a worktreeLink:
+      """json
+      {
+        "id": "card_2MtDFgH3mKpQ8sR7wXvN0oYiUcA",
+        "projectPath": "/Users/rchaves/Projects/remote/langwatch-saas",
+        "column": "requires_attention",
+        "source": "discovered",
+        "worktreeLink": {
+          "path": "/Users/rchaves/Projects/remote/langwatch-saas/.claude/worktrees/feat-auth",
+          "branch": "feat/auth"
+        }
+      }
+      """
+
+  Scenario: Card with only a session (discovered externally)
+    Given a Claude session was started from the terminal (not via Kanban)
+    Then a card should be created with only a sessionLink:
+      """json
+      {
+        "id": "card_2MtEAb9nK4pRtSw2xYz3oQm1VgH",
         "name": "Quick question about APIs",
-        "manualOverrides": {},
-        "manuallyArchived": false,
+        "projectPath": "/Users/rchaves/Projects/remote/langwatch-saas",
+        "column": "all_sessions",
+        "source": "discovered",
+        "sessionLink": {
+          "sessionId": "abc-123-def-456",
+          "sessionPath": "/Users/rchaves/.claude/projects/.../abc-123-def-456.jsonl"
+        }
+      }
+      """
+
+  Scenario: Manual task without a session yet
+    Given a user created a task but hasn't started it
+    Then the card should have no typed links, just promptBody:
+      """json
+      {
+        "id": "card_2MtFCd7mL5qStUx3yZa4pRn2WhJ",
+        "name": "Refactor database layer",
+        "projectPath": "/Users/rchaves/Projects/remote/langwatch-saas",
+        "column": "backlog",
+        "source": "manual",
+        "promptBody": "Refactor database layer\n\nMove all SQL queries to a dedicated repository pattern..."
+      }
+      """
+
+  Scenario: Card IDs use KSUID format
+    Given a new card is created
+    Then its ID should be a KSUID with "card_" prefix
+    And the KSUID part should be 27 base62 characters
+    And cards should be naturally sortable by creation time via their IDs
+    And old UUID-format IDs from previous versions should still work
+
+  # ── Backward Compatibility ──
+
+  Scenario: Old flat-format links.json is auto-migrated
+    Given an existing links.json with flat fields:
+      """json
+      {
+        "id": "old-uuid-format",
+        "sessionId": "claude-uuid",
+        "worktreePath": "/path/to/worktree",
+        "worktreeBranch": "feat/login",
+        "tmuxSession": "feat-login",
+        "githubIssue": 123,
+        "githubPR": 456,
+        "column": "in_progress",
         "source": "discovered"
       }
       """
+    When Kanban reads the file
+    Then it should decode the flat fields into typed link sub-structs
+    And the next write should output the new nested format
+    And no data should be lost
 
   # ── File Operations ──
 
@@ -88,57 +177,57 @@ Feature: Coordination File
       | 3    | Rebuild from session discovery             |
       | 4    | Show notification about the recovery      |
 
-  # ── Link Lifecycle ──
+  # ── Card Lifecycle ──
 
-  Scenario: New session creates a link entry
+  Scenario: New session creates a card
     Given a new Claude session "abc-123" is discovered
-    When no link exists for this session
-    Then a new link entry should be created with:
-      | Field     | Value        |
-      | sessionId | abc-123      |
-      | column    | all_sessions (or in_progress if hook triggered) |
-      | source    | discovered or hook                              |
+    When no card has a sessionLink with that sessionId
+    Then a new card should be created with:
+      | Field                  | Value                |
+      | sessionLink.sessionId  | abc-123              |
+      | column                 | all_sessions or in_progress (if hook triggered) |
+      | source                 | discovered or hook   |
 
-  Scenario: Link fields are updated incrementally
-    Given a link exists with sessionId only
+  Scenario: Links are added incrementally to existing cards
+    Given a card exists with only a sessionLink
     When the background process discovers a matching worktree
-    Then only the worktree-related fields should update
-    And other fields should remain unchanged
+    Then a worktreeLink should be added to the existing card
+    And the sessionLink should remain unchanged
     And updatedAt should be refreshed
 
-  Scenario: Link cleanup for deleted sessions
-    Given a link references a .jsonl file that no longer exists
-    When the background process runs
-    Then the link should be marked as orphaned
-    And after 7 days, orphaned links should be cleaned up
+  Scenario: Dead links are cleaned up
+    Given a card has a worktreeLink pointing to a path that no longer exists
+    When the reconciler detects the missing worktree
+    Then the worktreeLink should be set to nil
+    But the card itself should remain (other links may still be valid)
 
-  Scenario: Link cleanup for deleted worktrees
-    Given a link references a worktree path that no longer exists
-    When the background process detects the missing worktree
-    Then the worktreePath and worktreeBranch should be set to null
-    And the tmuxSession link should also be cleared (if path-based)
+  Scenario: Dead tmux links are cleared
+    Given a card has a tmuxLink with sessionName "issue-123"
+    When "issue-123" is no longer in the live tmux session list
+    Then the tmuxLink should be set to nil
+    But the card should remain with its other links
 
   # ── Manual Editing ──
 
   Scenario: User edits the file directly
     Given I open ~/.kanban/links.json in a text editor
-    When I change a worktreePath to a different path
+    When I add a worktreeLink to a card that didn't have one
     And save the file
     Then Kanban should detect the change
     And the UI should update to reflect the new link
     And the manual change should be treated as a manual override
 
-  Scenario: User adds a manual link entry
+  Scenario: User adds a manual card entry
     Given I add a new JSON entry to the links array
     When Kanban reloads the file
     Then the new entry should appear on the board
-    And it should be treated as a manually created link
+    And it should be treated as a manually created card
 
   # ── Debugging ──
 
-  Scenario: Link file is useful for debugging
+  Scenario: Card file is useful for debugging
     Given I'm debugging why a session isn't linked to its worktree
-    When I run `cat ~/.kanban/links.json | jq '.links[] | select(.sessionId == "abc-123")'`
-    Then I should see all the link data for that session
+    When I run `cat ~/.kanban/links.json | jq '.links[] | select(.sessionLink.sessionId == "abc-123")'`
+    Then I should see all the card data including all typed links
     And I should be able to identify what's missing or wrong
     And manually fix it if needed

--- a/specs/board/card-lifecycle.feature
+++ b/specs/board/card-lifecycle.feature
@@ -1,43 +1,90 @@
 Feature: Card Lifecycle and Automation
   As a developer using Kanban to manage Claude Code sessions
-  I want cards to automatically move between columns based on session state
+  I want cards to automatically move between columns based on their links and state
   So that my board always reflects the true state of work
 
   Background:
     Given the Kanban application is running
-    And the background linking process is active
+    And the background reconciliation process is active
+
+  # ── Card Labels ──
+
+  Scenario: Card label reflects the primary link type
+    Given a card exists on the board
+    Then the card should show a label based on which links are present:
+      | Links present                    | Label     | Color  |
+      | sessionLink (with or without others) | SESSION   | blue   |
+      | worktreeLink only                | WORKTREE  | green  |
+      | issueLink only                   | ISSUE     | orange |
+      | prLink only                      | PR        | purple |
+      | no typed links (manual task)     | TASK      | gray   |
+    And the priority order is: SESSION > WORKTREE > ISSUE > PR > TASK
+
+  Scenario: Card shows secondary link indicators
+    Given a card has sessionLink AND prLink AND issueLink
+    Then the primary label should be "SESSION" (blue)
+    And small secondary icons should appear for PR and issue
+
+  # ── Card Detail Header ──
+
+  Scenario: Card detail shows link pills
+    Given I select a card with sessionLink, tmuxLink, worktreeLink, prLink, and issueLink
+    Then the detail header should show link pills for each:
+      | Pill      | Icon                        | Label                |
+      | Session   | terminal                    | #3 (session number)  |
+      | Tmux      | rectangle.on.rectangle      | tmux                 |
+      | Worktree  | arrow.triangle.branch       | feat/login           |
+      | PR        | arrow.triangle.pull         | #456                 |
+      | Issue     | exclamationmark.circle      | #123                 |
+
+  Scenario: Card detail has dynamic tabs based on links
+    Given a card's available links determine which tabs appear:
+      | Links present     | Available tabs           |
+      | tmuxLink          | Terminal                 |
+      | sessionLink       | History                  |
+      | issueLink         | Context (issue body)     |
+      | promptBody        | Context (prompt text)    |
+    And a card with all links has Terminal + History + Context tabs
+
+  Scenario: Card with no session or tmux shows Context tab only
+    Given a card has only an issueLink (backlog GitHub issue)
+    Then the detail view should show a Context tab with the issue body
+    And a "Start Work" button to begin a session
 
   # ── Backlog → In Progress ──
 
   Scenario: Starting a task from backlog via Kanban
     Given a task "Implement user auth" is in the Backlog column
     When I click the "Start" button on the card
-    Then a tmux session should be created
-    And Claude Code should be launched inside it with the task description
-    And the card should move to "In Progress"
-    And the coordination file should record the session-tmux link
+    Then a launch confirmation dialog should appear with the prompt
+    And on confirmation:
+      | Step | Action                                              |
+      | 1    | A tmux session should be created                    |
+      | 2    | Claude Code should be launched with the prompt      |
+      | 3    | The card gains a tmuxLink                           |
+      | 4    | The card moves to "In Progress"                     |
+      | 5    | SessionStart hook adds sessionLink to the same card |
 
   Scenario: Starting a GitHub issue from backlog
     Given a GitHub issue "#123: Fix login bug" is in the Backlog
     When I click "Start" on the card
-    Then a tmux session should be created with name derived from the issue
-    And Claude Code should be launched with `claude --worktree issue-123`
-    And the prompt should include the issue title and body
-    And a configurable skill prefix should be prepended (e.g., "/orchestrate")
+    Then the launch confirmation dialog shows the prompt built from templates
+    And on launch, the existing card (with issueLink) gains tmuxLink + sessionLink
+    And the card moves to "In Progress" (no new card created)
 
-  Scenario: Starting a manual task from backlog
-    Given a manual task "Refactor database layer" is in the Backlog
-    When I click "Start"
-    Then a tmux session should be created
-    And Claude Code should be launched with `claude --worktree`
-    And the worktree should get an auto-generated name (random words)
-    And the task description should be the prompt
+  Scenario: Starting work on an orphan worktree
+    Given an orphan worktree card (label "WORKTREE") is on the board
+    When I click "Start Work"
+    Then the launch confirmation dialog should appear
+    And Claude should be launched in the existing worktree directory
+    And no --worktree flag should be passed (worktree already exists)
+    And the card gains tmuxLink + sessionLink while keeping worktreeLink
 
   Scenario: Task started externally appears in In Progress
     Given I started Claude Code from my terminal with `claude --worktree feat-123`
     When the background process detects the new session
     Then a new card should appear in "In Progress"
-    And it should attempt to link to any matching backlog item by branch name
+    And it should attempt to match to any backlog item by branch name
 
   # ── In Progress → Requires Attention ──
 
@@ -87,12 +134,13 @@ Feature: Card Lifecycle and Automation
   Scenario: PR created while Claude is not actively working
     Given a Claude session created a PR on GitHub
     And the session has been idle for more than 5 minutes
-    When the background process detects the PR via `gh`
-    Then the card should move to "In Review"
+    When the reconciler detects the PR via branch matching
+    Then a prLink should be added to the card
+    And the card should move to "In Review"
     And the PR number, title, and status should appear on the card
 
   Scenario: PR exists but Claude is still working
-    Given a Claude session has a linked PR
+    Given a card has a prLink
     But the session is actively working (recent activity)
     Then the card should remain in "In Progress"
     And the PR badge should be visible on the card
@@ -114,7 +162,6 @@ Feature: Card Lifecycle and Automation
     When the PR is merged on GitHub
     And the background process detects the merge via `gh`
     Then the card should move to "Done"
-    And the card should show a "Clean up worktree" button
 
   Scenario: PR is closed without merge
     Given a card is in "In Review" for PR #42
@@ -122,51 +169,52 @@ Feature: Card Lifecycle and Automation
     Then the card should move to "Done"
     And the card should show "Closed" status
 
-  # ── Done → All Sessions (cleanup) ──
+  # ── Done → Cleanup ──
 
   Scenario: Cleaning up a worktree from Done
-    Given a card is in "Done" with a linked worktree
-    When I click "Clean up worktree"
+    Given a card is in "Done" with a worktreeLink
+    Then a "Clean up worktree" button should be visible
+    When I click it
     Then a confirmation dialog should appear
     And on confirm:
       | Step | Action                                    |
       | 1    | Kill associated tmux session if exists     |
       | 2    | Remove the git worktree                   |
-      | 3    | Update coordination file                  |
+      | 3    | Clear worktreeLink and tmuxLink on card    |
     And the card should move to "All Sessions"
 
   Scenario: Done card without worktree moves to archive directly
-    Given a card is in "Done" without a linked worktree
+    Given a card is in "Done" without a worktreeLink
     When I click "Archive"
     Then the card should move to "All Sessions"
 
   # ── All Sessions → In Progress (reviving) ──
 
   Scenario: Resuming a session from All Sessions
-    Given a card is in "All Sessions"
-    When I send a message to it via the terminal
-    Then the card should move to "In Progress"
-    And a tmux session should be created if none exists
+    Given a card with a sessionLink is in "All Sessions"
+    When I click "Resume"
+    Then a tmux session should be created (tmuxLink added)
     And Claude should be resumed with `claude --resume <sessionId>`
+    And the card should move to "In Progress"
 
   Scenario: Forking a session from All Sessions
     Given a card is in "All Sessions"
     When I click "Fork"
     Then the session .jsonl should be duplicated with a new UUID
-    And a new card should appear in "In Progress" (or "Backlog" if not started)
+    And a new card should appear (new KSUID id, new sessionLink)
     And the original card should remain in "All Sessions"
 
   # ── Session Staleness ──
 
   Scenario: Active session without worktree or tmux
     Given a session is less than 24 hours old (configurable)
-    And it has no linked worktree or tmux session
+    And it has no worktreeLink or tmuxLink
     Then it should remain in its current column
     And not be auto-archived
 
   Scenario: Stale session auto-archives
     Given a session has been idle for more than 24 hours (configurable)
-    And it has no linked worktree or tmux session
+    And it has no worktreeLink or tmuxLink
     And it is not in "Backlog"
     Then it should automatically move to "All Sessions"
 
@@ -174,5 +222,5 @@ Feature: Card Lifecycle and Automation
     Given a session is in "In Progress"
     When I drag it to "All Sessions"
     Then the card should move to "All Sessions"
-    And the session should be marked as manually archived
+    And the card should be marked as manually archived
     And it should not auto-return to "In Progress" based on age alone

--- a/specs/sessions/launching.feature
+++ b/specs/sessions/launching.feature
@@ -1,32 +1,93 @@
 Feature: Session Launching
   As a developer using Kanban
-  I want to launch Claude Code sessions from the board
-  So that I can start work with proper worktree and tmux setup
+  I want to launch Claude Code sessions from the board with a confirmation dialog
+  So that I can review and edit prompts before starting work
 
   Background:
     Given the Kanban application is running
     And tmux is installed
 
+  # ── Launch Confirmation Dialog ──
+
+  Scenario: Launch confirmation dialog appears before every launch
+    Given I click "Start" on any backlog card
+    Then a launch confirmation dialog should appear with:
+      | Field            | Type              | Editable |
+      | Project path     | Text              | no       |
+      | Prompt           | TextEditor        | yes      |
+      | Create worktree  | Checkbox          | yes      |
+    And the prompt should be pre-filled from prompt templates
+    And I can edit the prompt before clicking "Launch"
+    And "Cancel" dismisses without launching
+
+  Scenario: Prompt is built from templates before dialog
+    Given the promptTemplate is "/orchestrate ${prompt}"
+    And a manual task has promptBody "Fix the login flow"
+    When I click "Start"
+    Then the dialog should show: "/orchestrate Fix the login flow"
+    And I can modify it before launching
+
+  Scenario: Create worktree checkbox defaults and persists
+    When the launch confirmation dialog first appears
+    Then "Create worktree" should be checked by default
+    When I uncheck "Create worktree" and launch
+    Then the next time I open the dialog, it should be unchecked
+    Because the preference is saved via @AppStorage("createWorktree")
+
+  Scenario: Launching without worktree
+    Given "Create worktree" is unchecked in the dialog
+    When I click "Launch"
+    Then Claude should be started without the --worktree flag
+    And no worktreeLink should be set on the card
+
+  Scenario: Launching with worktree
+    Given "Create worktree" is checked in the dialog
+    When I click "Launch"
+    Then Claude should be started with `claude --worktree <name>`
+    And the worktree name should be derived from the card:
+      | Card type      | Worktree name        |
+      | GitHub issue   | issue-123            |
+      | Manual task    | (auto-generated)     |
+
   # ── Launching from Backlog ──
 
-  Scenario: Launch Claude with worktree for a GitHub issue
+  Scenario: Launch Claude for a GitHub issue
     Given a GitHub issue "#123: Fix login bug" is in Backlog
     And the project is configured at "~/Projects/remote/langwatch-saas"
-    When I click "Start"
+    When I click "Start" and confirm the launch dialog
     Then the following should happen in order:
       | Step | Action                                                        |
       | 1    | Create tmux session named "issue-123"                         |
       | 2    | Inside tmux: cd to project directory                          |
       | 3    | Run: claude --worktree issue-123                              |
-      | 4    | Send prompt with skill prefix + issue description             |
-    And the coordination file should record the link
+      | 4    | Send the prompt from the dialog                              |
+    And the existing card should gain a tmuxLink
+    And no new card should be created
+
+  Scenario: Launch Claude for a manual task
+    Given a manual task is in Backlog
+    When I click "Start" and confirm the launch dialog
+    Then Claude should be launched with the edited prompt
+    And the existing card should gain a tmuxLink
+
+  Scenario: Launch Claude on an orphan worktree
+    Given an orphan worktree card exists (has worktreeLink, no sessionLink)
+    When I click "Start Work"
+    Then the launch confirmation dialog should appear
+    And the prompt field should be empty (user must provide a prompt)
+    And "Create worktree" should be hidden (worktree already exists)
+    When I enter a prompt and click "Launch"
+    Then Claude should be launched in the existing worktree directory
+    And no --worktree flag should be passed
 
   Scenario: Launch Claude with auto-generated worktree name
     Given a manual task without a specific branch name
-    When I click "Start"
+    When "Create worktree" is checked in the launch dialog
     Then Claude should be launched with `claude --worktree`
     And Claude Code will auto-generate the worktree name
-    And the background process should later detect the worktree and link it
+    And the reconciler should later detect the worktree and add worktreeLink
+
+  # ── Sub-repo Support ──
 
   Scenario: Launch Claude in a sub-repo
     Given a project is configured with:
@@ -35,13 +96,6 @@ Feature: Session Launching
     When I start a task
     Then Claude should be launched in the projectPath
     But worktrees and PRs should be tracked against the repoRoot
-    And the worktree should be created in the repoRoot
-
-  Scenario: Sub-repo worktree creation
-    Given a project with repoRoot different from projectPath
-    When a worktree needs to be created
-    Then `git -C <repoRoot> worktree add` should be used
-    And the tmux session should cd to the worktree path
 
   # ── Launching without tmux ──
 
@@ -53,7 +107,7 @@ Feature: Session Launching
     And the card should show "no tmux" indicator
     And I should see a hint to install tmux for better experience
 
-  # ── Launching with remote execution ──
+  # ── Remote Execution ──
 
   Scenario: Remote execution configured
     Given remote execution is configured with:
@@ -71,20 +125,7 @@ Feature: Session Launching
   Scenario: Backlog cards show a Start button
     Given a card is in the Backlog column
     Then a play button should be visible on the card
-    And clicking it should launch Claude for that task
-
-  Scenario: Start button on GitHub issue cards
-    Given a GitHub issue card "#123: Fix login bug" is in Backlog
-    When I click the Start button on the card
-    Then Claude should be launched with worktree "issue-123"
-    And the prompt should include the issue title and body
-    And the card should move to In Progress
-
-  Scenario: Start button on manual task cards
-    Given a manual task card is in Backlog
-    When I click the Start button
-    Then Claude should be launched with `claude --worktree` (auto name)
-    And the task title and description should be sent as the prompt
+    And clicking it should open the launch confirmation dialog
 
   Scenario: Context menu Start option
     Given any card in the Backlog column
@@ -94,28 +135,26 @@ Feature: Session Launching
   # ── Resuming ──
 
   Scenario: Resume an existing session from any column
-    Given a session "abc-123" exists in "Requires Attention"
-    When I open the terminal and send a message
-    Then if there's a tmux session, it should be attached
+    Given a card has sessionLink.sessionId = "abc-123"
+    When I click "Resume"
+    Then if there's an existing tmux session, it should be used
+    Otherwise a new tmux session should be created
     And Claude should be resumed with `claude --resume abc-123`
-    And it should use `$SHELL -ic` to inherit aliases
+    And the card should gain/update its tmuxLink
 
   Scenario: Resume without tmux session
-    Given a session "abc-123" exists but has no tmux session
+    Given a card has sessionLink but no tmuxLink
     When I click "Resume"
     Then a new tmux session should be created
-    And `claude --resume abc-123` should be run inside it
-    And the coordination file should record the new tmux link
-
-  Scenario: Resume from card detail Actions tab
-    Given a session card is selected in the inspector
-    When I click "Resume Session" in the Actions tab
-    Then a tmux session should be created/attached
-    And the terminal tab should show the live session
-    And the card should move to In Progress
+    And `claude --resume <sessionId>` should be run inside it
+    And the card should gain a tmuxLink
 
   Scenario: Copy resume command
-    Given a session "abc-123" exists
+    Given a card has sessionLink.sessionId = "abc-123"
     When I click "Copy resume command"
-    Then `claude --resume abc-123` should be copied to clipboard
-    And a toast should show "Copied to clipboard"
+    Then `cd <projectPath> && claude --resume abc-123` should be copied to clipboard
+
+  Scenario: Copy resume command for card without session
+    Given a card has no sessionLink (e.g., backlog issue)
+    When I click "Copy resume command"
+    Then "# no session yet" should be copied to clipboard

--- a/specs/sessions/linking.feature
+++ b/specs/sessions/linking.feature
@@ -1,181 +1,195 @@
-Feature: Session-Worktree-Tmux-PR Linking
+Feature: Card Reconciliation and Link Management
   As a developer with sessions started from various places
-  I want Kanban to intelligently link sessions, worktrees, tmux sessions, and PRs
-  So that my board accurately represents the state of all work
+  I want Kanban to intelligently match sessions, worktrees, tmux sessions, and PRs to existing cards
+  So that my board accurately represents the state of all work without duplicates
 
   Background:
     Given the Kanban application is running
-    And the background linking process is active
+    And the background reconciliation process is active
 
-  # ── Coordination File ──
+  # ── Core Reconciliation: Session → Card Matching ──
 
-  Scenario: Coordination file structure
-    Given the application has been used
-    Then a file should exist at ~/.kanban/links.json
-    And it should be human-readable JSON with entries like:
-      """json
-      {
-        "links": [
-          {
-            "id": "link-uuid",
-            "sessionId": "claude-session-uuid",
-            "worktreePath": "/path/to/worktree",
-            "worktreeBranch": "feat/issue-123",
-            "tmuxSession": "feat-issue-123",
-            "githubIssue": 123,
-            "githubPR": 456,
-            "projectPath": "/Users/rchaves/Projects/remote/langwatch-saas",
-            "column": "in_progress",
-            "name": "Custom session name",
-            "createdAt": "2026-02-28T10:00:00Z",
-            "updatedAt": "2026-02-28T10:30:00Z",
-            "manualOverrides": {},
-            "manuallyArchived": false
-          }
-        ]
-      }
-      """
+  Scenario: Discovered session matches existing card by sessionId
+    Given a card exists with sessionLink.sessionId = "abc-123"
+    When session discovery finds session "abc-123" with updated data
+    Then the existing card's sessionLink should be updated (path, timestamps)
+    And no new card should be created
 
-  Scenario: Coordination file is always readable
-    Given the coordination file exists
-    Then it should be valid JSON
-    And it should be inspectable with `cat ~/.kanban/links.json | jq`
-    And it should be editable by the user if needed
+  Scenario: Discovered session matches pending card via hook claim
+    Given a card was just launched (has tmuxLink but no sessionLink, updated < 60s ago)
+    When a SessionStart hook event fires with sessionId "new-session-uuid"
+    And no other card already has sessionLink.sessionId = "new-session-uuid"
+    Then the sessionLink should be added to the pending card
+    And the card should now be fully linked (tmux + session)
 
-  # ── Automatic Linking: Session → Worktree ──
+  Scenario: Discovered session has no matching card
+    Given no card has a sessionLink or tmuxLink matching the new session
+    When session discovery finds a new session "xyz-789"
+    Then a new card should be created with:
+      | Field                  | Value        |
+      | source                 | discovered   |
+      | sessionLink.sessionId  | xyz-789      |
+    And it should appear on the board
+
+  Scenario: Manual create + start + discovery produces exactly one card
+    Given I create a manual task "Fix login bug" with "Start immediately" checked
+    Then exactly one card should exist for this task
+    When the launch creates a tmux session
+    Then the existing card should gain a tmuxLink
+    When the SessionStart hook fires with the new Claude session UUID
+    Then the existing card should gain a sessionLink
+    When session discovery runs and finds the new session
+    Then the session should match the existing card by sessionId
+    And there should still be exactly one card (not 3!)
+
+  # ── Worktree Matching ──
 
   Scenario: Session started with --worktree flag
     Given Claude was started with `claude --worktree feat-123`
     When the session .jsonl contains cwd pointing to a worktree path
-    Then the session should be automatically linked to that worktree
-    And the branch should be extracted from the worktree
+    Then the card's worktreeLink should be set with the worktree path and branch
 
-  Scenario: Session without worktree but mentions branch in conversation
-    Given a Claude session is running on main (no --worktree)
-    And the conversation contains a message mentioning "worktree feat-login"
-    And no other link exists for "feat-login"
-    When the background heuristic scanner runs
-    Then it should attempt to match the branch name "feat-login"
-    And if a worktree exists with that branch, link them
+  Scenario: Orphan worktree creates a new card
+    Given a worktree exists at ~/Projects/remote/repo/.claude/worktrees/feat-auth
+    And no card has worktreeLink.branch matching "feat/auth"
+    When the reconciler scans worktrees
+    Then a new card should be created with:
+      | Field                | Value              |
+      | source               | discovered         |
+      | worktreeLink.path    | .../feat-auth      |
+      | worktreeLink.branch  | feat/auth          |
+      | column               | requires_attention |
+    And the card label should show "WORKTREE"
 
-  Scenario: Heuristic matching via exact branch name in conversation
-    Given a worktree exists at ~/Projects/remote/langwatch-saas/.claude/worktrees/feat-login
-    And a Claude session's transcript mentions "feat-login" exactly
-    And the session has no worktree link yet
-    Then the heuristic should propose this link
-    And the link should be created automatically
+  Scenario: Skip bare and main branch worktrees
+    Given the repo has a bare worktree and a main branch worktree
+    When the reconciler scans worktrees
+    Then no cards should be created for bare or main branch worktrees
 
-  Scenario: No false positive heuristic matches
-    Given a Claude session discusses "login" in general terms
-    And a worktree "feat-login" exists
-    Then the heuristic should NOT link them
-    Because "login" alone is not an exact branch/worktree name match
+  Scenario: Worktree already tracked by a card
+    Given a card exists with worktreeLink.branch = "feat/login"
+    When the reconciler finds a worktree with branch "feat/login"
+    Then it should verify/update the worktreeLink.path if needed
+    And not create a new card
 
-  # ── Automatic Linking: Worktree → tmux ──
-  # (Learned from git-orchard: path match first, then name match)
-
-  Scenario: tmux session matches worktree by path
-    Given a tmux session exists with session_path = "/path/to/worktree"
-    And a worktree exists at "/path/to/worktree"
-    Then they should be linked by exact path match (highest priority)
-
-  Scenario: tmux session matches worktree by directory name
-    Given a tmux session named "feat-login"
-    And a worktree at ~/Projects/remote/repo/.claude/worktrees/feat-login/
-    Then they should be linked by directory name match
-
-  Scenario: tmux session matches worktree by branch name
-    Given a tmux session named "feat-login"
-    And a worktree on branch "feat/login" (slash-to-dash normalization)
-    Then they should be linked because "feat/login" → "feat-login" matches
-
-  Scenario: Path match takes priority over name match
-    Given tmux session "wrong-name" has path "/correct/worktree"
-    And worktree at "/correct/worktree" on branch "correct-branch"
-    Then the tmux session should be linked to the worktree
-    Because path match (priority 1) overrides name match (priority 2)
-
-  # ── Automatic Linking: Worktree → PR ──
-  # (Learned from git-orchard: branch name is the PR map key)
+  # ── PR Matching ──
 
   Scenario: PR linked by branch name
-    Given a worktree is on branch "feat/issue-123"
-    And a PR exists with head ref "feat/issue-123"
-    Then the PR should be automatically linked to the worktree/session
+    Given a card has worktreeLink.branch = "feat/issue-123"
+    And a PR exists with headRefName = "feat/issue-123"
+    When the reconciler matches PRs
+    Then a prLink should be added to the card with the PR number
 
-  Scenario: PR fetched via gh CLI
-    When the background process checks for PRs
-    Then it should use `gh pr list --state all --json headRefName,number,state,title,url,reviewDecision`
-    And cache the results as a Map<branchName, PrInfo>
+  Scenario: PR discovery does not create new cards
+    Given a PR exists for branch "feat/unknown"
+    And no card has a worktreeLink matching that branch
+    Then no new card should be created for the PR alone
+    Because PRs are attached to existing cards, not standalone
 
-  # ── Automatic Linking: PR → GitHub Issue ──
+  # ── GitHub Issue → Card Flow ──
 
-  Scenario: PR body references an issue
-    Given PR #456 has body containing "Closes #123"
-    When the PR is linked to a session
-    Then the GitHub issue #123 should also be linked
-    And if #123 was in the Backlog, the backlog card should be merged with the session card
+  Scenario: GitHub issue creates a backlog card with issueLink
+    Given a GitHub issue #123 "Fix login bug" is fetched
+    And no card has issueLink.number = 123 for this project
+    Then a new card should be created with:
+      | Field              | Value        |
+      | source             | github_issue |
+      | column             | backlog      |
+      | issueLink.number   | 123          |
+      | issueLink.body     | (issue body) |
+      | name               | #123: Fix login bug |
+
+  Scenario: Starting work on issue card adds session + tmux + worktree
+    Given a card with issueLink.number = 123 is in Backlog
+    When I click "Start" and the launch completes
+    Then the same card should gain:
+      | Link         | Value                          |
+      | tmuxLink     | sessionName = "issue-123"      |
+      | sessionLink  | (from SessionStart hook claim) |
+      | worktreeLink | (from Claude --worktree)       |
+    And the card should move to In Progress
+    And no second card should be created
+
+  Scenario: Issue already started is not duplicated on re-fetch
+    Given a card with issueLink.number = 123 also has a sessionLink
+    When the next GitHub fetch returns issue #123 again
+    Then the existing card should be kept as-is
+    And no duplicate card should be created
+
+  Scenario: Stale issue removed from backlog
+    Given a card with issueLink.number = 123 is in Backlog (no sessionLink)
+    When the GitHub fetch no longer returns issue #123
+    Then the card should be removed from the board
+
+  Scenario: Started issue not removed even if stale
+    Given a card with issueLink.number = 123 also has a sessionLink
+    When the GitHub fetch no longer returns issue #123
+    Then the card should NOT be removed
+    Because work has already started on it
+
+  # ── Dead Link Cleanup ──
+
+  Scenario: Tmux session dies
+    Given a card has tmuxLink.sessionName = "feat-login"
+    When "feat-login" is no longer in the live tmux session list
+    Then tmuxLink should be set to nil
+    But the card should remain with its other links intact
+
+  Scenario: Worktree deleted from disk
+    Given a card has worktreeLink.path = "/path/to/worktree"
+    And the path no longer exists on disk
+    When the reconciler runs
+    Then worktreeLink should be set to nil
+    Unless manualOverrides.worktreePath is true
+
+  Scenario: Session .jsonl file temporarily unavailable
+    Given a card has sessionLink.sessionPath pointing to a file
+    And the file is temporarily inaccessible (e.g., remote mount down)
+    When the reconciler runs
+    Then the sessionLink should NOT be cleared
+    Because sessions may be temporarily unavailable
 
   # ── Manual Override ──
 
   Scenario: User manually changes worktree link
-    Given a session is linked to worktree "feat-login"
-    When I click "Change worktree" on the card
-    And select a different worktree "feat-auth"
-    Then the link should update to "feat-auth"
-    And "manualOverrides.worktreePath" should be set to true
-    And the heuristic should not overwrite this manual link
-
-  Scenario: User manually links a tmux session
-    Given a session has no tmux link
-    When I click "Link tmux session"
-    And I see a list of unlinked tmux sessions
-    And I select "my-session"
-    Then the tmux session should be linked
-    And the link should be marked as manual
+    Given a card is linked to worktree "feat-login"
+    When I change the worktreeLink to a different worktree
+    Then manualOverrides.worktreePath should be set to true
+    And the reconciler should not overwrite this manual link
 
   Scenario: Manual overrides survive re-linking
-    Given a session has a manual worktree override
-    When the background linking process runs
-    Then it should skip the manually overridden field
-    And only update non-overridden fields
+    Given a card has manualOverrides.worktreePath = true
+    When the reconciler runs
+    Then it should skip updating the worktreeLink
+    And only update non-overridden links
 
-  # ── Multiple Sessions per Worktree ──
+  # ── Multiple Sessions per Branch ──
 
-  Scenario: Two sessions linked to the same worktree
+  Scenario: Two sessions linked to the same worktree branch
     Given I started a session in worktree "feat-login"
     And I later forked it, creating a second session in the same worktree
-    Then both sessions should appear as cards
-    And both should show the same worktree link
-    And the PR should appear on both cards
+    Then both sessions should appear as separate cards
+    And both should have worktreeLink.branch = "feat/login"
+    And the PR should appear on both cards (same prLink.number)
 
   # ── Session Switching Worktrees ──
 
-  Scenario: User switches worktree within a session
-    Given session "abc-123" was linked to worktree "feat-login"
-    And the user told Claude to switch to worktree "feat-auth"
-    When the background process detects cwd changed to a different worktree
-    Then the session link should update to "feat-auth"
-    Unless there is a manual override
+  Scenario: Session changes worktree
+    Given a card has sessionLink and worktreeLink.branch = "feat-login"
+    When the session's .jsonl shows cwd changed to a different worktree
+    Then worktreeLink should update to the new worktree
+    Unless manualOverrides.worktreePath is true
 
-  # ── No Worktree (working on main) ──
+  # ── Performance ──
 
-  Scenario: Session without a worktree
-    Given a Claude session is running in ~/Projects/remote/langwatch-saas (not a worktree)
-    Then the session should be tracked without a worktree link
-    And the branch should show as "main" (or whatever the current branch is)
-    And the card should still be fully functional
-
-  # ── Background Process Performance ──
-
-  Scenario: Linking process is lightweight
+  Scenario: Reconciliation is lightweight
     Given 50 active sessions and 200 archived sessions
-    When the background linking process runs
+    When the reconciler runs
     Then it should complete in under 500ms
     And it should not block the UI thread
-    And it should only re-scan sessions that changed since last run
+    And it should use indexed lookups (not O(n^2) scanning)
 
   Scenario: tmux session list is cached and refreshed
-    Given the linking process polls tmux sessions
+    Given the reconciler polls tmux sessions
     Then `tmux list-sessions` should be called at most every 5 seconds
     And the result should be cached between polls

--- a/specs/sources/github-issues.feature
+++ b/specs/sources/github-issues.feature
@@ -22,16 +22,28 @@ Feature: GitHub Issues as Backlog Source
     And display a hint: "Uses `gh search issues` syntax"
     And examples like "assignee:@me repo:org/repo is:open label:bug"
 
-  Scenario: Multiple repositories via filter
-    Given the filter is "assignee:@me is:open"
-    When issues exist across multiple repos
-    Then all matching issues should appear in the backlog
-    And each card should show the repository name
+  # ── Card Structure for Issues ──
 
-  Scenario: Filtering by GitHub Project board
-    Given the filter is "project:myorg/myproject"
-    When the backlog refreshes
-    Then only issues from that project board should appear
+  Scenario: GitHub issues create cards with issueLink
+    When a GitHub issue #123 "Fix login bug" is fetched
+    Then a card should be created with:
+      | Field              | Value                              |
+      | id                 | card_<KSUID>                       |
+      | source             | github_issue                       |
+      | column             | backlog                            |
+      | name               | #123: Fix login bug                |
+      | issueLink.number   | 123                                |
+      | issueLink.body     | (the issue body text)              |
+      | issueLink.url      | https://github.com/.../issues/123  |
+    And sessionLink, tmuxLink, worktreeLink, prLink should all be nil
+    And the card label should be "ISSUE" (orange)
+
+  Scenario: Issue card detail shows issue body
+    Given an issue card "#123: Fix login bug" is selected
+    Then the detail view should have a "Context" tab
+    And it should show the full issue body as scrollable text
+    And an "Open in Browser" button should link to the issue URL
+    And a "Start Work" button should be available
 
   # ── Fetching and Display ──
 
@@ -40,18 +52,14 @@ Feature: GitHub Issues as Backlog Source
     Then GitHub issues should be fetched via `gh search issues`
     And each issue should appear as a card in "Backlog" with:
       | Field       | Source              |
-      | Title       | Issue title         |
-      | Number      | Issue number (#123) |
-      | Repository  | repo name           |
+      | Title       | #number: Issue title|
       | Labels      | Issue labels        |
-      | Assignee    | Assignee avatar     |
 
-  Scenario: Issue already has a linked session
-    Given issue #123 is in the backlog
-    And a Claude session exists that is working on branch "issue-123"
-    When the linking process detects the match
-    Then the card should move from "Backlog" to the appropriate column
-    And the card should show the linked session
+  Scenario: Deduplication of GitHub issues
+    Given a card with issueLink.number = 123 exists for this project
+    When the next GitHub fetch also returns issue #123
+    Then the existing card should be kept
+    And no duplicate card should be created
 
   Scenario: Background polling for new issues
     Given the backlog was loaded 5 minutes ago
@@ -59,11 +67,7 @@ Feature: GitHub Issues as Backlog Source
     Then new issues matching the filter should be fetched
     And new cards should appear in "Backlog"
     And stale issues (no longer matching) should be removed from "Backlog"
-    But started issues (moved out of Backlog) should not be removed
-
-  Scenario: Polling interval is configurable
-    Given settings has "github.pollIntervalSeconds": 120
-    Then the background fetch should happen every 120 seconds
+    But started issues (have sessionLink) should not be removed
 
   Scenario: Manual backlog refresh via column button
     Given the backlog column is visible
@@ -72,50 +76,65 @@ Feature: GitHub Issues as Backlog Source
     Then GitHub issues should be re-fetched immediately regardless of timer
     And the button should show a spinner while loading
 
-  Scenario: Deduplication of GitHub issues
-    Given issue #123 already exists as a Link with source=githubIssue
-    When the next GitHub fetch also returns issue #123
-    Then no duplicate Link should be created
-    And the existing card should be kept as-is
-
-  Scenario: GitHub issues create proper Link records
-    When a GitHub issue is fetched
-    Then a Link should be created with:
-      | Field         | Value                              |
-      | source        | github_issue                       |
-      | column        | backlog                            |
-      | githubIssue   | issue number                       |
-      | projectPath   | the project's path                 |
-      | name          | "#123: Issue title"                |
-      | issueBody     | the issue body text                |
-
   # ── Starting Work on an Issue ──
 
   Scenario: Start work on a GitHub issue
     Given issue "#123: Fix login bug" is in the Backlog
     When I click "Start" on the card
-    Then a tmux session should be created named "issue-123"
-    And Claude should be launched with:
-      | Flag        | Value                                    |
-      | --worktree  | issue-123                                |
-      | prompt      | /orchestrate Fix login bug (issue #123)  |
-    And the card should move to "In Progress"
+    Then the launch confirmation dialog should appear
+    And the prompt should be built from templates:
+      | Template                    | Applied to                      |
+      | githubIssuePromptTemplate   | Issue title, number, body       |
+      | promptTemplate              | Wraps the result                |
+    And I can edit the prompt before launching
 
-  Scenario: Skill prefix is configurable
-    Given settings has "skill": "/orchestrate"
+  Scenario: Issue prompt template rendering
+    Given the githubIssuePromptTemplate is "#${number}: ${title}\n\n${body}"
+    And the promptTemplate is "/orchestrate ${prompt}"
+    And issue #123 has title "Fix login bug" and body "Users get redirected..."
+    Then the rendered prompt should be:
+      """
+      /orchestrate #123: Fix login bug
+
+      Users get redirected...
+      """
+
+  Scenario: Launching adds links to existing issue card
+    Given I started work on issue #123 from the launch confirmation dialog
+    Then the EXISTING card (with issueLink.number = 123) should gain:
+      | Link         | Value                          |
+      | tmuxLink     | sessionName = "issue-123"      |
+      | sessionLink  | (added via SessionStart hook)  |
+      | worktreeLink | (added when worktree created)  |
+    And the card should move from Backlog to In Progress
+    And the label should change from "ISSUE" to "SESSION"
+    And there should still be exactly one card
+
+  # ── Prompt Templates ──
+
+  Scenario: Default prompt template
+    Given no custom promptTemplate is configured
+    Then the default promptTemplate should be "${prompt}"
+    And the prompt should be sent as-is to Claude
+
+  Scenario: Custom prompt template wraps the issue
+    Given settings has promptTemplate = "/orchestrate ${prompt}"
     When I start a GitHub issue
     Then the prompt should be prepended with "/orchestrate"
 
-  Scenario: No skill prefix configured
-    Given settings has no "skill" configured
-    When I start a GitHub issue
-    Then the prompt should just be the issue title and body
+  Scenario: Per-project prompt template override
+    Given project "LangWatch" has promptTemplate = "/orchestrate ${prompt}"
+    And project "SideProject" has no promptTemplate (inherits global)
+    When I start a LangWatch issue
+    Then the project's template should be used
+    When I start a SideProject issue
+    Then the global template should be used
 
-  Scenario: Issue body is included in prompt
-    Given issue #123 has a body with acceptance criteria
-    When I start working on it
-    Then the full issue body should be included in the Claude prompt
-    And it should be fetched via `gh issue view 123 --json title,body`
+  Scenario: GitHub issue prompt template
+    Given settings has githubIssuePromptTemplate = "Fix issue #${number}: ${title}\n\nDetails:\n${body}"
+    When building a prompt for issue #42 "Add dark mode"
+    Then the issue template should render first
+    Then the result should be wrapped by promptTemplate
 
   # ── Edge Cases ──
 
@@ -150,7 +169,6 @@ Feature: GitHub Issues as Backlog Source
     Given project "LangWatch" has githubFilter "assignee:@me repo:langwatch/langwatch is:open"
     When I select the LangWatch project view
     Then the backlog should only show issues matching that filter
-    And not issues from other repos
 
   Scenario: Global view combines per-project filters
     Given "LangWatch" has filter "repo:langwatch/langwatch"

--- a/specs/sources/manual-tasks.feature
+++ b/specs/sources/manual-tasks.feature
@@ -6,79 +6,116 @@ Feature: Manual Task Creation
   Background:
     Given the Kanban application is running
 
-  Scenario: Creating a manual task
+  # ── Task Creation ──
+
+  Scenario: Creating a manual task with single prompt field
     When I click the "+" button or press ⌘N
-    Then a task creation form should appear
-    And I should be able to enter:
-      | Field       | Required | Description                              |
-      | Title       | yes      | Short description of the task            |
-      | Description | no       | Detailed requirements for Claude         |
-      | Project     | yes      | Dropdown from configured projects        |
-    And the Project field should be a dropdown picker, not free text
+    Then a task creation form should appear with:
+      | Field              | Type                    | Required |
+      | Prompt             | Multiline text editor   | yes      |
+      | Project            | Dropdown picker         | yes      |
+      | Start immediately  | Checkbox                | no       |
+    And the prompt field placeholder should say "Describe what you want Claude to do..."
+
+  Scenario: Prompt field splits into name and body
+    When I enter a multi-line prompt:
+      """
+      Refactor database layer
+
+      Move all SQL queries to a dedicated repository pattern.
+      Add proper error handling and connection pooling.
+      """
+    Then the card name should be "Refactor database layer" (first line)
+    And the promptBody should be the full text
+    And the promptBody is what gets sent to Claude
+
+  Scenario: Single-line prompt
+    When I enter just "Fix the login button color"
+    Then the card name should be "Fix the login button color"
+    And the promptBody should be "Fix the login button color"
 
   Scenario: Project defaults to current selection
     Given I'm viewing the "LangWatch" project
     When I create a new task
     Then the project dropdown should default to "LangWatch"
 
-  Scenario: Quick-create with just a title
-    When I type a title and press Enter
-    Then the task should be created in the Backlog
-    And the project should default to the currently selected project
-
   Scenario: Custom project path
     When I need a project path not in the configured list
     Then I should be able to select "Custom path..." from the dropdown
     And type a path manually
 
+  # ── Start Immediately ──
+
   Scenario: Start immediately checkbox
     When the task creation form appears
     Then a "Start immediately" checkbox should be visible
-    And it should be checked by default
-    When I create a task with "Start immediately" checked
-    Then the task should be created in Backlog AND immediately launched
-    And a tmux session should be created with Claude running
+    And it should remember the last setting via @AppStorage
 
   Scenario: Start immediately preference persists
     Given I unchecked "Start immediately" on the last task I created
     When I open the task creation form again
     Then "Start immediately" should still be unchecked
-    Because the preference is saved via @AppStorage
+
+  Scenario: Create and start immediately
+    When I create a task with "Start immediately" checked
+    Then the card should be created in the board
+    And the launch confirmation dialog should appear with the prompt
+    And on launch, the card gains tmuxLink + sessionLink
+    And exactly one card should exist (no duplicates)
 
   Scenario: Create without starting
     When I uncheck "Start immediately" and create a task
-    Then the task should appear in Backlog
-    But no tmux session should be created
-    And I can start it later by clicking the Start button on the card
+    Then the card should appear in Backlog with label "TASK"
+    And no tmux session should be created
+    And the card should have no sessionLink, tmuxLink, or worktreeLink
+    And I can start it later by clicking the Start button
 
-  Scenario: Starting a manual task
+  # ── Card Structure ──
+
+  Scenario: Manual task card structure
+    When I create a manual task "Fix auth flow"
+    Then a card should be created with:
+      | Field         | Value                         |
+      | id            | card_<KSUID>                  |
+      | name          | Fix auth flow                 |
+      | source        | manual                        |
+      | column        | backlog (or in_progress)      |
+      | promptBody    | Full prompt text              |
+    And sessionLink, tmuxLink, worktreeLink, prLink, issueLink should all be nil
+
+  # ── Starting a Manual Task ──
+
+  Scenario: Starting a manual task from backlog
     Given a manual task "Refactor database layer" exists in Backlog
     When I click "Start"
-    Then Claude should be launched with `claude --worktree`
-    And the worktree should get a random-words name (e.g., "fluffy-walrus")
-    And the task description should be sent as the prompt
+    Then the launch confirmation dialog should show the promptBody
+    And the prompt should be wrapped with the project's promptTemplate
+    And on launch, the card gains tmuxLink (and later sessionLink via hook)
 
   Scenario: Manual task with specific project
     Given a manual task is linked to project "~/Projects/remote/langwatch-saas"
     When I start the task
     Then Claude should be launched in that project directory
-    And `claude --worktree` should create a worktree in that repo
+
+  # ── Editing and Deleting ──
 
   Scenario: Editing a manual task
     Given a manual task exists in the Backlog
     When I click on the card to open it
-    Then I should be able to edit the title and description
+    Then I should be able to edit the name
     And changes should save automatically
 
   Scenario: Deleting a manual task
     Given a manual task exists in the Backlog
     When I right-click and select "Delete"
     Then a confirmation dialog should appear
-    And on confirm, the task should be permanently removed
+    And on confirm, the card should be permanently removed
 
-  Scenario: Converting a manual task to track a GitHub issue
+  # ── Conversion ──
+
+  Scenario: Manual task gains GitHub issue link
     Given a manual task is in progress
     And the Claude session created a PR linked to issue #456
-    When the background process detects the link
-    Then the card should be enriched with the GitHub issue metadata
-    And it should behave like a GitHub-sourced card from now on
+    When the reconciler detects the PR and matches it by branch
+    Then the card should gain a prLink
+    And the card label should remain "SESSION" (session takes priority)


### PR DESCRIPTION
## Summary

- **Typed link sub-structs**: Restructure flat `Link` entity into independently optional `SessionLink`, `TmuxLink`, `WorktreeLink`, `PRLink`, `IssueLink` with KSUID-based card IDs. Backward-compatible Codable reads old flat JSON and writes new nested format.
- **CardReconciler**: Pure function that matches discovered sessions/worktrees/PRs to existing cards, fixing the triplication bug where "Start immediately" created 3 cards from different discovery sources.
- **Prompt templates & launch dialog**: Single multiline prompt field in NewTaskDialog, `${variable}` template substitution (global + per-project), and a launch confirmation dialog with editable prompt and "Create worktree" checkbox.
- **UI badges**: CardLabelBadge (SESSION/WORKTREE/ISSUE/PR/TASK) with color-coded capsules and adaptive text color for dark/light mode contrast.
- **BDD specs rewritten** for the card-centric model across all feature files.

## Test plan

- [x] `swift build` compiles clean
- [x] `swift test` — 204 tests passing
- [ ] Create task with "Start immediately" → 1 card (not 3)
- [ ] GitHub issue in backlog → Start → same card gains session link
- [ ] Badge readability in both dark and light mode
- [ ] Launch confirmation dialog shows editable prompt before every launch
- [ ] Old `links.json` files auto-migrate on read (backward compat)