### PR TITLE
fix: use which instead of where for command detection on Linux

### DIFF
--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -272,7 +272,30 @@ struct DependencyStatus {
 }
 
 async fn command_exists(name: &str) -> bool {
-    tokio::process::Command::new("where")
+    #[cfg(target_os = "linux")]
+    {
+        let home = std::env::var("HOME").unwrap_or_default();
+        let direct_paths = vec![
+            format!("{}/.local/bin/{}", home, name),
+            format!("/usr/local/bin/{}", name),
+            format!("/usr/bin/{}", name),
+        ];
+        for path in &direct_paths {
+            if std::path::Path::new(path).exists() {
+                return true;
+            }
+        }
+        let nvm_versions = format!("{}/.nvm/versions/node", home);
+        if let Ok(entries) = std::fs::read_dir(&nvm_versions) {
+            for entry in entries.flatten() {
+                let bin = entry.path().join("bin").join(name);
+                if bin.exists() {
+                    return true;
+                }
+            }
+        }
+    }
+    tokio::process::Command::new(if cfg!(target_os = "windows") { "where" } else { "which" })
         .arg(name)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())


### PR DESCRIPTION
## Fix command detection on native Linux

### Problem

The `command_exists` function in `lib.rs` uses the `where` command to check for installed dependencies (Claude Code, git, gh). `where` is Windows-only — on Linux it doesn't exist, so all dependency checks fail silently and the onboarding wizard reports everything as "not found" regardless of what's actually installed.

This affects anyone running the Tauri build on native Linux (e.g. Ubuntu, Pop_OS, Fedora). WSL users are unaffected since they're running a Windows host binary.

A second related issue: even after switching to `which`, Tauri apps on Linux launch with a stripped `PATH` that excludes common user bin directories. This means binaries installed via npm (`~/.local/bin`), nvm (`~/.nvm/versions/node/*/bin`), or manually to `/usr/local/bin` won't be found by a plain `which` call.

### Fix

- Use `which` instead of `where` on non-Windows targets
- On Linux, explicitly check common user bin locations before falling back to `which`:
  - `~/.local/bin` (default npm global bin on many distros)
  - `/usr/local/bin`
  - `/usr/bin`
  - `~/.nvm/versions/node/*/bin` (any installed nvm node version)

### Testing

Tested on Pop_OS 22.04 with:
- Node 23.11.0 managed via nvm
- Claude Code 2.1.92 installed globally via npm (binary at `~/.local/bin/claude`)
- Rust 1.90.0

All three dependency checks (Claude Code, git, gh) now correctly resolve after this fix.