### PR TITLE
fix(ui): prevent LazyVStack layout hang with 700+ cards

### DIFF
--- a/Sources/KanbanCode/ChannelShareController.swift
+++ b/Sources/KanbanCode/ChannelShareController.swift
@@ -230,12 +230,11 @@ final class ChannelShareController {
     }
 
     private static func drainStderr(_ handle: FileHandle, tag: String) {
-        Task.detached {
+        DispatchQueue.global(qos: .utility).async {
             while true {
                 let data = handle.availableData
                 if data.isEmpty { return }
                 if let s = String(data: data, encoding: .utf8) {
-                    // Keep share-related diagnostics quiet unless debugging.
                     FileHandle.standardError.write(Data("\(tag) \(s)".utf8))
                 }
             }
@@ -243,7 +242,7 @@ final class ChannelShareController {
     }
 
     private static func drainStdout(_ handle: FileHandle, tag: String) {
-        Task.detached {
+        DispatchQueue.global(qos: .utility).async {
             while true {
                 let data = handle.availableData
                 if data.isEmpty { return }

--- a/Sources/KanbanCode/ListBoardView.swift
+++ b/Sources/KanbanCode/ListBoardView.swift
@@ -61,7 +61,7 @@ struct ListBoardView: View {
 
     private func scrollView(proxy: ScrollViewProxy) -> some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
+            LazyVStack(alignment: .leading, spacing: 0) {
                 channelsSection
                 ForEach(sections, id: \.column) { section in
                     sectionView(for: section)
@@ -350,7 +350,7 @@ private struct ListBoardSectionView: View {
                 onReorderCard: onReorderCard
             ))
         } else {
-            LazyVStack(spacing: 4) {
+            VStack(spacing: 4) {
                 ForEach(section.cards) { card in
                     if dragState.reorderTargetId == card.id && dragState.reorderAbove {
                         ReorderIndicator()


### PR DESCRIPTION
## Summary

- **Fix 100% CPU hang** caused by `LazyVStack(pinnedViews: [.sectionHeaders])` in the sidebar `ListBoardView`. The outer container needed to measure each section to position pinned headers, which forced materializing all ~700 card views on every reconciliation cycle (3s), permanently blocking the main thread.
- **Remove inner `LazyVStack`** in section bodies, replacing with `VStack` so the outer lazy container can size sections via direct children.
- **Move `ChannelShareController` drain loops** from `Task.detached` to `DispatchQueue.global` to avoid blocking the cooperative thread pool with synchronous `FileHandle.availableData` reads.

### Evidence

Thread samples (`~/.kanban-code/logs/main-thread-samples/`) showed 100% of samples in `LazySubviewPlacements.placeSubviews` → `ForEachList.applyNodes` with deeply nested per-item modifier chains. Watchdog log confirmed continuous `HANG: main thread blocked for >500ms` every 10 seconds for 2+ hours.

## Test plan

- [x] `swift test` — all 755 tests pass
- [ ] Launch app with 700+ cards, verify sidebar list scrolls smoothly
- [ ] Create a new card and launch it — confirm no hang
- [ ] Verify section headers still render correctly (they scroll with content now instead of pinning)