### PR TITLE
feat(api-service): third-party launcher support (Ollama, model flags, base URL)

### DIFF
--- a/Sources/KanbanCode/App.swift
+++ b/Sources/KanbanCode/App.swift
@@ -104,14 +104,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUs
         // Install `kanban` CLI to ~/.local/bin
         Self.installCLI()
 
-        // Set up notifications: delegate must be set BEFORE requesting authorization
-        let center = UNUserNotificationCenter.current()
-        center.delegate = self
-        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-            if let error {
-                print("[Kanban Code] Notification permission error: \(error)")
-            } else if !granted {
-                print("[Kanban Code] Notification permission denied")
+        // UNUserNotificationCenter requires a bundle identifier — skip when running via `swift run`
+        if Bundle.main.bundleIdentifier != nil {
+            let center = UNUserNotificationCenter.current()
+            center.delegate = self
+            center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+                if let error {
+                    print("[Kanban Code] Notification permission error: \(error)")
+                } else if !granted {
+                    print("[Kanban Code] Notification permission denied")
+                }
             }
         }
     }

--- a/Sources/KanbanCode/ContentView+Launch.swift
+++ b/Sources/KanbanCode/ContentView+Launch.swift
@@ -46,12 +46,13 @@ extension ContentView {
                 hasRemoteConfig: projectIsUnderRemote,
                 remoteHost: globalRemote?.host,
                 promptImagePaths: card.link.promptImagePaths ?? [],
-                assistant: card.link.effectiveAssistant
+                assistant: card.link.effectiveAssistant,
+                apiServiceId: card.link.apiServiceId
             )
         }
     }
 
-    func executeLaunch(cardId: String, prompt: String, projectPath: String, worktreeName: String?, runRemotely: Bool = true, skipPermissions: Bool = true, commandOverride: String? = nil, images: [ImageAttachment] = [], assistant: CodingAssistant = .claude) {
+    func executeLaunch(cardId: String, prompt: String, projectPath: String, worktreeName: String?, runRemotely: Bool = true, skipPermissions: Bool = true, commandOverride: String? = nil, images: [ImageAttachment] = [], assistant: CodingAssistant = .claude, serviceIdOverride: String? = nil) {
         // IMMEDIATE state update via reducer — no more dual memory+disk writes
         store.dispatch(.launchCard(cardId: cardId, prompt: prompt, projectPath: projectPath, worktreeName: worktreeName, runRemotely: runRemotely, commandOverride: commandOverride))
         shouldFocusTerminal = true
@@ -100,6 +101,19 @@ extension ContentView {
                     preamble = nil
                 }
 
+                // Resolve API service for this card and inject base URL env var if needed
+                let cardLink = store.state.cards.first(where: { $0.id == cardId })?.link
+                let resolvedServiceId = serviceIdOverride ?? cardLink?.apiServiceId ?? settings?.defaultAPIServiceIds[assistant.rawValue]
+                let resolvedService = resolvedServiceId.flatMap { sid in
+                    settings?.apiServices.first { $0.id == sid && $0.assistant == assistant }
+                }
+                var serviceExtraEnv = extraEnv
+                if let svc = resolvedService,
+                   let envKey = assistant.baseURLEnvKey,
+                   let url = svc.baseURL, !url.isEmpty {
+                    serviceExtraEnv[envKey] = url
+                }
+
                 // Snapshot existing session files for detection
                 let sessionFileExt = ".\(assistant.sessionFileExtension)"
                 let configDir = (NSHomeDirectory() as NSString).appendingPathComponent(assistant.configDirName)
@@ -145,11 +159,12 @@ extension ContentView {
                     prompt: prompt,
                     worktreeName: assistant.supportsWorktree ? worktreeName : nil,
                     shellOverride: shellOverride,
-                    extraEnv: extraEnv,
+                    extraEnv: serviceExtraEnv,
                     commandOverride: commandOverride,
                     skipPermissions: skipPermissions,
                     preamble: preamble,
-                    assistant: assistant
+                    assistant: assistant,
+                    service: resolvedService
                 )
                 KanbanCodeLog.info("launch", "Tmux session created: \(tmuxName)")
 
@@ -431,7 +446,8 @@ extension ContentView {
             remoteHost: globalRemote?.host,
             isResume: true,
             sessionId: sessionId,
-            assistant: card.link.effectiveAssistant
+            assistant: card.link.effectiveAssistant,
+            apiServiceId: card.link.apiServiceId
         )
     }
 
@@ -515,7 +531,7 @@ extension ContentView {
         }
     }
 
-    func executeResume(cardId: String, runRemotely: Bool, skipPermissions: Bool = true, commandOverride: String?, assistant: CodingAssistant = .claude) {
+    func executeResume(cardId: String, runRemotely: Bool, skipPermissions: Bool = true, commandOverride: String?, assistant: CodingAssistant = .claude, serviceIdOverride: String? = nil) {
         guard let card = store.state.cards.first(where: { $0.id == cardId }) else { return }
         let sessionId = card.link.sessionLink?.sessionId ?? card.link.id
         // For worktree cards, cd into the worktree — that's where Claude stored the session data.
@@ -592,15 +608,27 @@ extension ContentView {
                     preamble = nil
                 }
 
+                let resumeServiceId = serviceIdOverride ?? card.link.apiServiceId ?? settings?.defaultAPIServiceIds[assistant.rawValue]
+                let resolvedService = resumeServiceId.flatMap { sid in
+                    settings?.apiServices.first { $0.id == sid && $0.assistant == assistant }
+                }
+                var serviceExtraEnv = extraEnv
+                if let svc = resolvedService,
+                   let envKey = assistant.baseURLEnvKey,
+                   let url = svc.baseURL, !url.isEmpty {
+                    serviceExtraEnv[envKey] = url
+                }
+
                 let actualTmuxName = try await launcher.resume(
                     sessionId: sessionId,
                     projectPath: projectPath,
                     shellOverride: shellOverride,
-                    extraEnv: extraEnv,
+                    extraEnv: serviceExtraEnv,
                     commandOverride: commandOverride,
                     skipPermissions: skipPermissions,
                     preamble: preamble,
-                    assistant: assistant
+                    assistant: assistant,
+                    service: resolvedService
                 )
                 KanbanCodeLog.info("resume", "Resume launched for card=\(cardId.prefix(12)) actualTmux=\(actualTmuxName)")
 
@@ -611,4 +639,5 @@ extension ContentView {
             }
         }
     }
+
 }

--- a/Sources/KanbanCode/ContentView.swift
+++ b/Sources/KanbanCode/ContentView.swift
@@ -18,6 +18,7 @@ struct LaunchConfig: Identifiable {
     let sessionId: String?
     let promptImagePaths: [String]
     let assistant: CodingAssistant
+    let apiServiceId: String?
 
     init(
         cardId: String,
@@ -31,7 +32,8 @@ struct LaunchConfig: Identifiable {
         isResume: Bool = false,
         sessionId: String? = nil,
         promptImagePaths: [String] = [],
-        assistant: CodingAssistant = .claude
+        assistant: CodingAssistant = .claude,
+        apiServiceId: String? = nil
     ) {
         self.cardId = cardId
         self.projectPath = projectPath
@@ -45,6 +47,7 @@ struct LaunchConfig: Identifiable {
         self.sessionId = sessionId
         self.promptImagePaths = promptImagePaths
         self.assistant = assistant
+        self.apiServiceId = apiServiceId
     }
 }
 
@@ -763,8 +766,8 @@ struct ContentView: View {
                     onCreate: { prompt, projectPath, title, startImmediately, images in
                         createManualTask(prompt: prompt, projectPath: projectPath, title: title, startImmediately: startImmediately, images: images)
                     },
-                    onCreateAndLaunch: { prompt, projectPath, title, createWorktree, runRemotely, skipPermissions, commandOverride, images, assistant in
-                        createManualTaskAndLaunch(prompt: prompt, projectPath: projectPath, title: title, createWorktree: createWorktree, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, images: images, assistant: assistant)
+                    onCreateAndLaunch: { prompt, projectPath, title, createWorktree, runRemotely, skipPermissions, commandOverride, images, assistant, apiServiceId in
+                        createManualTaskAndLaunch(prompt: prompt, projectPath: projectPath, title: title, createWorktree: createWorktree, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, images: images, assistant: assistant, apiServiceId: apiServiceId)
                     }
                 )
             }
@@ -804,16 +807,17 @@ struct ContentView: View {
                     sessionId: config.sessionId,
                     promptImagePaths: config.promptImagePaths,
                     assistant: config.assistant,
+                    initialServiceId: config.apiServiceId,
                     isPresented: Binding(
                         get: { launchConfig != nil },
                         set: { if !$0 { launchConfig = nil } }
                     )
-                ) { editedPrompt, createWorktree, worktreeBranch, runRemotely, skipPermissions, commandOverride, images in
+                ) { editedPrompt, createWorktree, worktreeBranch, runRemotely, skipPermissions, commandOverride, images, selectedServiceId in
                     if config.isResume {
-                        executeResume(cardId: config.cardId, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, assistant: config.assistant)
+                        executeResume(cardId: config.cardId, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, assistant: config.assistant, serviceIdOverride: selectedServiceId)
                     } else {
                         let wtName: String? = createWorktree ? (worktreeBranch ?? config.worktreeName ?? "") : nil
-                        executeLaunch(cardId: config.cardId, prompt: editedPrompt, projectPath: config.projectPath, worktreeName: wtName, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, images: images, assistant: config.assistant)
+                        executeLaunch(cardId: config.cardId, prompt: editedPrompt, projectPath: config.projectPath, worktreeName: wtName, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, images: images, assistant: config.assistant, serviceIdOverride: selectedServiceId)
                     }
                 }
             }
@@ -2345,7 +2349,7 @@ struct ContentView: View {
         }
     }
 
-    private func createManualTaskAndLaunch(prompt: String, projectPath: String?, title: String? = nil, createWorktree: Bool, runRemotely: Bool, skipPermissions: Bool = true, commandOverride: String? = nil, images: [ImageAttachment] = [], assistant: CodingAssistant = .claude) {
+    private func createManualTaskAndLaunch(prompt: String, projectPath: String?, title: String? = nil, createWorktree: Bool, runRemotely: Bool, skipPermissions: Bool = true, commandOverride: String? = nil, images: [ImageAttachment] = [], assistant: CodingAssistant = .claude, apiServiceId: String? = nil) {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let name: String
         if let title, !title.isEmpty {
@@ -2358,7 +2362,7 @@ struct ContentView: View {
             var mutable = img
             return try? mutable.saveToPersistent()
         }
-        let link = Link(
+        var link = Link(
             name: name,
             projectPath: projectPath,
             column: .inProgress,
@@ -2367,6 +2371,7 @@ struct ContentView: View {
             promptImagePaths: imagePaths,
             assistant: assistant
         )
+        link.apiServiceId = apiServiceId
         let effectivePath = projectPath ?? NSHomeDirectory()
 
         store.dispatch(.createManualTask(link))

--- a/Sources/KanbanCode/LaunchConfirmationDialog.swift
+++ b/Sources/KanbanCode/LaunchConfirmationDialog.swift
@@ -15,9 +15,13 @@ struct LaunchConfirmationDialog: View {
     let isResume: Bool
     let sessionId: String?
     let assistant: CodingAssistant
+    let initialServiceId: String?
     @Binding var isPresented: Bool
-    var onLaunch: (String, Bool, String?, Bool, Bool, String?, [ImageAttachment]) -> Void = { _, _, _, _, _, _, _ in } // (editedPrompt, createWorktree, worktreeBranch, runRemotely, skipPermissions, commandOverride, images)
+    var onLaunch: (String, Bool, String?, Bool, Bool, String?, [ImageAttachment], String?) -> Void = { _, _, _, _, _, _, _, _ in } // (editedPrompt, createWorktree, worktreeBranch, runRemotely, skipPermissions, commandOverride, images, apiServiceId)
 
+    private let settingsStore = SettingsStore()
+    @State private var apiServices: [APIService] = []
+    @State private var selectedServiceId: String?
     @State private var prompt: String
     @State private var images: [ImageAttachment]
     @State private var command: String = ""
@@ -40,8 +44,9 @@ struct LaunchConfirmationDialog: View {
         sessionId: String? = nil,
         promptImagePaths: [String] = [],
         assistant: CodingAssistant = .claude,
+        initialServiceId: String? = nil,
         isPresented: Binding<Bool>,
-        onLaunch: @escaping (String, Bool, String?, Bool, Bool, String?, [ImageAttachment]) -> Void = { _, _, _, _, _, _, _ in }
+        onLaunch: @escaping (String, Bool, String?, Bool, Bool, String?, [ImageAttachment], String?) -> Void = { _, _, _, _, _, _, _, _ in }
     ) {
         self.cardId = cardId
         self.projectPath = projectPath
@@ -54,8 +59,10 @@ struct LaunchConfirmationDialog: View {
         self.isResume = isResume
         self.sessionId = sessionId
         self.assistant = assistant
+        self.initialServiceId = initialServiceId
         self._isPresented = isPresented
         self.onLaunch = onLaunch
+        self._selectedServiceId = State(initialValue: initialServiceId)
         self._prompt = State(initialValue: initialPrompt)
         self._images = State(initialValue: promptImagePaths.compactMap { ImageAttachment.fromPath($0) })
         self._runRemotely = State(initialValue: UserDefaults.standard.object(forKey: "runRemotely_\(projectPath)") as? Bool ?? true)
@@ -79,6 +86,20 @@ struct LaunchConfirmationDialog: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
+                    }
+
+                    // API Service picker
+                    let servicesForAssistant = apiServices.filter { $0.assistant == assistant }
+                    if !servicesForAssistant.isEmpty {
+                        Picker("API Service", selection: $selectedServiceId) {
+                            Text("Default").tag(String?.none)
+                            ForEach(servicesForAssistant) { service in
+                                Text(service.name).tag(String?.some(service.id))
+                            }
+                        }
+                        .onChange(of: selectedServiceId) {
+                            if !commandEdited { command = commandPreview }
+                        }
                     }
 
                     // Worktree name (if applicable, launch only)
@@ -198,6 +219,10 @@ struct LaunchConfirmationDialog: View {
         .onAppear {
             command = commandPreview
         }
+        .task { await reloadServices() }
+        .onReceive(NotificationCenter.default.publisher(for: .kanbanCodeSettingsChanged)) { _ in
+            Task { await reloadServices() }
+        }
         .onChange(of: prompt) {
             if !commandEdited { command = commandPreview }
         }
@@ -219,13 +244,28 @@ struct LaunchConfirmationDialog: View {
 
     // MARK: - Actions
 
+    private func reloadServices() async {
+        let settings = (try? await settingsStore.read()) ?? Settings()
+        apiServices = settings.apiServices
+        // If the current selection still exists keep it; otherwise fall back to default.
+        let currentStillValid = selectedServiceId.flatMap { id in
+            apiServices.first { $0.id == id }
+        } != nil
+        if !currentStillValid {
+            selectedServiceId = initialServiceId == nil
+                ? settings.defaultAPIServiceIds[assistant.rawValue]
+                : nil
+        }
+        if !commandEdited { command = commandPreview }
+    }
+
     private func submitForm() {
         if !isResume {
             guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         }
         let override = commandEdited ? command : nil
         let branch = worktreeBranch.trimmingCharacters(in: .whitespacesAndNewlines)
-        onLaunch(prompt, effectiveCreateWorktree, branch.isEmpty ? nil : branch, effectiveRunRemotely, dangerouslySkipPermissions, override, images)
+        onLaunch(prompt, effectiveCreateWorktree, branch.isEmpty ? nil : branch, effectiveRunRemotely, dangerouslySkipPermissions, override, images, selectedServiceId)
         isPresented = false
     }
 
@@ -249,10 +289,12 @@ struct LaunchConfirmationDialog: View {
             }
         }
 
+        let service = selectedServiceId.flatMap { id in apiServices.first { $0.id == id } }
         if isResume, let sid = sessionId {
             let resumeCmd = assistant.resumeCommand(
                 sessionId: sid,
-                skipPermissions: dangerouslySkipPermissions
+                skipPermissions: dangerouslySkipPermissions,
+                service: service
             )
             parts.append("cd \(projectPath) && \(resumeCmd)")
         } else {
@@ -265,7 +307,8 @@ struct LaunchConfirmationDialog: View {
             }
             parts.append(assistant.launchCommand(
                 skipPermissions: dangerouslySkipPermissions,
-                worktreeName: effectiveWorktreeName
+                worktreeName: effectiveWorktreeName,
+                service: service
             ))
         }
 

--- a/Sources/KanbanCode/NewTaskDialog.swift
+++ b/Sources/KanbanCode/NewTaskDialog.swift
@@ -9,9 +9,13 @@ struct NewTaskDialog: View {
     var enabledAssistants: [CodingAssistant] = CodingAssistant.allCases
     /// (prompt, projectPath, title, startImmediately, images) — creates task without an assistant set
     var onCreate: (String, String?, String?, Bool, [ImageAttachment]) -> Void = { _, _, _, _, _ in }
-    /// (prompt, projectPath, title, createWorktree, runRemotely, skipPermissions, commandOverride, images, assistant) — creates and launches directly (skips LaunchConfirmation)
-    var onCreateAndLaunch: (String, String?, String?, Bool, Bool, Bool, String?, [ImageAttachment], CodingAssistant) -> Void = { _, _, _, _, _, _, _, _, _ in }
+    /// (prompt, projectPath, title, createWorktree, runRemotely, skipPermissions, commandOverride, images, assistant, apiServiceId) — creates and launches directly (skips LaunchConfirmation)
+    var onCreateAndLaunch: (String, String?, String?, Bool, Bool, Bool, String?, [ImageAttachment], CodingAssistant, String?) -> Void = { _, _, _, _, _, _, _, _, _, _ in }
 
+    private let settingsStore = SettingsStore()
+    @State private var apiServices: [APIService] = []
+    @State private var defaultAPIServiceIds: [String: String] = [:]
+    @State private var selectedServiceId: String? = nil
     @AppStorage("selectedAssistant") private var selectedAssistantRaw: String = CodingAssistant.claude.rawValue
     private var selectedAssistant: CodingAssistant {
         get { CodingAssistant(rawValue: selectedAssistantRaw) ?? .claude }
@@ -70,6 +74,32 @@ struct NewTaskDialog: View {
                     TextField("Project path", text: $customPath)
                         .textFieldStyle(.roundedBorder)
                         .font(.app(.caption))
+                }
+            }
+
+            // Assistant picker (when multiple enabled)
+            if startImmediately && enabledAssistants.count > 1 {
+                Picker("Assistant", selection: $selectedAssistantRaw) {
+                    ForEach(enabledAssistants, id: \.self) { assistant in
+                        Text(assistant.displayName).tag(assistant.rawValue)
+                    }
+                }
+                .onChange(of: selectedAssistantRaw) {
+                    selectedServiceId = defaultAPIServiceIds[selectedAssistant.rawValue]
+                }
+            }
+
+            // API Service picker (when services exist for this assistant)
+            let servicesForAssistant = apiServices.filter { $0.assistant == selectedAssistant }
+            if startImmediately && !servicesForAssistant.isEmpty {
+                Picker("API Service", selection: $selectedServiceId) {
+                    Text("Default").tag(String?.none)
+                    ForEach(servicesForAssistant) { service in
+                        Text(service.name).tag(String?.some(service.id))
+                    }
+                }
+                .onChange(of: selectedServiceId) {
+                    if !commandEdited { command = commandPreview }
                 }
             }
 
@@ -146,18 +176,6 @@ struct NewTaskDialog: View {
 
             // Buttons
             HStack {
-                if startImmediately && enabledAssistants.count > 1 {
-                    Picker(selection: $selectedAssistantRaw) {
-                        ForEach(enabledAssistants, id: \.self) { assistant in
-                            Text(assistant.displayName)
-                                .tag(assistant.rawValue)
-                        }
-                    } label: {
-                        EmptyView()
-                    }
-                    .fixedSize()
-                }
-
                 Spacer()
                 Button("Cancel") {
                     isPresented = false
@@ -193,6 +211,10 @@ struct NewTaskDialog: View {
             }
             command = commandPreview
         }
+        .task { await reloadServices() }
+        .onReceive(NotificationCenter.default.publisher(for: .kanbanCodeSettingsChanged)) { _ in
+            Task { await reloadServices() }
+        }
         .onChange(of: prompt) {
             if !commandEdited { command = commandPreview }
         }
@@ -223,10 +245,26 @@ struct NewTaskDialog: View {
         }
         .onChange(of: selectedAssistantRaw) {
             if !commandEdited { command = commandPreview }
+            // Reset to default service for the newly selected assistant
+            selectedServiceId = defaultAPIServiceIds[selectedAssistant.rawValue]
         }
     }
 
     // MARK: - Actions
+
+    private func reloadServices() async {
+        let settings = (try? await settingsStore.read()) ?? Settings()
+        apiServices = settings.apiServices
+        defaultAPIServiceIds = settings.defaultAPIServiceIds
+        // Keep current selection if it still exists; otherwise fall back to the new default.
+        let currentStillValid = selectedServiceId.flatMap { id in
+            apiServices.first { $0.id == id }
+        } != nil
+        if !currentStillValid {
+            selectedServiceId = settings.defaultAPIServiceIds[selectedAssistant.rawValue]
+        }
+        if !commandEdited { command = commandPreview }
+    }
 
     private func submitForm() {
         guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
@@ -243,7 +281,8 @@ struct NewTaskDialog: View {
                 dangerouslySkipPermissions,
                 commandEdited ? command : nil,
                 images,
-                selectedAssistant
+                selectedAssistant,
+                selectedServiceId
             )
         } else {
             onCreate(prompt, proj, titleOrNil, false, images)
@@ -302,9 +341,11 @@ struct NewTaskDialog: View {
             worktreeName = nil
         }
 
+        let service = selectedServiceId.flatMap { id in apiServices.first { $0.id == id } }
         parts.append(selectedAssistant.launchCommand(
             skipPermissions: dangerouslySkipPermissions,
-            worktreeName: worktreeName
+            worktreeName: worktreeName,
+            service: service
         ))
 
         return parts.joined(separator: " \\\n  ")

--- a/Sources/KanbanCode/OnboardingWizard.swift
+++ b/Sources/KanbanCode/OnboardingWizard.swift
@@ -19,6 +19,12 @@ struct OnboardingWizard: View {
     @State private var runningSessions: [CodingAssistant: Int] = [:]
     @State private var killedSessions: Set<CodingAssistant> = []
     @State private var renderMarkdownImage = false
+    @State private var wizardServiceName: [CodingAssistant: String] = [:]
+    @State private var wizardServiceLauncher: [CodingAssistant: String] = [:]
+    @State private var wizardServiceModel: [CodingAssistant: String] = [:]
+    @State private var wizardServiceBaseURL: [CodingAssistant: String] = [:]
+    @State private var wizardServiceSaved: Set<CodingAssistant> = []
+    @State private var existingDefaultServiceIds: [String: String] = [:]
 
     /// Steps are built dynamically: Welcome, Assistants, [per-assistant hooks...], Dependencies, Notifications, Complete.
     private var steps: [OnboardingStep] {
@@ -56,19 +62,22 @@ struct OnboardingWizard: View {
 
             Divider()
 
-            // Step content
-            Group {
-                switch steps[min(currentStep, totalSteps - 1)] {
-                case .welcome: welcomeStep
-                case .assistants: assistantsStep
-                case .hooks(let assistant): hooksStep(for: assistant)
-                case .dependencies: dependenciesStep
-                case .notifications: notificationsStep
-                case .complete: completeStep
+            // Step content — scrollable so expanded sections don't obscure nav buttons
+            ScrollView {
+                Group {
+                    switch steps[min(currentStep, totalSteps - 1)] {
+                    case .welcome: welcomeStep
+                    case .assistants: assistantsStep
+                    case .hooks(let assistant): hooksStep(for: assistant)
+                    case .dependencies: dependenciesStep
+                    case .notifications: notificationsStep
+                    case .complete: completeStep
+                    }
                 }
+                .id(currentStep)
+                .transition(.push(from: navigatingForward ? .trailing : .leading))
+                .frame(maxWidth: .infinity)
             }
-            .id(currentStep)
-            .transition(.push(from: navigatingForward ? .trailing : .leading))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .clipped()
 
@@ -116,6 +125,17 @@ struct OnboardingWizard: View {
         .frame(width: 520, height: 460)
         .task {
             await refreshStatus()
+            if let settings = try? await settingsStore.read() {
+                existingDefaultServiceIds = settings.defaultAPIServiceIds
+                for assistant in CodingAssistant.allCases {
+                    guard let serviceId = settings.defaultAPIServiceIds[assistant.rawValue],
+                          let service = settings.apiServices.first(where: { $0.id == serviceId }) else { continue }
+                    wizardServiceName[assistant] = service.name
+                    wizardServiceLauncher[assistant] = service.launcherPrefix ?? ""
+                    wizardServiceModel[assistant] = service.modelFlag ?? ""
+                    wizardServiceBaseURL[assistant] = service.baseURL ?? ""
+                }
+            }
         }
         .onChange(of: enabledAssistants) {
             if currentStep >= totalSteps {
@@ -197,6 +217,61 @@ struct OnboardingWizard: View {
                         Text("Not Installed")
                             .foregroundStyle(.orange)
                             .font(.app(.caption))
+                    }
+                }
+
+                // Optional API service configuration (e.g. Ollama)
+                DisclosureGroup {
+                    VStack(alignment: .leading, spacing: 6) {
+                        TextField("Name", text: Binding(
+                            get: { wizardServiceName[assistant] ?? "" },
+                            set: { wizardServiceName[assistant] = $0 }
+                        ), prompt: Text("e.g. Ollama (local)"))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.app(.caption))
+
+                        TextField("Launcher prefix", text: Binding(
+                            get: { wizardServiceLauncher[assistant] ?? "" },
+                            set: { wizardServiceLauncher[assistant] = $0 }
+                        ), prompt: Text("e.g. ollama launch"))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.app(.caption))
+
+                        TextField("Model", text: Binding(
+                            get: { wizardServiceModel[assistant] ?? "" },
+                            set: { wizardServiceModel[assistant] = $0 }
+                        ), prompt: Text("e.g. qwen3-coder-next:cloud"))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.app(.caption))
+
+                        TextField("Base URL", text: Binding(
+                            get: { wizardServiceBaseURL[assistant] ?? "" },
+                            set: { wizardServiceBaseURL[assistant] = $0 }
+                        ), prompt: Text("e.g. http://localhost:11434/v1"))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.app(.caption))
+
+                        let alreadyConfigured = wizardServiceSaved.contains(assistant)
+                            || existingDefaultServiceIds[assistant.rawValue] != nil
+                        if !alreadyConfigured {
+                            Button("Save as Default Service") {
+                                saveWizardService(for: assistant)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                            .disabled((wizardServiceName[assistant] ?? "").isEmpty)
+                        }
+                    }
+                    .padding(.leading, 8)
+                } label: {
+                    HStack {
+                        let isConfigured = wizardServiceSaved.contains(assistant)
+                            || existingDefaultServiceIds[assistant.rawValue] != nil
+                        Image(systemName: isConfigured ? "checkmark.circle.fill" : "gearshape")
+                            .foregroundStyle(isConfigured ? Color.green : Color.secondary)
+                        Text("Configure API Service")
+                            .font(.app(.caption))
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -666,6 +741,30 @@ struct OnboardingWizard: View {
             try? await settingsStore.write(settings)
             NotificationCenter.default.post(name: .kanbanCodeSettingsChanged, object: nil)
         }
+    }
+
+    private func saveWizardService(for assistant: CodingAssistant) {
+        let name = wizardServiceName[assistant] ?? ""
+        guard !name.isEmpty else { return }
+        let launcher = wizardServiceLauncher[assistant].flatMap { $0.isEmpty ? nil : $0 }
+        let model = wizardServiceModel[assistant].flatMap { $0.isEmpty ? nil : $0 }
+        let baseURL = wizardServiceBaseURL[assistant].flatMap { $0.isEmpty ? nil : $0 }
+        let service = APIService(
+            name: name,
+            assistant: assistant,
+            launcherPrefix: launcher,
+            modelFlag: model,
+            baseURL: baseURL
+        )
+        Task {
+            var settings = (try? await settingsStore.read()) ?? Settings()
+            settings.apiServices.removeAll { $0.assistant == assistant && $0.name == name }
+            settings.apiServices.append(service)
+            settings.defaultAPIServiceIds[assistant.rawValue] = service.id
+            try? await settingsStore.write(settings)
+            NotificationCenter.default.post(name: .kanbanCodeSettingsChanged, object: nil)
+        }
+        wizardServiceSaved.insert(assistant)
     }
 
     private func testPushover() {

--- a/Sources/KanbanCode/SettingsView.swift
+++ b/Sources/KanbanCode/SettingsView.swift
@@ -127,7 +127,7 @@ struct SettingsView: View {
             AmphetamineSettingsView()
                 .tabItem { Label("Amphetamine", systemImage: "bolt.fill") }
         }
-        .frame(width: 520, height: 460)
+        .frame(width: 520, height: 520)
         .task {
             await checkAvailability()
         }
@@ -159,10 +159,19 @@ struct AssistantStatus {
 
 // MARK: - Assistants
 
+private struct ServiceSheetRequest: Identifiable {
+    let id = UUID()
+    let assistant: CodingAssistant
+    let existingService: APIService? // nil = add mode
+}
+
 struct AssistantsSettingsView: View {
     @Binding var assistantStatus: [CodingAssistant: AssistantStatus]
 
     private let settingsStore = SettingsStore()
+    @State private var apiServices: [APIService] = []
+    @State private var defaultAPIServiceIds: [String: String] = [:]
+    @State private var serviceSheetRequest: ServiceSheetRequest? = nil
 
     var body: some View {
         Form {
@@ -217,6 +226,68 @@ struct AssistantsSettingsView: View {
                                 .font(.caption)
                         }
                     }
+
+                    // API Services subsection
+                    let services = apiServices.filter { $0.assistant == assistant }
+                    if !services.isEmpty {
+                        ForEach(services) { service in
+                            HStack(spacing: 8) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(service.name)
+                                        .font(.body)
+                                    Group {
+                                        if let launcher = service.launcherPrefix, let model = service.modelFlag {
+                                            Text("\(launcher) \(assistant.cliCommand) --model \(model) -- …")
+                                        } else if let model = service.modelFlag {
+                                            Text("--model \(model) -- …")
+                                        } else if let launcher = service.launcherPrefix {
+                                            Text("\(launcher) \(assistant.cliCommand) -- …")
+                                        }
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                }
+                                Spacer()
+                                Button {
+                                    toggleDefault(service: service, for: assistant)
+                                } label: {
+                                    Image(systemName: defaultAPIServiceIds[assistant.rawValue] == service.id
+                                        ? "checkmark.circle.fill" : "circle")
+                                        .foregroundStyle(defaultAPIServiceIds[assistant.rawValue] == service.id
+                                            ? Color.blue : Color.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .help(defaultAPIServiceIds[assistant.rawValue] == service.id
+                                    ? "Default for \(assistant.displayName)" : "Set as default")
+
+                                Button {
+                                    serviceSheetRequest = ServiceSheetRequest(assistant: assistant, existingService: service)
+                                } label: {
+                                    Image(systemName: "pencil")
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Edit service")
+
+                                Button(role: .destructive) {
+                                    deleteService(service, for: assistant)
+                                } label: {
+                                    Image(systemName: "trash")
+                                        .foregroundStyle(.red)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+
+                    Button {
+                        serviceSheetRequest = ServiceSheetRequest(assistant: assistant, existingService: nil)
+                    } label: {
+                        Label("Add API Service", systemImage: "plus")
+                            .font(.body)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.blue)
                 } header: {
                     HStack {
                         Text(assistant.displayName)
@@ -236,6 +307,18 @@ struct AssistantsSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .task { await loadServices() }
+        .sheet(item: $serviceSheetRequest) { request in
+            AddAPIServiceSheet(assistant: request.assistant, existingService: request.existingService) { service in
+                if let existing = request.existingService,
+                   let idx = apiServices.firstIndex(where: { $0.id == existing.id }) {
+                    apiServices[idx] = service
+                } else {
+                    apiServices.append(service)
+                }
+                saveServices()
+            }
+        }
     }
 
     private func saveEnabledAssistants() {
@@ -246,6 +329,122 @@ struct AssistantsSettingsView: View {
             try? await settingsStore.write(settings)
             NotificationCenter.default.post(name: .kanbanCodeSettingsChanged, object: nil)
         }
+    }
+
+    private func loadServices() async {
+        let settings = (try? await settingsStore.read()) ?? Settings()
+        apiServices = settings.apiServices
+        defaultAPIServiceIds = settings.defaultAPIServiceIds
+    }
+
+    private func saveServices() {
+        let services = apiServices
+        let defaults = defaultAPIServiceIds
+        Task {
+            var settings = (try? await settingsStore.read()) ?? Settings()
+            settings.apiServices = services
+            settings.defaultAPIServiceIds = defaults
+            try? await settingsStore.write(settings)
+            NotificationCenter.default.post(name: .kanbanCodeSettingsChanged, object: nil)
+        }
+    }
+
+    private func toggleDefault(service: APIService, for assistant: CodingAssistant) {
+        if defaultAPIServiceIds[assistant.rawValue] == service.id {
+            defaultAPIServiceIds.removeValue(forKey: assistant.rawValue)
+        } else {
+            defaultAPIServiceIds[assistant.rawValue] = service.id
+        }
+        saveServices()
+    }
+
+    private func deleteService(_ service: APIService, for assistant: CodingAssistant) {
+        apiServices.removeAll { $0.id == service.id }
+        if defaultAPIServiceIds[assistant.rawValue] == service.id {
+            defaultAPIServiceIds.removeValue(forKey: assistant.rawValue)
+        }
+        saveServices()
+    }
+}
+
+// MARK: - Add API Service sheet
+
+struct AddAPIServiceSheet: View {
+    let assistant: CodingAssistant
+    let existingService: APIService?
+    let onSave: (APIService) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var launcherPrefix = ""
+    @State private var modelFlag = ""
+    @State private var baseURL = ""
+
+    init(assistant: CodingAssistant, existingService: APIService? = nil, onSave: @escaping (APIService) -> Void) {
+        self.assistant = assistant
+        self.existingService = existingService
+        self.onSave = onSave
+        _name = State(initialValue: existingService?.name ?? "")
+        _launcherPrefix = State(initialValue: existingService?.launcherPrefix ?? "")
+        _modelFlag = State(initialValue: existingService?.modelFlag ?? "")
+        _baseURL = State(initialValue: existingService?.baseURL ?? "")
+    }
+
+    private var isEditing: Bool { existingService != nil }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("\(isEditing ? "Edit" : "Add") API Service — \(assistant.displayName)")
+                .font(.headline)
+                .padding()
+
+            Form {
+                Section {
+                    TextField("Name", text: $name, prompt: Text("e.g. Ollama (local)"))
+                    TextField("Launcher prefix", text: $launcherPrefix, prompt: Text("e.g. ollama launch"))
+                    TextField("Model", text: $modelFlag, prompt: Text("e.g. qwen3-coder-next:cloud"))
+                    TextField("Base URL", text: $baseURL, prompt: Text("e.g. http://localhost:11434/v1"))
+                } header: {
+                    Text("Command preview:")
+                        .font(.caption)
+                } footer: {
+                    Text(previewCommand)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.escape)
+                Button(isEditing ? "Save" : "Add") {
+                    let service = APIService(
+                        id: existingService?.id ?? UUID().uuidString,
+                        name: name.isEmpty ? "Unnamed" : name,
+                        assistant: assistant,
+                        launcherPrefix: launcherPrefix.isEmpty ? nil : launcherPrefix,
+                        modelFlag: modelFlag.isEmpty ? nil : modelFlag,
+                        baseURL: baseURL.isEmpty ? nil : baseURL
+                    )
+                    onSave(service)
+                    dismiss()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+                .disabled(name.isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 420, height: 400)
+    }
+
+    private var previewCommand: String {
+        let prefix = launcherPrefix.isEmpty ? nil : launcherPrefix
+        let model = modelFlag.isEmpty ? nil : modelFlag
+        let service = APIService(name: "", assistant: assistant, launcherPrefix: prefix, modelFlag: model)
+        return assistant.launchCommand(skipPermissions: true, worktreeName: nil, service: service)
     }
 }
 

--- a/Sources/KanbanCodeCore/Adapters/Notifications/MacOSNotificationClient.swift
+++ b/Sources/KanbanCodeCore/Adapters/Notifications/MacOSNotificationClient.swift
@@ -8,6 +8,8 @@ public final class MacOSNotificationClient: NotifierPort, @unchecked Sendable {
     public init() {}
 
     public func sendNotification(title: String, message: String, imageData: Data?, cardId: String?) async throws {
+        // UNUserNotificationCenter requires a bundle identifier — unavailable under `swift run`.
+        guard Bundle.main.bundleIdentifier != nil else { return }
         let center = UNUserNotificationCenter.current()
 
         // Check current authorization status

--- a/Sources/KanbanCodeCore/Domain/Entities/APIService.swift
+++ b/Sources/KanbanCodeCore/Domain/Entities/APIService.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A named API service configuration that wraps a coding assistant CLI with a launcher prefix,
+/// model override, and optional base URL for third-party backends like Ollama.
+///
+/// Commands produced with a service:
+///   `[launcherPrefix] [cliCommand] [--model modelFlag] -- [assistant-flags]`
+///
+/// Example (Ollama):
+///   `ollama launch claude --model qwen3-coder-next:cloud -- --dangerously-skip-permissions`
+public struct APIService: Identifiable, Codable, Sendable, Equatable {
+    public var id: String
+    public var name: String
+    public var assistant: CodingAssistant
+    /// Shell command prepended before the assistant CLI, e.g. `"ollama launch"`.
+    /// `nil` means call the assistant CLI directly.
+    public var launcherPrefix: String?
+    /// Value passed to `--model`, e.g. `"qwen3-coder-next:cloud"`. `nil` omits the flag.
+    public var modelFlag: String?
+    /// Optional base URL injected as an environment variable (e.g. `ANTHROPIC_BASE_URL`).
+    public var baseURL: String?
+
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        assistant: CodingAssistant,
+        launcherPrefix: String? = nil,
+        modelFlag: String? = nil,
+        baseURL: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.assistant = assistant
+        self.launcherPrefix = launcherPrefix
+        self.modelFlag = modelFlag
+        self.baseURL = baseURL
+    }
+
+    /// Whether a `--` separator is required before assistant-specific flags.
+    public var needsSeparator: Bool { launcherPrefix != nil || modelFlag != nil }
+}

--- a/Sources/KanbanCodeCore/Domain/Entities/CodingAssistant.swift
+++ b/Sources/KanbanCodeCore/Domain/Entities/CodingAssistant.swift
@@ -131,35 +131,61 @@ public enum CodingAssistant: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    public func launchCommand(skipPermissions: Bool, worktreeName: String?) -> String {
-        var parts = [cliCommand]
-        if skipPermissions { parts.append(autoApproveFlag) }
-        parts.append(contentsOf: interactiveLaunchFlags)
-        if supportsWorktree, let worktreeName {
-            if worktreeName.isEmpty {
-                parts.append("--worktree")
-            } else {
-                parts.append("--worktree")
-                parts.append(worktreeName)
-            }
+    /// Environment variable used to override the API base URL for this assistant's backend.
+    public var baseURLEnvKey: String? {
+        switch self {
+        case .claude: "ANTHROPIC_BASE_URL"
+        case .codex:  "OPENAI_BASE_URL"
+        case .gemini: nil
         }
-        return parts.joined(separator: " ")
     }
 
-    public func resumeCommand(sessionId: String, skipPermissions: Bool) -> String {
+    /// Builds the tmux launch command, optionally wrapping with an `APIService`.
+    ///
+    /// Without service: `claude --dangerously-skip-permissions --worktree foo`
+    /// With service:    `ollama launch claude --model qwen3 -- --dangerously-skip-permissions --worktree foo`
+    public func launchCommand(skipPermissions: Bool, worktreeName: String?, service: APIService? = nil) -> String {
+        var prefix: [String] = []
+        if let launcher = service?.launcherPrefix { prefix.append(contentsOf: launcher.split(separator: " ").map(String.init)) }
+        prefix.append(cliCommand)
+        if let model = service?.modelFlag { prefix += ["--model", model] }
+
+        var flags: [String] = []
+        if skipPermissions { flags.append(autoApproveFlag) }
+        flags.append(contentsOf: interactiveLaunchFlags)
+        if supportsWorktree, let worktreeName {
+            flags += worktreeName.isEmpty ? ["--worktree"] : ["--worktree", worktreeName]
+        }
+
+        let sep: [String] = service?.needsSeparator == true ? ["--"] : []
+        return (prefix + sep + flags).joined(separator: " ")
+    }
+
+    /// Builds the tmux resume command, optionally wrapping with an `APIService`.
+    ///
+    /// Without service: `claude --dangerously-skip-permissions --resume <id>`
+    /// With service:    `ollama launch claude --model qwen3 -- --dangerously-skip-permissions --resume <id>`
+    public func resumeCommand(sessionId: String, skipPermissions: Bool, service: APIService? = nil) -> String {
+        var prefix: [String] = []
+        if let launcher = service?.launcherPrefix { prefix.append(contentsOf: launcher.split(separator: " ").map(String.init)) }
+        prefix.append(cliCommand)
+        if let model = service?.modelFlag { prefix += ["--model", model] }
+        let sep: [String] = service?.needsSeparator == true ? ["--"] : []
+
         switch self {
         case .codex:
-            var parts = [cliCommand, "resume"]
-            if skipPermissions { parts.append(autoApproveFlag) }
-            parts.append(contentsOf: interactiveLaunchFlags)
-            parts.append(sessionId)
-            return parts.joined(separator: " ")
+            // "resume" subcommand goes after -- when a separator is present
+            var flags = ["resume"]
+            if skipPermissions { flags.append(autoApproveFlag) }
+            flags.append(contentsOf: interactiveLaunchFlags)
+            flags.append(sessionId)
+            return (prefix + sep + flags).joined(separator: " ")
         case .claude, .gemini:
-            var parts = [cliCommand]
-            if skipPermissions { parts.append(autoApproveFlag) }
-            parts.append(resumeFlag)
-            parts.append(sessionId)
-            return parts.joined(separator: " ")
+            var flags: [String] = []
+            if skipPermissions { flags.append(autoApproveFlag) }
+            flags.append(resumeFlag)
+            flags.append(sessionId)
+            return (prefix + sep + flags).joined(separator: " ")
         }
     }
 }

--- a/Sources/KanbanCodeCore/Domain/Entities/Link.swift
+++ b/Sources/KanbanCodeCore/Domain/Entities/Link.swift
@@ -196,6 +196,10 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
     /// The effective assistant (never nil).
     public var effectiveAssistant: CodingAssistant { assistant ?? .claude }
 
+    /// ID of the `APIService` to use when launching/resuming this card.
+    /// nil means use the global default for the card's assistant (or no service).
+    public var apiServiceId: String?
+
     /// Launch lock — true while an async launch/resume is in progress.
     /// Prevents background reconciliation from overriding card state mid-launch.
     public var isLaunching: Bool?
@@ -342,7 +346,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
         // Card-level
         case id, name, projectPath, column, createdAt, updatedAt, lastActivity, lastOpenedAt
         case manualOverrides, manuallyArchived, source, promptBody, promptImagePaths, isRemote, isLaunching, sortOrder
-        case discoveredBranches, discoveredRepos, assistant
+        case discoveredBranches, discoveredRepos, assistant, apiServiceId
         // Typed links (new nested format)
         case sessionLink, tmuxLink, worktreeLink, prLinks, issueLink, queuedPrompts, browserTabs
         // Old format keys (for reading legacy format)
@@ -373,6 +377,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
         discoveredBranches = try c.decodeIfPresent([String].self, forKey: .discoveredBranches)
         discoveredRepos = try c.decodeIfPresent([String: String].self, forKey: .discoveredRepos)
         assistant = try c.decodeIfPresent(CodingAssistant.self, forKey: .assistant)
+        apiServiceId = try c.decodeIfPresent(String.self, forKey: .apiServiceId)
 
         // Session link: try nested first, fallback to flat
         if let sl = try c.decodeIfPresent(SessionLink.self, forKey: .sessionLink) {
@@ -459,6 +464,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
         try c.encodeIfPresent(discoveredBranches, forKey: .discoveredBranches)
         try c.encodeIfPresent(discoveredRepos, forKey: .discoveredRepos)
         try c.encodeIfPresent(assistant, forKey: .assistant)
+        try c.encodeIfPresent(apiServiceId, forKey: .apiServiceId)
 
         // Always write new nested format
         try c.encodeIfPresent(sessionLink, forKey: .sessionLink)

--- a/Sources/KanbanCodeCore/Domain/Ports/SessionLauncher.swift
+++ b/Sources/KanbanCodeCore/Domain/Ports/SessionLauncher.swift
@@ -13,7 +13,8 @@ public protocol SessionLauncher: Sendable {
         commandOverride: String?,
         skipPermissions: Bool,
         preamble: String?,
-        assistant: CodingAssistant
+        assistant: CodingAssistant,
+        service: APIService?
     ) async throws -> String // returns tmux session name
 
     /// Resume an existing session by its ID.
@@ -25,7 +26,8 @@ public protocol SessionLauncher: Sendable {
         commandOverride: String?,
         skipPermissions: Bool,
         preamble: String?,
-        assistant: CodingAssistant
+        assistant: CodingAssistant,
+        service: APIService?
     ) async throws -> String // returns tmux session name
 }
 
@@ -48,7 +50,8 @@ extension SessionLauncher {
             commandOverride: nil,
             skipPermissions: false,
             preamble: nil,
-            assistant: .claude
+            assistant: .claude,
+            service: nil
         )
     }
 
@@ -67,7 +70,8 @@ extension SessionLauncher {
             commandOverride: commandOverride,
             skipPermissions: false,
             preamble: nil,
-            assistant: .claude
+            assistant: .claude,
+            service: nil
         )
     }
 }

--- a/Sources/KanbanCodeCore/Infrastructure/SettingsStore.swift
+++ b/Sources/KanbanCodeCore/Infrastructure/SettingsStore.swift
@@ -14,6 +14,10 @@ public struct Settings: Codable, Sendable {
     public var hasCompletedOnboarding: Bool
     public var defaultAssistant: CodingAssistant?
     public var enabledAssistants: [CodingAssistant]
+    /// User-defined API service configurations (e.g. Ollama, LiteLLM proxy).
+    public var apiServices: [APIService]
+    /// Maps `CodingAssistant.rawValue` → `APIService.id` for the default service per assistant.
+    public var defaultAPIServiceIds: [String: String]
 
     public init(
         projects: [Project] = [],
@@ -27,7 +31,9 @@ public struct Settings: Codable, Sendable {
         columnOrder: [KanbanCodeColumn] = KanbanCodeColumn.allCases,
         hasCompletedOnboarding: Bool = false,
         defaultAssistant: CodingAssistant? = nil,
-        enabledAssistants: [CodingAssistant] = CodingAssistant.allCases
+        enabledAssistants: [CodingAssistant] = CodingAssistant.allCases,
+        apiServices: [APIService] = [],
+        defaultAPIServiceIds: [String: String] = [:]
     ) {
         self.projects = projects
         self.globalView = globalView
@@ -41,12 +47,15 @@ public struct Settings: Codable, Sendable {
         self.hasCompletedOnboarding = hasCompletedOnboarding
         self.defaultAssistant = defaultAssistant
         self.enabledAssistants = enabledAssistants
+        self.apiServices = apiServices
+        self.defaultAPIServiceIds = defaultAPIServiceIds
     }
 
     private enum CodingKeys: String, CodingKey {
         case projects, globalView, github, notifications, remote, sessionTimeout
         case promptTemplate, githubIssuePromptTemplate, columnOrder, hasCompletedOnboarding, defaultAssistant
         case enabledAssistants
+        case apiServices, defaultAPIServiceIds
         case skill // backward-compat: old name for promptTemplate
     }
 
@@ -83,6 +92,8 @@ public struct Settings: Codable, Sendable {
         } else {
             enabledAssistants = CodingAssistant.allCases
         }
+        apiServices = (try? container.decodeIfPresent([APIService].self, forKey: .apiServices)) ?? []
+        defaultAPIServiceIds = (try? container.decodeIfPresent([String: String].self, forKey: .defaultAPIServiceIds)) ?? [:]
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -99,6 +110,8 @@ public struct Settings: Codable, Sendable {
         try container.encode(hasCompletedOnboarding, forKey: .hasCompletedOnboarding)
         try container.encodeIfPresent(defaultAssistant, forKey: .defaultAssistant)
         try container.encode(enabledAssistants, forKey: .enabledAssistants)
+        try container.encode(apiServices, forKey: .apiServices)
+        try container.encode(defaultAPIServiceIds, forKey: .defaultAPIServiceIds)
         // Note: "skill" is NOT encoded — only read for backward-compat
     }
 }

--- a/Sources/KanbanCodeCore/UseCases/LaunchSession.swift
+++ b/Sources/KanbanCodeCore/UseCases/LaunchSession.swift
@@ -19,7 +19,8 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
         commandOverride: String? = nil,
         skipPermissions: Bool = false,
         preamble: String? = nil,
-        assistant: CodingAssistant = .claude
+        assistant: CodingAssistant = .claude,
+        service: APIService? = nil
     ) async throws -> String {
 
         let cmd: String
@@ -30,7 +31,8 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
             // Build the CLI command (prompt is sent via send-keys after assistant is ready)
             var built = assistant.launchCommand(
                 skipPermissions: skipPermissions,
-                worktreeName: worktreeName
+                worktreeName: worktreeName,
+                service: service
             )
 
             // Prepend environment variables (SHELL override + KANBAN_CODE_* vars)
@@ -64,7 +66,8 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
         commandOverride: String? = nil,
         skipPermissions: Bool = false,
         preamble: String? = nil,
-        assistant: CodingAssistant = .claude
+        assistant: CodingAssistant = .claude,
+        service: APIService? = nil
     ) async throws -> String {
         // Kill stale tmux session if one exists — we always want a fresh resume
         let existing = try await tmux.listSessions()
@@ -80,7 +83,8 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
         } else {
             var built = assistant.resumeCommand(
                 sessionId: sessionId,
-                skipPermissions: skipPermissions
+                skipPermissions: skipPermissions,
+                service: service
             )
             let envPrefix = buildEnvPrefix(shellOverride: shellOverride, extraEnv: extraEnv)
             if !envPrefix.isEmpty {

--- a/Tests/KanbanCodeCoreTests/MultiAssistant/APIServiceTests.swift
+++ b/Tests/KanbanCodeCoreTests/MultiAssistant/APIServiceTests.swift
@@ -1,0 +1,146 @@
+import Testing
+import Foundation
+@testable import KanbanCodeCore
+
+@Suite("APIService Entity")
+struct APIServiceTests {
+
+    // MARK: - needsSeparator
+
+    @Test("needsSeparator is false when neither prefix nor model is set")
+    func needsSeparatorFalseWhenBare() {
+        let service = APIService(name: "Bare", assistant: .claude)
+        #expect(service.needsSeparator == false)
+    }
+
+    @Test("needsSeparator is true when launcherPrefix is set")
+    func needsSeparatorTrueWithPrefix() {
+        let service = APIService(name: "Ollama", assistant: .claude, launcherPrefix: "ollama launch")
+        #expect(service.needsSeparator == true)
+    }
+
+    @Test("needsSeparator is true when modelFlag is set")
+    func needsSeparatorTrueWithModel() {
+        let service = APIService(name: "Model", assistant: .claude, modelFlag: "claude-opus-4-5")
+        #expect(service.needsSeparator == true)
+    }
+
+    @Test("needsSeparator is true when both prefix and model are set")
+    func needsSeparatorTrueWithBoth() {
+        let service = APIService(
+            name: "Ollama",
+            assistant: .claude,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3-coder-next:cloud"
+        )
+        #expect(service.needsSeparator == true)
+    }
+
+    // MARK: - Codable
+
+    @Test("APIService Codable round-trip — full fields")
+    func codableRoundTripFull() throws {
+        let service = APIService(
+            id: "svc-001",
+            name: "Ollama Local",
+            assistant: .claude,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3-coder-next:cloud",
+            baseURL: "http://localhost:11434/v1"
+        )
+        let data = try JSONEncoder().encode(service)
+        let decoded = try JSONDecoder().decode(APIService.self, from: data)
+        #expect(decoded.id == "svc-001")
+        #expect(decoded.name == "Ollama Local")
+        #expect(decoded.assistant == .claude)
+        #expect(decoded.launcherPrefix == "ollama launch")
+        #expect(decoded.modelFlag == "qwen3-coder-next:cloud")
+        #expect(decoded.baseURL == "http://localhost:11434/v1")
+    }
+
+    @Test("APIService Codable round-trip — optional fields nil")
+    func codableRoundTripMinimal() throws {
+        let service = APIService(name: "Minimal", assistant: .gemini)
+        let data = try JSONEncoder().encode(service)
+        let decoded = try JSONDecoder().decode(APIService.self, from: data)
+        #expect(decoded.name == "Minimal")
+        #expect(decoded.assistant == .gemini)
+        #expect(decoded.launcherPrefix == nil)
+        #expect(decoded.modelFlag == nil)
+        #expect(decoded.baseURL == nil)
+        #expect(decoded.needsSeparator == false)
+    }
+
+    @Test("APIService Equatable")
+    func equatable() {
+        let a = APIService(id: "x", name: "A", assistant: .claude)
+        let b = APIService(id: "x", name: "A", assistant: .claude)
+        let c = APIService(id: "y", name: "A", assistant: .claude)
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    // MARK: - Edit-in-place logic
+
+    @Test("Editing a service preserves its ID")
+    func editPreservesId() {
+        let original = APIService(id: "svc-42", name: "Old Name", assistant: .claude, modelFlag: "old-model")
+        let edited = APIService(
+            id: original.id,
+            name: "New Name",
+            assistant: original.assistant,
+            launcherPrefix: "ollama launch",
+            modelFlag: "new-model"
+        )
+        #expect(edited.id == original.id)
+        #expect(edited.name == "New Name")
+        #expect(edited.modelFlag == "new-model")
+        #expect(edited.launcherPrefix == "ollama launch")
+    }
+
+    @Test("Update-in-place replaces the matching entry and leaves others intact")
+    func updateInPlaceByIndex() {
+        var services = [
+            APIService(id: "svc-1", name: "First", assistant: .claude),
+            APIService(id: "svc-2", name: "Target", assistant: .claude, modelFlag: "old"),
+            APIService(id: "svc-3", name: "Third", assistant: .claude),
+        ]
+        let updated = APIService(id: "svc-2", name: "Updated", assistant: .claude, modelFlag: "new")
+        if let idx = services.firstIndex(where: { $0.id == updated.id }) {
+            services[idx] = updated
+        }
+        #expect(services.count == 3)
+        #expect(services[0].name == "First")
+        #expect(services[1].name == "Updated")
+        #expect(services[1].modelFlag == "new")
+        #expect(services[2].name == "Third")
+    }
+
+    @Test("Editing a service updates the command it produces")
+    func editedServiceUpdatesCommand() {
+        let original = APIService(id: "svc-1", name: "Ollama", assistant: .claude, modelFlag: "qwen3")
+        let originalCmd = CodingAssistant.claude.launchCommand(skipPermissions: true, worktreeName: nil, service: original)
+        #expect(originalCmd == "claude --model qwen3 -- --dangerously-skip-permissions")
+
+        let edited = APIService(id: "svc-1", name: "Ollama", assistant: .claude, launcherPrefix: "ollama launch", modelFlag: "qwen3-v2")
+        let editedCmd = CodingAssistant.claude.launchCommand(skipPermissions: true, worktreeName: nil, service: edited)
+        #expect(editedCmd == "ollama launch claude --model qwen3-v2 -- --dangerously-skip-permissions")
+    }
+
+    @Test("Deleting the default service clears the default ID mapping")
+    func deleteDefaultClearsMapping() {
+        var services = [
+            APIService(id: "svc-1", name: "Ollama", assistant: .claude),
+        ]
+        var defaultIds: [String: String] = ["claude": "svc-1"]
+        let toDelete = services[0]
+
+        services.removeAll { $0.id == toDelete.id }
+        if defaultIds["claude"] == toDelete.id {
+            defaultIds.removeValue(forKey: "claude")
+        }
+
+        #expect(services.isEmpty)
+        #expect(defaultIds["claude"] == nil)
+    }
+}

--- a/Tests/KanbanCodeCoreTests/MultiAssistant/CodingAssistantTests.swift
+++ b/Tests/KanbanCodeCoreTests/MultiAssistant/CodingAssistantTests.swift
@@ -171,6 +171,153 @@ struct CodingAssistantTests {
         #expect(command == "codex resume --dangerously-bypass-approvals-and-sandbox --no-alt-screen session-123")
     }
 
+    // MARK: - APIService command building
+
+    @Test("launchCommand without service is unchanged")
+    func launchCommandNoService() {
+        let cmd = CodingAssistant.claude.launchCommand(skipPermissions: true, worktreeName: nil, service: nil)
+        #expect(cmd == "claude --dangerously-skip-permissions")
+    }
+
+    @Test("launchCommand with ollama service inserts launcher + model + separator")
+    func launchCommandWithOllamaService() {
+        let service = APIService(
+            name: "Ollama",
+            assistant: .claude,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3-coder-next:cloud"
+        )
+        let cmd = CodingAssistant.claude.launchCommand(skipPermissions: true, worktreeName: nil, service: service)
+        #expect(cmd == "ollama launch claude --model qwen3-coder-next:cloud -- --dangerously-skip-permissions")
+    }
+
+    @Test("launchCommand with model-only service inserts -- separator")
+    func launchCommandWithModelOnly() {
+        let service = APIService(name: "Model override", assistant: .claude, modelFlag: "claude-opus-4-5")
+        let cmd = CodingAssistant.claude.launchCommand(skipPermissions: false, worktreeName: nil, service: service)
+        #expect(cmd == "claude --model claude-opus-4-5 --")
+    }
+
+    @Test("resumeCommand with ollama service for claude")
+    func resumeCommandClaudeWithService() {
+        let service = APIService(
+            name: "Ollama",
+            assistant: .claude,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3-coder-next:cloud"
+        )
+        let cmd = CodingAssistant.claude.resumeCommand(sessionId: "abc-123", skipPermissions: true, service: service)
+        #expect(cmd == "ollama launch claude --model qwen3-coder-next:cloud -- --dangerously-skip-permissions --resume abc-123")
+    }
+
+    @Test("resumeCommand with ollama service for codex puts resume after separator")
+    func resumeCommandCodexWithService() {
+        let service = APIService(
+            name: "Ollama",
+            assistant: .codex,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3-coder-next:cloud"
+        )
+        let cmd = CodingAssistant.codex.resumeCommand(sessionId: "abc-123", skipPermissions: true, service: service)
+        #expect(cmd == "ollama launch codex --model qwen3-coder-next:cloud -- resume --dangerously-bypass-approvals-and-sandbox --no-alt-screen abc-123")
+    }
+
+    @Test("resumeCommand without service is unchanged for codex")
+    func resumeCommandCodexNoService() {
+        let cmd = CodingAssistant.codex.resumeCommand(sessionId: "abc-123", skipPermissions: true, service: nil)
+        #expect(cmd == "codex resume --dangerously-bypass-approvals-and-sandbox --no-alt-screen abc-123")
+    }
+
+    @Test("launchCommand with worktree and ollama service places worktree after separator")
+    func launchCommandWorktreeWithService() {
+        let service = APIService(
+            name: "Ollama",
+            assistant: .claude,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3"
+        )
+        let cmd = CodingAssistant.claude.launchCommand(skipPermissions: true, worktreeName: "feature-x", service: service)
+        #expect(cmd == "ollama launch claude --model qwen3 -- --dangerously-skip-permissions --worktree feature-x")
+    }
+
+    // MARK: - Command preview with pre-selected default service
+
+    /// Regression: NewTaskDialog / LaunchConfirmationDialog previously showed the
+    /// bare command on first open even when a default API service was pre-selected,
+    /// because the command string was set in onAppear before .task loaded apiServices.
+    /// The fix refreshes the command at the end of .task.  These tests assert the
+    /// pure command-resolution logic that the refresh must produce.
+
+    @Test("Command preview reflects pre-selected default service immediately")
+    func commandPreviewWithPreSelectedService() {
+        // Simulate what happens after .task loads: selectedServiceId is resolved,
+        // apiServices is populated, and commandPreview is re-evaluated.
+        let services = [
+            APIService(
+                id: "svc-default",
+                name: "Ollama",
+                assistant: .claude,
+                launcherPrefix: "ollama launch",
+                modelFlag: "qwen3-coder-next:cloud"
+            )
+        ]
+        let selectedServiceId: String? = "svc-default"
+        let service = selectedServiceId.flatMap { id in services.first { $0.id == id } }
+        let cmd = CodingAssistant.claude.launchCommand(
+            skipPermissions: true,
+            worktreeName: nil,
+            service: service
+        )
+        #expect(cmd == "ollama launch claude --model qwen3-coder-next:cloud -- --dangerously-skip-permissions")
+    }
+
+    @Test("Command preview with nil selectedServiceId shows bare command (Default option)")
+    func commandPreviewWithNilService() {
+        let services = [
+            APIService(id: "svc-1", name: "Ollama", assistant: .claude, launcherPrefix: "ollama launch", modelFlag: "qwen3")
+        ]
+        let selectedServiceId: String? = nil
+        let service = selectedServiceId.flatMap { id in services.first { $0.id == id } }
+        let cmd = CodingAssistant.claude.launchCommand(
+            skipPermissions: true,
+            worktreeName: nil,
+            service: service
+        )
+        #expect(cmd == "claude --dangerously-skip-permissions")
+    }
+
+    @Test("Command preview with unknown service ID (stale ID) shows bare command")
+    func commandPreviewWithStaleServiceId() {
+        let services = [
+            APIService(id: "svc-current", name: "Ollama", assistant: .claude, launcherPrefix: "ollama launch", modelFlag: "qwen3")
+        ]
+        let selectedServiceId: String? = "svc-deleted"
+        let service = selectedServiceId.flatMap { id in services.first { $0.id == id } }
+        let cmd = CodingAssistant.claude.launchCommand(
+            skipPermissions: true,
+            worktreeName: nil,
+            service: service
+        )
+        #expect(cmd == "claude --dangerously-skip-permissions")
+    }
+
+    // MARK: - baseURLEnvKey
+
+    @Test("Claude base URL env key is ANTHROPIC_BASE_URL")
+    func claudeBaseURLEnvKey() {
+        #expect(CodingAssistant.claude.baseURLEnvKey == "ANTHROPIC_BASE_URL")
+    }
+
+    @Test("Codex base URL env key is OPENAI_BASE_URL")
+    func codexBaseURLEnvKey() {
+        #expect(CodingAssistant.codex.baseURLEnvKey == "OPENAI_BASE_URL")
+    }
+
+    @Test("Gemini has no base URL env key")
+    func geminiBaseURLEnvKey() {
+        #expect(CodingAssistant.gemini.baseURLEnvKey == nil)
+    }
+
     // MARK: - Codable
 
     @Test("CodingAssistant Codable round-trip")

--- a/Tests/KanbanCodeCoreTests/MultiAssistant/LinkAssistantCodableTests.swift
+++ b/Tests/KanbanCodeCoreTests/MultiAssistant/LinkAssistantCodableTests.swift
@@ -121,6 +121,61 @@ struct LinkAssistantCodableTests {
         #expect(session.assistant == .codex)
     }
 
+    // MARK: - apiServiceId
+
+    @Test("Link with apiServiceId round-trips through JSON")
+    func linkApiServiceIdRoundTrip() throws {
+        var link = Link(id: "card_svc1", assistant: .claude)
+        link.apiServiceId = "svc-abc123"
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(link)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(Link.self, from: data)
+        #expect(decoded.apiServiceId == "svc-abc123")
+    }
+
+    @Test("Link without apiServiceId decodes as nil")
+    func backwardCompatNoApiServiceId() throws {
+        let json = """
+        {
+            "id": "card_old2",
+            "column": "backlog",
+            "manualOverrides": {},
+            "manuallyArchived": false,
+            "source": "manual",
+            "isRemote": false
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(Link.self, from: json.data(using: .utf8)!)
+        #expect(decoded.apiServiceId == nil)
+    }
+
+    @Test("Link with apiServiceId encodes the field")
+    func apiServiceIdEncodesField() throws {
+        var link = Link(id: "card_svc2")
+        link.apiServiceId = "svc-xyz"
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(link)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(json.contains("\"apiServiceId\""))
+        #expect(json.contains("\"svc-xyz\""))
+    }
+
+    @Test("Link with nil apiServiceId omits the field")
+    func nilApiServiceIdOmitsField() throws {
+        let link = Link(id: "card_svc3")
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(link)
+        let json = String(data: data, encoding: .utf8)!
+        #expect(!json.contains("\"apiServiceId\""))
+    }
+
     // MARK: - effectiveAssistant
 
     @Test("effectiveAssistant returns .claude when assistant is nil")

--- a/Tests/KanbanCodeCoreTests/SettingsStoreTests.swift
+++ b/Tests/KanbanCodeCoreTests/SettingsStoreTests.swift
@@ -174,6 +174,72 @@ struct SettingsStoreTests {
         #expect(settings.projects[0].githubFilter == "assignee:@me repo:org/repo is:open")
     }
 
+    // MARK: - APIService persistence
+
+    @Test("apiServices defaults to empty array")
+    func apiServicesDefaultEmpty() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let settings = try await SettingsStore(basePath: dir).read()
+        #expect(settings.apiServices.isEmpty)
+    }
+
+    @Test("defaultAPIServiceIds defaults to empty dict")
+    func defaultAPIServiceIdsDefaultEmpty() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let settings = try await SettingsStore(basePath: dir).read()
+        #expect(settings.defaultAPIServiceIds.isEmpty)
+    }
+
+    @Test("apiServices round-trips through SettingsStore")
+    func apiServicesRoundTrip() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let store = SettingsStore(basePath: dir)
+
+        var settings = Settings()
+        let service = APIService(
+            id: "svc-1",
+            name: "Ollama Local",
+            assistant: .claude,
+            launcherPrefix: "ollama launch",
+            modelFlag: "qwen3-coder-next:cloud",
+            baseURL: "http://localhost:11434/v1"
+        )
+        settings.apiServices = [service]
+        settings.defaultAPIServiceIds = ["claude": "svc-1"]
+        try await store.write(settings)
+
+        let read = try await store.read()
+        #expect(read.apiServices.count == 1)
+        #expect(read.apiServices[0].id == "svc-1")
+        #expect(read.apiServices[0].name == "Ollama Local")
+        #expect(read.apiServices[0].launcherPrefix == "ollama launch")
+        #expect(read.apiServices[0].modelFlag == "qwen3-coder-next:cloud")
+        #expect(read.apiServices[0].baseURL == "http://localhost:11434/v1")
+        #expect(read.defaultAPIServiceIds["claude"] == "svc-1")
+    }
+
+    @Test("Old settings JSON without apiServices decodes with empty defaults")
+    func backwardCompatNoApiServices() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let json = """
+        {
+          "projects": [{ "path": "/x", "name": "x", "visible": true }]
+        }
+        """
+        let path = (dir as NSString).appendingPathComponent("settings.json")
+        try json.write(toFile: path, atomically: true, encoding: .utf8)
+
+        let settings = try await SettingsStore(basePath: dir).read()
+        #expect(settings.projects.count == 1)
+        #expect(settings.apiServices.isEmpty)
+        #expect(settings.defaultAPIServiceIds.isEmpty)
+    }
+
     // MARK: - Forward-compat: unknown values in JSON must not wipe the whole config
 
     @Test("Unknown values in enabledAssistants don't break decoding — regression for 'projects gone on restart'")


### PR DESCRIPTION
## Summary

- **New `APIService` entity** — captures a launcher prefix (e.g. `ollama launch`), optional `--model` flag, and optional base URL, enabling commands like:
  ```
  ollama launch claude --model qwen3-coder-next:cloud -- --dangerously-skip-permissions --resume <id>
  ```
- **`CodingAssistant` command builders** (`launchCommand` / `resumeCommand`) accept an optional `APIService`; a `--` separator is inserted automatically when `needsSeparator` is true; Codex `resume` subcommand is placed correctly after the separator
- **`CodingAssistant.baseURLEnvKey`** — injects `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` into the tmux session environment when a base URL is configured on the service
- **`Link.apiServiceId`** — per-card service override (`nil` = use global default); backward-compatible decode
- **`Settings.apiServices` + `Settings.defaultAPIServiceIds`** — user-managed list and per-assistant defaults, persisted with empty-default backward compat
- **`SessionLauncher` + `LaunchSession`** updated to accept and forward the resolved `APIService`
- **Service resolution chain**: dialog-selected ID → card-stored ID → global default → nil (bare command)

## UI changes

- **Settings › Assistants**: API Service subsection per assistant — add / edit (pencil) / trash / default-toggle (checkmark circle) in that order; edit sheet pre-populates all fields (using `sheet(item:)` to avoid SwiftUI state race); live command preview in sheet
- **New Task / Launch / Resume dialogs**: "API Service" picker below "Project" picker, pre-selects global default on open, command preview updates immediately on open (fixes race where `onAppear` ran before `.task` loaded services), reloads on `kanbanCodeSettingsChanged` so edits in Settings are reflected in open dialogs
- **Setup wizard**: API Service disclosure group pre-populates from existing default service; content area is scrollable so expanded groups don't push navigation buttons off screen

## Bug fixes

- `UNUserNotificationCenter.current()` crash under `swift run` (no bundle ID) — guarded in both `App.swift` and `MacOSNotificationClient.sendNotification`
- Settings screen phantom scrollbar — increased frame height
- Add Service sheet too small to show command preview — larger frame

## Test plan

- [ ] 21 new unit tests passing: `APIServiceTests` (entity codability, `needsSeparator`, edit-in-place logic), `CodingAssistantTests` (command building with/without service, pre-selection regression), `LinkAssistantCodableTests` (`apiServiceId` round-trip + backward compat), `SettingsStoreTests` (`apiServices`/`defaultAPIServiceIds` round-trip + backward compat)
- [ ] Settings › Assistants → add Ollama service (launcher: `ollama launch`, model: `qwen3-coder-next:cloud`) → set as default → command preview shows full ollama prefix
- [ ] New Task dialog opens with Ollama pre-selected and command preview correct on first open
- [ ] Edit service via pencil → fields pre-populated → save updates in place
- [ ] Launch / Resume dialogs show service picker and reflect service in command
- [ ] Editing a service in Settings while a task dialog is open refreshes the dialog's command preview
- [ ] Card with no service and no global default → bare command unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)