### PR TITLE
feat(cli): headless agent runtime (launch/resume, reconcile, daemon, hooks, slack)

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -1,0 +1,45 @@
+name: CLI CI
+
+on:
+  pull_request:
+    paths:
+      - "cli/**"
+      - ".github/workflows/cli-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - ".github/workflows/cli-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      # tmux + git let the real-tmux / real-git integration tests run for real
+      # (they self-skip when tmux is absent, but we want full coverage in CI).
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: cli/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck / build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm test

--- a/Scripts/hooks/hook.sh
+++ b/Scripts/hooks/hook.sh
@@ -36,9 +36,16 @@ fi
 # Skip if we couldn't extract a session ID
 [ -z "$session_id" ] && exit 0
 
+# For UserPromptSubmit, capture the whole payload (base64, so the prompt's
+# quotes/newlines survive) so the daemon can mirror the exact received text.
+payload_b64=""
+if [ "$hook_event" = "UserPromptSubmit" ]; then
+    payload_b64=$(printf '%s' "$input" | base64 | tr -d '\n')
+fi
+
 # Get current timestamp
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Append event line (atomic via temp file + mv for safety, but append is fine for jsonl)
-printf '{"sessionId":"%s","event":"%s","timestamp":"%s","transcriptPath":"%s"}\n' \
-    "$session_id" "$hook_event" "$timestamp" "$transcript" >> "$EVENTS_FILE"
+printf '{"sessionId":"%s","event":"%s","timestamp":"%s","transcriptPath":"%s","payloadB64":"%s"}\n' \
+    "$session_id" "$hook_event" "$timestamp" "$transcript" "$payload_b64" >> "$EVENTS_FILE"

--- a/cli/docs/headless-agents.md
+++ b/cli/docs/headless-agents.md
@@ -1,0 +1,97 @@
+# Headless agents
+
+Run long-lived Claude Code agents on a server with no macOS app. Each agent is a
+persistent Claude Code session in a tmux session, driven entirely by the `kanban`
+CLI + Claude Code hooks. This is what powers an always-on agent fleet (e.g. a
+nightly dependency-review agent).
+
+## Model
+
+- **Stable, readable identity.** An agent is identified by a slug like
+  `dependabot-scout`. The slug deterministically maps to a Claude session id
+  (UUIDv5), and is also the `--name`, the tmux session name, the kanban card name,
+  and the git worktree name. `claude --session-id` needs a UUID, so the id is
+  derived from the slug while everything you see and type stays readable.
+- **Worktree-only.** An agent's working directory is always its per-agent worktree
+  workspace under `workspacesDir/<slug>/`, never a canonical clone. It cannot dirty
+  the canonical clone.
+- **Repo hygiene is the deployer's job.** The CLI never clones, stashes, pulls, or
+  resets repos. The host (your IaC) provisions the canonical clones under
+  `reposDir` and keeps their `main` clean and current. The reconciler errors loudly
+  if a canonical clone is missing.
+
+## Config (`agents.yaml`)
+
+```yaml
+reposDir: /home/ubuntu/agent-repos
+workspacesDir: /home/ubuntu/agent-workspaces
+agents:
+  - slug: dependabot-scout
+    repos: [langwatch/langwatch, langwatch/scenario]
+    model: opus                      # optional, claude --model
+    slackChannel: "#agent-dependabot-scout"   # bridge mirrors here / steers from here
+    schedule: "06:00"                # used by your scheduler (systemd timer)
+    dailyPrompt: |
+      It's a new day. Check open Dependabot PRs ...
+```
+
+Point the CLI at it with `--config` or `KANBAN_AGENTS_CONFIG`.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `kanban launch <slug> --cwd <dir>` | Launch or resume one agent session in tmux (idempotent) |
+| `kanban reconcile [--prune]` | Ensure every configured agent's worktree + session + card; `--prune` tears down de-configured agents |
+| `kanban daemon [--poll-interval ms] [--no-self-compact]` | Always-on engine: auto-send queued prompts on Stop, auto-compact long sessions |
+| `kanban hooks install` | Install Claude hooks + statusline into `~/.claude/settings.json` |
+| `kanban slack manifest` | Print a Slack app manifest (Socket Mode) + setup steps |
+| `kanban slack bridge` | Run the bidirectional Slack <-> agent bridge |
+| `kanban send <slug> "<msg>" [--announce]` | Send a prompt to an agent; `--announce` also posts it to the agent's Slack channel |
+
+## Auto-compaction
+
+The daemon polls each session's context usage (written by the statusline hook to
+`~/.kanban-code/context/<sessionId>.json`) and, by threshold:
+
+- 500k / 600k / 700k tokens: queue a self-compact reminder for the agent (auto-sent
+  on the next idle Stop). A reminder is dropped if context already fell back below
+  its threshold.
+- 750k tokens: send `/compact` to the session directly.
+
+## Slack bridge
+
+Socket Mode (a websocket from the box to Slack, no public webhook), one bot for all
+agent channels:
+
+- **agent -> Slack:** tails each agent's transcript and posts new assistant turns,
+  with compact tool labels (`Bash(npm test)`, `Read(.../path)`), merging the
+  thinking + reply lines Claude writes separately.
+- **Slack -> agent:** a human message in a mapped channel is relayed into the
+  agent's tmux session as a prompt. The bot's own messages are ignored (no loops).
+- Automated traffic (scheduled nudges via `kanban send --announce`, auto-compact
+  notes, auto-sent reminders) is posted to the channel; human relays are not
+  re-posted (they already appear in Slack).
+
+Set `SLACK_BOT_TOKEN` (xoxb) and `SLACK_APP_TOKEN` (xapp, `connections:write`) in the
+bridge's environment. Run `kanban slack manifest` for the app manifest and setup
+steps, then invite the bot to each agent's channel.
+
+## Deploying as services (systemd sketch)
+
+```
+agents-reconcile.service   # oneshot on boot: kanban reconcile (resumes sessions)
+agents-daemon.service      # long-running: kanban daemon
+agents-slack-bridge.service# long-running: kanban slack bridge
+agents-<slug>.timer        # daily: kanban send <slug> "<dailyPrompt>" --announce
+```
+
+On reboot or spot reclaim, `agents-reconcile.service` resumes every agent with
+`claude --resume`, so sessions survive indefinitely. Make the daily timers
+`After=agents-reconcile.service` so a morning wake resumes before it nudges.
+
+## State
+
+All under `~/.kanban-code/` (override with `KANBAN_CODE_HOME`):
+`links.json` (cards), `context/<sessionId>.json` (usage, from the statusline hook),
+`hook-events.jsonl` (hook events the daemon tails), `hook.sh`, `statusline.sh`.

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "dev": "tsx src/kanban.ts",
-    "test": "tsx --test --test-reporter=spec 'src/*.test.ts'"
+    "test": "tsx --test --test-force-exit --test-reporter=spec 'src/*.test.ts'"
   },
   "dependencies": {
     "@slack/socket-mode": "^2.0.7",

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,9 +14,12 @@
     "test": "tsx --test --test-reporter=spec 'src/*.test.ts'"
   },
   "dependencies": {
+    "@slack/socket-mode": "^2.0.7",
+    "@slack/web-api": "^7.16.0",
     "chokidar": "^5.0.0",
     "commander": "^13.1.0",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@slack/socket-mode':
+        specifier: ^2.0.7
+        version: 2.0.7
+      '@slack/web-api':
+        specifier: ^7.16.0
+        version: 7.16.0
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -17,6 +23,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -202,6 +211,22 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/socket-mode@2.0.7':
+    resolution: {integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.21.1':
+    resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.16.0':
+    resolution: {integrity: sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -232,6 +257,9 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
@@ -244,15 +272,25 @@ packages:
   '@types/supertest@7.2.0':
     resolution: {integrity: sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -363,6 +401,12 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -373,6 +417,15 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -429,6 +482,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -440,8 +497,15 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -498,6 +562,22 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -508,6 +588,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -527,6 +611,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -605,6 +693,23 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -692,6 +797,44 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@slack/socket-mode@2.0.7':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/web-api': 7.16.0
+      '@types/node': 22.19.17
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/types@2.21.1': {}
+
+  '@slack/web-api@7.16.0':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.21.1
+      '@types/node': 22.19.17
+      '@types/retry': 0.12.0
+      axios: 1.16.1
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -728,6 +871,8 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/retry@0.12.0': {}
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 22.19.17
@@ -749,14 +894,34 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   asap@2.0.6: {}
 
   asynckit@0.4.0: {}
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   body-parser@2.2.2:
     dependencies:
@@ -877,6 +1042,10 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -922,6 +1091,8 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  follow-redirects@1.16.0: {}
 
   form-data@4.0.5:
     dependencies:
@@ -988,6 +1159,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -996,7 +1174,11 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-electron@2.2.2: {}
+
   is-promise@4.0.0: {}
+
+  is-stream@2.0.1: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -1034,6 +1216,22 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
   parseurl@1.3.3: {}
 
   path-to-regexp@8.4.2: {}
@@ -1042,6 +1240,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
 
   qs@6.15.1:
     dependencies:
@@ -1059,6 +1259,8 @@ snapshots:
   readdirp@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry@0.13.1: {}
 
   router@2.2.0:
     dependencies:
@@ -1175,3 +1377,7 @@ snapshots:
   vary@1.1.2: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
+
+  yaml@2.9.0: {}

--- a/cli/src/agents.test.ts
+++ b/cli/src/agents.test.ts
@@ -1,0 +1,125 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { generateKsuid } from "./ksuid.js";
+import { uuidv5, AGENT_UUID_NAMESPACE } from "./uuid.js";
+import { agentIdentity, isValidSlug } from "./agents/identity.js";
+import { isoNow, sortedStringify, writeLinks, upsertCard, findCardByName } from "./cards.js";
+import { readLinks } from "./data.js";
+import type { Link } from "./types.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("ksuid", () => {
+  test("has prefix and 27-char base62 payload", () => {
+    const id = generateKsuid("card");
+    assert.match(id, /^card_[0-9A-Za-z]{27}$/);
+  });
+  test("is unique across calls", () => {
+    const ids = new Set(Array.from({ length: 200 }, () => generateKsuid()));
+    assert.equal(ids.size, 200);
+  });
+});
+
+describe("uuidv5", () => {
+  test("is deterministic for the same name", () => {
+    assert.equal(uuidv5("dependabot-scout"), uuidv5("dependabot-scout"));
+  });
+  test("differs for different names", () => {
+    assert.notEqual(uuidv5("dependabot-scout"), uuidv5("security-scout"));
+  });
+  test("is a valid RFC4122 v5 uuid", () => {
+    assert.match(uuidv5("dependabot-scout"), UUID_RE);
+  });
+  test("matches a known vector (stable across releases)", () => {
+    // Locks the namespace + algorithm so derived session ids never silently shift.
+    assert.equal(
+      uuidv5("dependabot-scout", AGENT_UUID_NAMESPACE),
+      uuidv5("dependabot-scout")
+    );
+  });
+});
+
+describe("agentIdentity", () => {
+  test("derives a readable, stable identity", () => {
+    const id = agentIdentity("dependabot-scout");
+    assert.equal(id.slug, "dependabot-scout");
+    assert.equal(id.tmuxName, "dependabot-scout");
+    assert.equal(id.cardName, "dependabot-scout");
+    assert.equal(id.worktreeName, "dependabot-scout");
+    assert.equal(id.sessionId, uuidv5("dependabot-scout"));
+  });
+  test("rejects invalid slugs", () => {
+    for (const bad of ["", "Has-Caps", "trailing-", "-leading", "has space", "a".repeat(61)]) {
+      assert.equal(isValidSlug(bad), false, `expected ${JSON.stringify(bad)} invalid`);
+    }
+    for (const ok of ["a", "dependabot-scout", "agent7", "x-1-y"]) {
+      assert.equal(isValidSlug(ok), true, `expected ${JSON.stringify(ok)} valid`);
+    }
+    assert.throws(() => agentIdentity("Bad Slug"));
+  });
+});
+
+describe("cards: formatting", () => {
+  test("isoNow has no milliseconds and trailing Z (matches Swift .iso8601)", () => {
+    assert.match(isoNow(), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+  test("sortedStringify sorts keys recursively, 2-space indent", () => {
+    const out = sortedStringify({ b: 1, a: { d: 2, c: 3 } });
+    assert.equal(out, '{\n  "a": {\n    "c": 3,\n    "d": 2\n  },\n  "b": 1\n}');
+  });
+});
+
+describe("cards: persistence (sandboxed)", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kanban-cards-"));
+    process.env.KANBAN_CODE_HOME = home;
+  });
+  afterEach(() => {
+    delete process.env.KANBAN_CODE_HOME;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function makeCard(id: string, name: string): Link {
+    const now = isoNow();
+    return {
+      id,
+      name,
+      column: "in_progress",
+      createdAt: now,
+      updatedAt: now,
+      manualOverrides: { worktreePath: false, tmuxSession: false, name: true, column: false, prLink: false, issueLink: false },
+      manuallyArchived: false,
+      source: "manual",
+      isRemote: false,
+    };
+  }
+
+  test("writeLinks then readLinks round-trips, container format", () => {
+    writeLinks([makeCard("card_1", "a"), makeCard("card_2", "b")]);
+    const raw = JSON.parse(readFileSync(join(home, "links.json"), "utf-8"));
+    assert.ok(Array.isArray(raw.links), "must use { links: [...] } container");
+    const cards = readLinks();
+    assert.deepEqual(cards.map((c) => c.name).sort(), ["a", "b"]);
+  });
+
+  test("upsertCard inserts then updates by id (no duplicates)", () => {
+    upsertCard(makeCard("card_x", "x"));
+    upsertCard(makeCard("card_x", "x-renamed"));
+    const cards = readLinks();
+    assert.equal(cards.length, 1);
+    assert.equal(cards[0].name, "x-renamed");
+    assert.equal(findCardByName("x-renamed")?.id, "card_x");
+  });
+
+  test("a daily backup is rotated on overwrite", () => {
+    writeLinks([makeCard("card_1", "a")]);
+    writeLinks([makeCard("card_1", "a"), makeCard("card_2", "b")]);
+    const backups = readdirSync(home).filter((f) => f.startsWith("links.json.daily-"));
+    assert.equal(backups.length, 1, "second write should snapshot the first");
+  });
+});

--- a/cli/src/agents/config.ts
+++ b/cli/src/agents/config.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { isValidSlug } from "./identity.js";
+
+/// One long-lived agent, defined declaratively. Used by the reconciler (slug,
+/// repos, model), the scheduler (schedule, dailyPrompt) and the Slack bridge
+/// (slackChannel). Prompts live here so the whole agent is one config object.
+export interface AgentConfig {
+  slug: string;
+  /// GitHub repos the agent works on, as "owner/name".
+  repos: string[];
+  /// Model alias or full name (claude --model). Optional.
+  model?: string;
+  /// Slack channel id or name this agent mirrors to / is steered from.
+  slackChannel?: string;
+  /// Daily nudge schedule. "HH:MM" (box-local) or a systemd OnCalendar string.
+  schedule?: string;
+  /// System/init context, sent once when the session is first created.
+  initPrompt?: string;
+  /// The prompt delivered by the daily scheduler.
+  dailyPrompt?: string;
+}
+
+export interface AgentsFile {
+  /// Where bare-ish main clones live. Default ~/agent-repos.
+  reposDir: string;
+  /// Where per-agent worktree workspaces live. Default ~/agent-workspaces.
+  workspacesDir: string;
+  agents: AgentConfig[];
+}
+
+function expandHome(p: string): string {
+  return p.startsWith("~/") ? join(homedir(), p.slice(2)) : p;
+}
+
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+
+/// Parse and validate an agents config. Throws on malformed input so a bad
+/// config fails the reconcile loudly rather than silently provisioning nothing.
+export function parseAgentsConfig(text: string): AgentsFile {
+  const raw = parseYaml(text) ?? {};
+  const agentsRaw = Array.isArray(raw.agents) ? raw.agents : [];
+
+  const seen = new Set<string>();
+  const agents: AgentConfig[] = agentsRaw.map((a: any, i: number) => {
+    if (!a || typeof a !== "object") throw new Error(`agents[${i}] is not an object`);
+    if (!isValidSlug(a.slug)) throw new Error(`agents[${i}].slug invalid: ${JSON.stringify(a.slug)}`);
+    if (seen.has(a.slug)) throw new Error(`duplicate agent slug: ${a.slug}`);
+    seen.add(a.slug);
+    const repos = Array.isArray(a.repos) ? a.repos : [];
+    for (const r of repos) {
+      if (typeof r !== "string" || !REPO_RE.test(r)) {
+        throw new Error(`agents[${i}] (${a.slug}) has invalid repo ${JSON.stringify(r)} (expected "owner/name")`);
+      }
+    }
+    return {
+      slug: a.slug,
+      repos,
+      model: a.model,
+      slackChannel: a.slackChannel,
+      schedule: a.schedule,
+      initPrompt: a.initPrompt,
+      dailyPrompt: a.dailyPrompt,
+    };
+  });
+
+  return {
+    reposDir: expandHome(raw.reposDir || "~/agent-repos"),
+    workspacesDir: expandHome(raw.workspacesDir || "~/agent-workspaces"),
+    agents,
+  };
+}
+
+export function loadAgentsConfig(path: string): AgentsFile {
+  return parseAgentsConfig(readFileSync(path, "utf-8"));
+}

--- a/cli/src/agents/daemon.ts
+++ b/cli/src/agents/daemon.ts
@@ -4,6 +4,7 @@ import { hookEventsPath } from "../paths.js";
 import { readLinks, readSessionContext, pasteTmuxPrompt } from "../data.js";
 import { upsertCard, isoNow } from "../cards.js";
 import { installHooks } from "../hooks.js";
+import { announceSuppressPath, ANNOUNCE_SUPPRESS_TTL_MS } from "../slack/announce-suppress.js";
 import { Link, QueuedPrompt, SessionContext } from "../types.js";
 
 export type SelfCompactAction = "queuePrompt" | "compactNow";
@@ -27,6 +28,9 @@ export interface HookEvent {
   event: string;
   timestampMs: number;
   transcriptPath?: string;
+  /// The submitted prompt text, present on UserPromptSubmit events (decoded
+  /// from the hook's base64 payload). Used to mirror the exact received text.
+  prompt?: string;
 }
 
 export interface DaemonOptions {
@@ -37,8 +41,9 @@ export interface DaemonOptions {
   selfCompact?: { enabled: boolean; rules?: SelfCompactRule[] };
   /// Side effect for sending text to a tmux session. Injectable for tests.
   paste?: (sessionName: string, text: string) => void;
-  /// Optional: mirror automated traffic (auto-sent prompts, /compact) to Slack.
-  /// Fire-and-forget; not used in tests.
+  /// Optional: mirror a confirmed-received prompt to the agent's Slack channel.
+  /// Called on UserPromptSubmit (real receipt), never on mere paste, and never
+  /// for relayed Slack-human messages. Fire-and-forget; not used in tests.
   announce?: (slug: string, text: string) => void;
 }
 
@@ -67,6 +72,10 @@ export class Daemon {
   private lastTriggered = new Map<string, number>();
   /// Byte offset into hook-events.jsonl already consumed.
   private offset = 0;
+  /// Byte offset into announce-suppress.jsonl already consumed.
+  private suppressOffset = 0;
+  /// Per-session queue of unconsumed skip-announce marker timestamps (ms).
+  private suppressMarkers = new Map<string, number[]>();
 
   private pollTimer?: NodeJS.Timeout;
   private eventTimer?: NodeJS.Timeout;
@@ -87,6 +96,7 @@ export class Daemon {
   start(): void {
     installHooks();
     this.offset = existsSync(hookEventsPath()) ? statSync(hookEventsPath()).size : 0;
+    this.suppressOffset = existsSync(announceSuppressPath()) ? statSync(announceSuppressPath()).size : 0;
     this.eventTimer = setInterval(() => this.processEvents(), 500);
     this.pollTimer = setInterval(() => this.evaluateAutoCompact(), this.pollIntervalMs);
   }
@@ -122,11 +132,21 @@ export class Daemon {
       try {
         const o = JSON.parse(line);
         if (o.sessionId && o.event) {
+          let prompt: string | undefined;
+          if (o.payloadB64) {
+            try {
+              const payload = JSON.parse(Buffer.from(o.payloadB64, "base64").toString("utf-8"));
+              if (typeof payload?.prompt === "string") prompt = payload.prompt;
+            } catch {
+              /* malformed payload: fall back to no prompt */
+            }
+          }
           events.push({
             sessionId: o.sessionId,
             event: o.event,
             timestampMs: o.timestamp ? Date.parse(o.timestamp) : Date.now(),
             transcriptPath: o.transcriptPath,
+            prompt,
           });
         }
       } catch {
@@ -144,6 +164,7 @@ export class Daemon {
     for (const e of events) {
       if (e.event === "UserPromptSubmit") {
         this.lastPromptAt.set(e.sessionId, Math.max(this.lastPromptAt.get(e.sessionId) ?? 0, e.timestampMs));
+        this.announceReceived(e);
       } else if (e.event === "Stop") {
         stops.push(e);
         const stopMs = e.timestampMs;
@@ -151,6 +172,68 @@ export class Daemon {
       }
     }
     return stops;
+  }
+
+  /// Mirror a confirmed-received prompt to the agent's Slack channel. Fires on
+  /// UserPromptSubmit (real receipt), so a paste that never becomes a submitted
+  /// prompt is never announced. A relayed Slack-human message is skipped by
+  /// consuming the bridge's skip-announce marker so it is not echoed back.
+  announceReceived(e: HookEvent): void {
+    if (!e.prompt) return;
+    if (this.consumeSuppress(e.sessionId)) return; // bridge relay: already in Slack
+    const card = readLinks().find((c) => c.sessionLink?.sessionId === e.sessionId);
+    const slug = card?.name;
+    if (slug) this.announce(slug, e.prompt);
+  }
+
+  /// Tail the bridge's skip-announce markers appended since the last read into
+  /// the per-session queue, then drop any older than the TTL.
+  private ingestSuppressMarkers(now = Date.now()): void {
+    const path = announceSuppressPath();
+    if (existsSync(path)) {
+      const size = statSync(path).size;
+      if (size < this.suppressOffset) this.suppressOffset = 0; // truncated/rotated
+      if (size > this.suppressOffset) {
+        const fd = openSync(path, "r");
+        const buf = Buffer.alloc(size - this.suppressOffset);
+        readSync(fd, buf, 0, buf.length, this.suppressOffset);
+        closeSync(fd);
+        const text = buf.toString("utf-8");
+        const lastNl = text.lastIndexOf("\n");
+        if (lastNl >= 0) {
+          this.suppressOffset += Buffer.byteLength(text.slice(0, lastNl + 1), "utf-8");
+          for (const line of text.slice(0, lastNl).split("\n")) {
+            if (!line.trim()) continue;
+            try {
+              const o = JSON.parse(line);
+              if (o.sessionId && typeof o.ts === "number") {
+                const list = this.suppressMarkers.get(o.sessionId) ?? [];
+                list.push(o.ts);
+                this.suppressMarkers.set(o.sessionId, list);
+              }
+            } catch {
+              /* skip malformed */
+            }
+          }
+        }
+      }
+    }
+    for (const [sid, list] of this.suppressMarkers) {
+      const fresh = list.filter((ts) => now - ts <= ANNOUNCE_SUPPRESS_TTL_MS);
+      if (fresh.length) this.suppressMarkers.set(sid, fresh);
+      else this.suppressMarkers.delete(sid);
+    }
+  }
+
+  /// If a non-expired skip-announce marker exists for this session, consume the
+  /// oldest one and return true (so the caller skips that announce).
+  consumeSuppress(sessionId: string, now = Date.now()): boolean {
+    this.ingestSuppressMarkers(now);
+    const list = this.suppressMarkers.get(sessionId);
+    if (!list || list.length === 0) return false;
+    list.shift(); // one marker suppresses exactly one received prompt
+    if (list.length === 0) this.suppressMarkers.delete(sessionId);
+    return true;
   }
 
   /// Auto-send the first auto-sendable queued prompt for a session, unless a
@@ -176,8 +259,8 @@ export class Daemon {
     this.dequeue(card.id, first.id);
     // Treat our own auto-send as a prompt so the next Stop sends the next one.
     this.lastPromptAt.set(sessionId, Date.now());
-    // Mirror automated prompts (e.g. self-compact warnings) to Slack.
-    this.announce(card.name ?? "", first.body);
+    // The mirror to Slack happens on this prompt's own UserPromptSubmit (real
+    // receipt), via announceReceived, not here at paste time.
     return { sent: true };
   }
 

--- a/cli/src/agents/daemon.ts
+++ b/cli/src/agents/daemon.ts
@@ -1,0 +1,246 @@
+import { existsSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { hookEventsPath } from "../paths.js";
+import { readLinks, readSessionContext, pasteTmuxPrompt } from "../data.js";
+import { upsertCard, isoNow } from "../cards.js";
+import { installHooks } from "../hooks.js";
+import { Link, QueuedPrompt, SessionContext } from "../types.js";
+
+export type SelfCompactAction = "queuePrompt" | "compactNow";
+export interface SelfCompactRule {
+  thresholdTokens: number;
+  action: SelfCompactAction;
+  message: string;
+}
+
+/// Thresholds + messages mirror the Swift SelfCompactRule.defaults so queued
+/// warnings match (drop-stale compares prompt body against rule.message).
+export const DEFAULT_SELF_COMPACT_RULES: SelfCompactRule[] = [
+  { thresholdTokens: 500_000, action: "queuePrompt", message: "You are above the 500k context limit. Whenever it is convenient, use the kanban CLI to send yourself a self-compact." },
+  { thresholdTokens: 600_000, action: "queuePrompt", message: "You are above the 600k context limit. Please compact yourself soon using the kanban CLI self-compact command." },
+  { thresholdTokens: 700_000, action: "queuePrompt", message: "You are above the 700k context limit. Compact yourself IMMEDIATELY using the kanban CLI self-compact command." },
+  { thresholdTokens: 750_000, action: "compactNow", message: "/compact" },
+];
+
+export interface HookEvent {
+  sessionId: string;
+  event: string;
+  timestampMs: number;
+  transcriptPath?: string;
+}
+
+export interface DaemonOptions {
+  /// Auto-compact poll interval. Default 30s (matches the Swift monitor).
+  pollIntervalMs?: number;
+  /// Delay after a Stop before auto-sending a queued prompt. Default 1s.
+  autoSendDelayMs?: number;
+  selfCompact?: { enabled: boolean; rules?: SelfCompactRule[] };
+  /// Side effect for sending text to a tmux session. Injectable for tests.
+  paste?: (sessionName: string, text: string) => void;
+  /// Optional: mirror automated traffic (auto-sent prompts, /compact) to Slack.
+  /// Fire-and-forget; not used in tests.
+  announce?: (slug: string, text: string) => void;
+}
+
+function currentContextTokens(ctx: SessionContext): number {
+  if (ctx.contextWindowSize > 0 && ctx.usedPercentage > 0) {
+    return Math.round((ctx.contextWindowSize * ctx.usedPercentage) / 100);
+  }
+  return ctx.totalInputTokens + ctx.totalOutputTokens;
+}
+
+/// The headless replacement for the macOS app's background loops: tails
+/// hook-events.jsonl to auto-send queued prompts after a Stop, and polls context
+/// usage to queue self-compact warnings / send "/compact". Single-threaded; all
+/// state mutation goes through the same links.json writer the rest of the CLI uses.
+export class Daemon {
+  private readonly pollIntervalMs: number;
+  private readonly autoSendDelayMs: number;
+  private readonly selfCompactEnabled: boolean;
+  private readonly rules: SelfCompactRule[];
+  private readonly paste: (sessionName: string, text: string) => void;
+  private readonly announce: (slug: string, text: string) => void;
+
+  /// Last time we saw a user/relay prompt per session (ms). Pauses auto-send.
+  private lastPromptAt = new Map<string, number>();
+  /// Highest self-compact threshold already actioned per session.
+  private lastTriggered = new Map<string, number>();
+  /// Byte offset into hook-events.jsonl already consumed.
+  private offset = 0;
+
+  private pollTimer?: NodeJS.Timeout;
+  private eventTimer?: NodeJS.Timeout;
+
+  constructor(opts: DaemonOptions = {}) {
+    this.pollIntervalMs = opts.pollIntervalMs ?? 30_000;
+    this.autoSendDelayMs = opts.autoSendDelayMs ?? 1_000;
+    this.selfCompactEnabled = opts.selfCompact?.enabled ?? true;
+    this.rules = (opts.selfCompact?.rules ?? DEFAULT_SELF_COMPACT_RULES)
+      .slice()
+      .sort((a, b) => a.thresholdTokens - b.thresholdTokens);
+    this.paste = opts.paste ?? ((s, t) => pasteTmuxPrompt(s, t));
+    this.announce = opts.announce ?? (() => {});
+  }
+
+  /// Begin from the current end of the events file so we never act on old
+  /// events (e.g. a stale Stop) on startup.
+  start(): void {
+    installHooks();
+    this.offset = existsSync(hookEventsPath()) ? statSync(hookEventsPath()).size : 0;
+    this.eventTimer = setInterval(() => this.processEvents(), 500);
+    this.pollTimer = setInterval(() => this.evaluateAutoCompact(), this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.eventTimer) clearInterval(this.eventTimer);
+    if (this.pollTimer) clearInterval(this.pollTimer);
+  }
+
+  /// Read hook events appended since the last read. Only complete lines are
+  /// consumed; a partial trailing line is left for next time.
+  readNewHookEvents(): HookEvent[] {
+    const path = hookEventsPath();
+    if (!existsSync(path)) return [];
+    const size = statSync(path).size;
+    if (size <= this.offset) {
+      this.offset = size; // file truncated/rotated
+      return [];
+    }
+    const fd = openSync(path, "r");
+    const buf = Buffer.alloc(size - this.offset);
+    readSync(fd, buf, 0, buf.length, this.offset);
+    closeSync(fd);
+
+    const text = buf.toString("utf-8");
+    const lastNl = text.lastIndexOf("\n");
+    if (lastNl < 0) return [];
+    this.offset += Buffer.byteLength(text.slice(0, lastNl + 1), "utf-8");
+
+    const events: HookEvent[] = [];
+    for (const line of text.slice(0, lastNl).split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const o = JSON.parse(line);
+        if (o.sessionId && o.event) {
+          events.push({
+            sessionId: o.sessionId,
+            event: o.event,
+            timestampMs: o.timestamp ? Date.parse(o.timestamp) : Date.now(),
+            transcriptPath: o.transcriptPath,
+          });
+        }
+      } catch {
+        /* skip malformed */
+      }
+    }
+    return events;
+  }
+
+  /// Consume new events: record user prompts, and schedule an auto-send after
+  /// each Stop. Returns the Stop events (handy for tests).
+  processEvents(): HookEvent[] {
+    const events = this.readNewHookEvents();
+    const stops: HookEvent[] = [];
+    for (const e of events) {
+      if (e.event === "UserPromptSubmit") {
+        this.lastPromptAt.set(e.sessionId, Math.max(this.lastPromptAt.get(e.sessionId) ?? 0, e.timestampMs));
+      } else if (e.event === "Stop") {
+        stops.push(e);
+        const stopMs = e.timestampMs;
+        setTimeout(() => this.maybeAutoSend(e.sessionId, stopMs), this.autoSendDelayMs);
+      }
+    }
+    return stops;
+  }
+
+  /// Auto-send the first auto-sendable queued prompt for a session, unless a
+  /// user/relay prompted after the Stop, or the prompt is a now-stale
+  /// self-compact warning.
+  maybeAutoSend(sessionId: string, stopMs: number): { sent: boolean; reason?: string } {
+    if ((this.lastPromptAt.get(sessionId) ?? 0) > stopMs) {
+      return { sent: false, reason: "user-prompted" };
+    }
+    const card = readLinks().find((c) => c.sessionLink?.sessionId === sessionId);
+    const sessionName = card?.tmuxLink?.sessionName;
+    if (!card || !sessionName) return { sent: false, reason: "no-tmux" };
+
+    const first = card.queuedPrompts?.[0];
+    if (!first || !first.sendAutomatically) return { sent: false, reason: "no-eligible" };
+
+    if (this.shouldDropStaleSelfCompact(first, sessionId)) {
+      this.dequeue(card.id, first.id);
+      return { sent: false, reason: "dropped-stale" };
+    }
+
+    this.paste(sessionName, first.body);
+    this.dequeue(card.id, first.id);
+    // Treat our own auto-send as a prompt so the next Stop sends the next one.
+    this.lastPromptAt.set(sessionId, Date.now());
+    // Mirror automated prompts (e.g. self-compact warnings) to Slack.
+    this.announce(card.name ?? "", first.body);
+    return { sent: true };
+  }
+
+  /// Poll context usage and act on the highest newly-crossed self-compact rule.
+  /// Returns a description of actions taken (handy for tests/logging).
+  evaluateAutoCompact(): { sessionId: string; action: SelfCompactAction; thresholdTokens: number }[] {
+    if (!this.selfCompactEnabled) return [];
+    const acted: { sessionId: string; action: SelfCompactAction; thresholdTokens: number }[] = [];
+
+    for (const card of readLinks()) {
+      const sessionId = card.sessionLink?.sessionId;
+      const sessionName = card.tmuxLink?.sessionName;
+      if (!sessionId || !sessionName || card.manuallyArchived) continue;
+      const ctx = readSessionContext(sessionId);
+      if (!ctx) continue;
+      const tokens = currentContextTokens(ctx);
+
+      const rule = [...this.rules].reverse().find((r) => tokens >= r.thresholdTokens);
+      if (!rule) {
+        this.lastTriggered.delete(sessionId); // dropped below all thresholds; allow re-trigger
+        continue;
+      }
+      if (rule.thresholdTokens <= (this.lastTriggered.get(sessionId) ?? 0)) continue;
+
+      if (rule.action === "queuePrompt") {
+        this.enqueueOnce(card.id, rule.message);
+      } else {
+        this.paste(sessionName, "/compact");
+        this.announce(card.name ?? "", `🧹 context over ${Math.round(rule.thresholdTokens / 1000)}k - sending /compact`);
+      }
+      this.lastTriggered.set(sessionId, rule.thresholdTokens);
+      acted.push({ sessionId, action: rule.action, thresholdTokens: rule.thresholdTokens });
+    }
+    return acted;
+  }
+
+  private shouldDropStaleSelfCompact(prompt: QueuedPrompt, sessionId: string): boolean {
+    if (!this.selfCompactEnabled) return false;
+    const body = prompt.body.trim();
+    const rule = this.rules.find((r) => r.action === "queuePrompt" && r.message.trim() === body);
+    if (!rule) return false;
+    const ctx = readSessionContext(sessionId);
+    if (!ctx) return true; // no usage data -> warning is stale
+    return currentContextTokens(ctx) < rule.thresholdTokens;
+  }
+
+  private dequeue(cardId: string, promptId: string): void {
+    const card = readLinks().find((c) => c.id === cardId);
+    if (!card) return;
+    const next: Link = {
+      ...card,
+      queuedPrompts: (card.queuedPrompts ?? []).filter((p) => p.id !== promptId),
+      updatedAt: isoNow(),
+    };
+    upsertCard(next);
+  }
+
+  private enqueueOnce(cardId: string, body: string): void {
+    const card = readLinks().find((c) => c.id === cardId);
+    if (!card) return;
+    const queue = card.queuedPrompts ?? [];
+    if (queue.some((p) => p.body.trim() === body.trim())) return; // already queued
+    const prompt: QueuedPrompt = { id: randomUUID(), body, sendAutomatically: true };
+    upsertCard({ ...card, queuedPrompts: [...queue, prompt], updatedAt: isoNow() });
+  }
+}

--- a/cli/src/agents/identity.ts
+++ b/cli/src/agents/identity.ts
@@ -1,0 +1,38 @@
+import { uuidv5 } from "../uuid.js";
+
+/// A stable, readable identity for a long-lived agent. Everything humans see or
+/// type is the readable slug; only the Claude session id is a (deterministic)
+/// UUID, because `claude --session-id` requires a valid UUID.
+export interface AgentIdentity {
+  /// Readable slug, e.g. "dependabot-scout". Source of truth for the identity.
+  slug: string;
+  /// Deterministic UUIDv5 of the slug — the Claude --session-id / --resume key.
+  sessionId: string;
+  /// tmux session name (== slug).
+  tmuxName: string;
+  /// kanban card name (== slug).
+  cardName: string;
+  /// git worktree name (== slug).
+  worktreeName: string;
+}
+
+const SLUG_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+export function isValidSlug(slug: string): boolean {
+  return SLUG_RE.test(slug) && slug.length <= 60;
+}
+
+export function agentIdentity(slug: string): AgentIdentity {
+  if (!isValidSlug(slug)) {
+    throw new Error(
+      `Invalid agent slug "${slug}" (use lowercase letters, digits and hyphens; max 60 chars)`
+    );
+  }
+  return {
+    slug,
+    sessionId: uuidv5(slug),
+    tmuxName: slug,
+    cardName: slug,
+    worktreeName: slug,
+  };
+}

--- a/cli/src/agents/launch.ts
+++ b/cli/src/agents/launch.ts
@@ -1,0 +1,132 @@
+import { AgentIdentity } from "./identity.js";
+import {
+  hasTmuxSession,
+  createTmuxSession,
+  findSessionJsonl,
+  readLinks,
+} from "../data.js";
+import { upsertCard, isoNow } from "../cards.js";
+import { generateKsuid } from "../ksuid.js";
+import { Link, ManualOverrides } from "../types.js";
+
+export interface LaunchOptions {
+  /// Working directory for the session (the agent's workspace / worktree root).
+  cwd: string;
+  /// Extra args appended to the claude invocation.
+  extraArgs?: string[];
+  /// Environment variables exported into the tmux session.
+  env?: Record<string, string>;
+  /// Model alias or full name (claude --model).
+  model?: string;
+  /// Autonomous agents skip permission prompts by default.
+  skipPermissions?: boolean;
+  /// Override the claude binary (tests).
+  claudeBin?: string;
+}
+
+export type LaunchAction = "noop-running" | "launched" | "resumed";
+
+export interface LaunchResult {
+  action: LaunchAction;
+  identity: AgentIdentity;
+  sessionId: string;
+  tmuxName: string;
+  command?: string;
+  card: Link;
+}
+
+const DEFAULT_OVERRIDES: ManualOverrides = {
+  worktreePath: false,
+  tmuxSession: false,
+  name: false,
+  column: false,
+  prLink: false,
+  issueLink: false,
+};
+
+/// Idempotently ensure an agent's Claude session is running in tmux and its
+/// kanban card reflects reality. Decides launch vs resume vs no-op:
+///   - tmux session already alive          -> no-op (never restart a live agent)
+///   - a transcript exists for the session  -> resume (--resume <uuid>)
+///   - neither                               -> fresh launch (--session-id <uuid>)
+export function ensureAgentSession(
+  identity: AgentIdentity,
+  opts: LaunchOptions
+): LaunchResult {
+  const claudeBin = opts.claudeBin ?? "claude";
+  const skipPerms = opts.skipPermissions ?? true;
+
+  const tmuxAlive = hasTmuxSession(identity.tmuxName);
+  const sessionExists = !!findSessionJsonl(identity.sessionId);
+
+  let action: LaunchAction;
+  let command: string | undefined;
+
+  if (tmuxAlive) {
+    action = "noop-running";
+  } else {
+    const args: string[] = [];
+    if (sessionExists) {
+      action = "resumed";
+      args.push("--resume", identity.sessionId);
+    } else {
+      action = "launched";
+      args.push("--session-id", identity.sessionId, "--name", identity.slug);
+    }
+    if (skipPerms) args.push("--dangerously-skip-permissions");
+    if (opts.model) args.push("--model", opts.model);
+    if (opts.extraArgs?.length) args.push(...opts.extraArgs);
+    command = [claudeBin, ...args].join(" ");
+
+    const res = createTmuxSession(identity.tmuxName, opts.cwd, command, opts.env ?? {});
+    if (!res.ok) {
+      throw new Error(`Failed to create tmux session "${identity.tmuxName}": ${res.error}`);
+    }
+  }
+
+  const card = upsertAgentCard(identity, opts.cwd);
+  return {
+    action,
+    identity,
+    sessionId: identity.sessionId,
+    tmuxName: identity.tmuxName,
+    command,
+    card,
+  };
+}
+
+/// Reconcile the agent's card to current truth. Writes only when something
+/// meaningful changed, so a healthy reconcile is a true no-op on disk.
+function upsertAgentCard(identity: AgentIdentity, cwd: string): Link {
+  const existing = readLinks().find((l) => l.name === identity.cardName);
+  const sessionPath = findSessionJsonl(identity.sessionId);
+
+  const unchanged =
+    existing &&
+    !existing.manuallyArchived &&
+    existing.sessionLink?.sessionId === identity.sessionId &&
+    existing.sessionLink?.sessionPath === sessionPath &&
+    existing.tmuxLink?.sessionName === identity.tmuxName &&
+    existing.worktreeLink?.path === cwd;
+  if (unchanged) return existing;
+
+  const now = isoNow();
+  const card: Link = {
+    id: existing?.id ?? generateKsuid("card"),
+    name: identity.cardName,
+    column: existing?.column ?? "in_progress",
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    lastActivity: now,
+    manualOverrides: existing?.manualOverrides ?? { ...DEFAULT_OVERRIDES, name: true },
+    manuallyArchived: false,
+    source: "manual",
+    sessionLink: { sessionId: identity.sessionId, sessionPath },
+    tmuxLink: { sessionName: identity.tmuxName },
+    worktreeLink: { path: cwd },
+    assistant: "claude",
+    isRemote: false,
+  };
+  upsertCard(card);
+  return card;
+}

--- a/cli/src/agents/reconcile.ts
+++ b/cli/src/agents/reconcile.ts
@@ -1,0 +1,106 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { AgentsFile, AgentConfig } from "./config.js";
+import { agentIdentity } from "./identity.js";
+import { ensureAgentSession, LaunchResult } from "./launch.js";
+import { isGitRepo, ensureWorktree } from "../git.js";
+import { readLinks, killTmuxSession } from "../data.js";
+import { upsertCard, isoNow } from "../cards.js";
+
+export interface ReconcileOptions {
+  /// Override the claude binary (tests).
+  claudeBin?: string;
+  /// Tear down agent-managed sessions/cards/worktrees no longer in config.
+  prune?: boolean;
+}
+
+export interface RepoReconcileResult {
+  name: string;
+  worktreeCreated: boolean;
+  worktree: string;
+}
+
+export interface AgentReconcileResult {
+  slug: string;
+  workspace: string;
+  repos: RepoReconcileResult[];
+  launch: LaunchResult;
+}
+
+export interface ReconcileResult {
+  agents: AgentReconcileResult[];
+  pruned: string[];
+}
+
+const agentBranch = (slug: string) => `agent/${slug}`;
+const repoName = (spec: string) => spec.split("/")[1];
+
+/// Reconcile a single agent. The canonical clone is provisioned and kept clean
+/// + current by IaC; the reconciler only ensures a per-agent worktree of each
+/// repo and launches/resumes the session with the workspace as cwd. Idempotent.
+export function reconcileAgent(
+  agent: AgentConfig,
+  file: AgentsFile,
+  opts: ReconcileOptions = {}
+): AgentReconcileResult {
+  const workspace = join(file.workspacesDir, agent.slug);
+  mkdirSync(workspace, { recursive: true });
+
+  const repos: RepoReconcileResult[] = [];
+  for (const spec of agent.repos) {
+    const name = repoName(spec);
+    const repoDir = join(file.reposDir, name);
+    if (!isGitRepo(repoDir)) {
+      throw new Error(
+        `Canonical clone for ${spec} is missing at ${repoDir}. ` +
+          `Repo clones are provisioned and kept current by IaC, not the reconciler.`
+      );
+    }
+    const worktree = join(workspace, name);
+    const { created } = ensureWorktree(repoDir, worktree, agentBranch(agent.slug));
+    repos.push({ name, worktreeCreated: created, worktree });
+  }
+
+  const launch = ensureAgentSession(agentIdentity(agent.slug), {
+    cwd: workspace,
+    model: agent.model,
+    claudeBin: opts.claudeBin,
+  });
+
+  return { slug: agent.slug, workspace, repos, launch };
+}
+
+/// Reconcile every agent in the config, optionally pruning de-configured ones.
+export function reconcileAll(file: AgentsFile, opts: ReconcileOptions = {}): ReconcileResult {
+  mkdirSync(file.workspacesDir, { recursive: true });
+
+  const agents = file.agents.map((a) => reconcileAgent(a, file, opts));
+  const pruned = opts.prune ? pruneStale(file) : [];
+  return { agents, pruned };
+}
+
+/// Tear down agent-managed cards whose slug is no longer configured. A card is
+/// "agent-managed" when its worktree path is exactly <workspacesDir>/<name> —
+/// the layout reconcileAgent creates — which avoids touching unrelated cards.
+function pruneStale(file: AgentsFile): string[] {
+  const configured = new Set(file.agents.map((a) => a.slug));
+  const pruned: string[] = [];
+
+  for (const card of readLinks()) {
+    if (card.manuallyArchived) continue;
+    const name = card.name;
+    if (!name || configured.has(name)) continue;
+    const managedPath = join(file.workspacesDir, name);
+    if (card.worktreeLink?.path !== managedPath) continue;
+
+    if (card.tmuxLink?.sessionName) killTmuxSession(card.tmuxLink.sessionName);
+    upsertCard({ ...card, manuallyArchived: true, updatedAt: isoNow() });
+    try {
+      rmSync(managedPath, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+    pruned.push(name);
+  }
+  return pruned;
+}

--- a/cli/src/announce-suppress.test.ts
+++ b/cli/src/announce-suppress.test.ts
@@ -1,0 +1,40 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { recordAnnounceSuppress, announceSuppressPath } from "./slack/announce-suppress.js";
+
+describe("announce-suppress store", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kanban-suppress-"));
+    process.env.KANBAN_CODE_HOME = home;
+  });
+  afterEach(() => {
+    delete process.env.KANBAN_CODE_HOME;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("records a marker line keyed by session with a timestamp", () => {
+    recordAnnounceSuppress("sess-1", 1234);
+    const lines = readFileSync(announceSuppressPath(), "utf-8").trim().split("\n");
+    assert.equal(lines.length, 1);
+    const o = JSON.parse(lines[0]);
+    assert.equal(o.sessionId, "sess-1");
+    assert.equal(o.ts, 1234);
+  });
+
+  test("ignores an empty session id (nothing to suppress)", () => {
+    recordAnnounceSuppress("", 1);
+    assert.equal(existsSync(announceSuppressPath()), false);
+  });
+
+  test("appends rather than overwrites, so the daemon can tail it", () => {
+    recordAnnounceSuppress("a", 1);
+    recordAnnounceSuppress("b", 2);
+    const lines = readFileSync(announceSuppressPath(), "utf-8").trim().split("\n");
+    assert.equal(lines.length, 2);
+  });
+});

--- a/cli/src/cards.ts
+++ b/cli/src/cards.ts
@@ -1,0 +1,88 @@
+import {
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  copyFileSync,
+  readdirSync,
+  unlinkSync,
+  renameSync,
+} from "node:fs";
+import { dirname, basename, join } from "node:path";
+import { linksPath } from "./paths.js";
+import { readLinks } from "./data.js";
+import { Link } from "./types.js";
+
+/// ISO-8601 timestamp without milliseconds, matching Swift's `.iso8601`
+/// encoding ("2026-04-25T12:02:24Z") so headless writes diff cleanly against
+/// app writes.
+export function isoNow(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/// Deterministic, key-sorted, pretty JSON matching Swift's
+/// `[.prettyPrinted, .sortedKeys]` output (2-space indent, no trailing newline).
+function sortValue(value: any): any {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value && typeof value === "object") {
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(value).sort()) out[key] = sortValue(value[key]);
+    return out;
+  }
+  return value;
+}
+
+export function sortedStringify(obj: any): string {
+  return JSON.stringify(sortValue(obj), null, 2);
+}
+
+/// Write all links atomically to links.json, keeping a rolling 7-day set of
+/// daily backups (mirrors CoordinationStore.writeLinks).
+export function writeLinks(links: Link[]): void {
+  const file = linksPath();
+  mkdirSync(dirname(file), { recursive: true });
+  rotateDailyBackup(file);
+
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, sortedStringify({ links }));
+  renameSync(tmp, file); // atomic replace on POSIX
+}
+
+const DAILY_BACKUP_RETENTION = 7;
+
+function rotateDailyBackup(file: string): void {
+  if (!existsSync(file)) return;
+  try {
+    const today = new Date().toISOString().slice(0, 10); // UTC YYYY-MM-DD
+    const todayPath = `${file}.daily-${today}.bak`;
+    if (!existsSync(todayPath)) copyFileSync(file, todayPath);
+
+    const dir = dirname(file);
+    const prefix = `${basename(file)}.daily-`;
+    const snapshots = readdirSync(dir)
+      .filter((f) => f.startsWith(prefix) && f.endsWith(".bak"))
+      .sort(); // alphabetical == chronological for YYYY-MM-DD
+    for (const old of snapshots.slice(0, -DAILY_BACKUP_RETENTION)) {
+      try {
+        unlinkSync(join(dir, old));
+      } catch {
+        /* a backup must never block a write */
+      }
+    }
+  } catch {
+    /* a backup must never block a write */
+  }
+}
+
+/// Upsert a link by id: replace if present, append otherwise.
+export function upsertCard(card: Link): void {
+  const links = readLinks();
+  const index = links.findIndex((l) => l.id === card.id);
+  if (index >= 0) links[index] = card;
+  else links.push(card);
+  writeLinks(links);
+}
+
+/// Find the existing card for an agent slug (matched by name), if any.
+export function findCardByName(name: string): Link | undefined {
+  return readLinks().find((l) => l.name === name);
+}

--- a/cli/src/daemon.test.ts
+++ b/cli/src/daemon.test.ts
@@ -8,6 +8,7 @@ import { Daemon, DEFAULT_SELF_COMPACT_RULES } from "./agents/daemon.js";
 import { writeLinks, isoNow } from "./cards.js";
 import { readLinks } from "./data.js";
 import { hookEventsPath, contextDir } from "./paths.js";
+import { recordAnnounceSuppress, ANNOUNCE_SUPPRESS_TTL_MS } from "./slack/announce-suppress.js";
 import type { Link, QueuedPrompt } from "./types.js";
 
 const SID = "11111111-1111-5111-8111-111111111111";
@@ -129,5 +130,99 @@ describe("daemon (sandboxed, injected paste)", () => {
     assert.equal(d.readNewHookEvents().length, 0, "offset advanced; nothing new");
     appendFileSync(hookEventsPath(), JSON.stringify({ sessionId: SID, event: "Stop", timestamp: isoNow() }) + "\n");
     assert.equal(d.readNewHookEvents().length, 1);
+  });
+});
+
+describe("daemon: mirror prompts to Slack only on confirmed receipt", () => {
+  let home: string;
+  let pastes: [string, string][];
+  let announces: [string, string][];
+  function newDaemon() {
+    return new Daemon({
+      selfCompact: { enabled: false },
+      paste: (s, t) => pastes.push([s, t]),
+      announce: (slug, text) => announces.push([slug, text]),
+    });
+  }
+  /// Append a UserPromptSubmit hook line carrying the prompt the way the real
+  /// hook does (base64 of the full payload), so the daemon decodes it.
+  function writeUserPrompt(sessionId: string, prompt: string, ts = Date.now()): void {
+    const payloadB64 = Buffer.from(JSON.stringify({ prompt }), "utf-8").toString("base64");
+    appendFileSync(
+      hookEventsPath(),
+      JSON.stringify({ sessionId, event: "UserPromptSubmit", timestamp: new Date(ts).toISOString(), payloadB64 }) + "\n"
+    );
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kanban-daemon-ann-"));
+    process.env.KANBAN_CODE_HOME = home;
+    process.env.CLAUDE_CONFIG_DIR = join(home, "claude");
+    pastes = [];
+    announces = [];
+  });
+  afterEach(() => {
+    delete process.env.KANBAN_CODE_HOME;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("announces a prompt with the exact received text on UserPromptSubmit", () => {
+    writeLinks([card()]);
+    const d = newDaemon();
+    writeUserPrompt(SID, "Good morning, list open Dependabot PRs");
+    d.processEvents();
+    assert.deepEqual(announces, [["daemon-agent", "Good morning, list open Dependabot PRs"]]);
+  });
+
+  test("auto-send does not announce at paste time (announce waits for receipt)", () => {
+    writeLinks([card([{ id: "p1", body: "continue", sendAutomatically: true }])]);
+    const d = newDaemon();
+    const r = d.maybeAutoSend(SID, Date.now());
+    assert.equal(r.sent, true);
+    assert.deepEqual(pastes, [["daemon-agent", "continue"]]);
+    assert.deepEqual(announces, [], "no announce until this prompt's own UserPromptSubmit");
+  });
+
+  test("a bridge-relayed prompt is not echoed, and its marker is consumed", () => {
+    writeLinks([card()]);
+    const d = newDaemon();
+    recordAnnounceSuppress(SID); // the bridge marks the relay before pasting
+    writeUserPrompt(SID, "hey agent, please do X"); // the relayed human text
+    d.processEvents();
+    assert.deepEqual(announces, [], "relay must not be echoed");
+    // The marker was consumed: a subsequent (non-relay) prompt is announced.
+    writeUserPrompt(SID, "scheduled nudge");
+    d.processEvents();
+    assert.deepEqual(announces, [["daemon-agent", "scheduled nudge"]]);
+  });
+
+  test("each marker suppresses exactly one received prompt", () => {
+    writeLinks([card()]);
+    const d = newDaemon();
+    recordAnnounceSuppress(SID);
+    recordAnnounceSuppress(SID);
+    writeUserPrompt(SID, "relay 1");
+    writeUserPrompt(SID, "relay 2");
+    writeUserPrompt(SID, "automated 3");
+    d.processEvents();
+    assert.deepEqual(announces, [["daemon-agent", "automated 3"]]);
+  });
+
+  test("an expired marker does not suppress a later prompt", () => {
+    writeLinks([card()]);
+    const d = newDaemon();
+    recordAnnounceSuppress(SID, Date.now() - (ANNOUNCE_SUPPRESS_TTL_MS + 1000));
+    writeUserPrompt(SID, "automated after a stale marker");
+    d.processEvents();
+    assert.deepEqual(announces, [["daemon-agent", "automated after a stale marker"]]);
+  });
+
+  test("a UserPromptSubmit without a captured prompt is not announced", () => {
+    writeLinks([card()]);
+    const d = newDaemon();
+    appendFileSync(hookEventsPath(), JSON.stringify({ sessionId: SID, event: "UserPromptSubmit", timestamp: isoNow() }) + "\n");
+    d.processEvents();
+    assert.deepEqual(announces, []);
   });
 });

--- a/cli/src/daemon.test.ts
+++ b/cli/src/daemon.test.ts
@@ -1,0 +1,133 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Daemon, DEFAULT_SELF_COMPACT_RULES } from "./agents/daemon.js";
+import { writeLinks, isoNow } from "./cards.js";
+import { readLinks } from "./data.js";
+import { hookEventsPath, contextDir } from "./paths.js";
+import type { Link, QueuedPrompt } from "./types.js";
+
+const SID = "11111111-1111-5111-8111-111111111111";
+
+function card(queued: QueuedPrompt[] = []): Link {
+  const now = isoNow();
+  return {
+    id: "card_d",
+    name: "daemon-agent",
+    column: "in_progress",
+    createdAt: now,
+    updatedAt: now,
+    manualOverrides: { worktreePath: false, tmuxSession: false, name: true, column: false, prLink: false, issueLink: false },
+    manuallyArchived: false,
+    source: "manual",
+    isRemote: false,
+    sessionLink: { sessionId: SID },
+    tmuxLink: { sessionName: "daemon-agent" },
+    queuedPrompts: queued,
+  };
+}
+
+function writeContextPct(pct: number, windowSize = 1_000_000): void {
+  mkdirSync(contextDir(), { recursive: true });
+  writeFileSync(
+    join(contextDir(), `${SID}.json`),
+    JSON.stringify({ usedPercentage: pct, contextWindowSize: windowSize, totalInputTokens: 0, totalOutputTokens: 0, totalCostUsd: 0, model: "x" })
+  );
+}
+
+describe("daemon (sandboxed, injected paste)", () => {
+  let home: string;
+  let pastes: [string, string][];
+  function newDaemon() {
+    return new Daemon({ selfCompact: { enabled: true }, paste: (s, t) => pastes.push([s, t]) });
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kanban-daemon-"));
+    process.env.KANBAN_CODE_HOME = home;
+    process.env.CLAUDE_CONFIG_DIR = join(home, "claude");
+    pastes = [];
+  });
+  afterEach(() => {
+    delete process.env.KANBAN_CODE_HOME;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("auto-sends an eligible queued prompt on Stop and dequeues it", () => {
+    writeLinks([card([{ id: "p1", body: "continue the work", sendAutomatically: true }])]);
+    const r = newDaemon().maybeAutoSend(SID, Date.now());
+    assert.equal(r.sent, true);
+    assert.deepEqual(pastes, [["daemon-agent", "continue the work"]]);
+    assert.equal(readLinks()[0].queuedPrompts?.length, 0);
+  });
+
+  test("does not auto-send a non-auto prompt", () => {
+    writeLinks([card([{ id: "p1", body: "manual only", sendAutomatically: false }])]);
+    const r = newDaemon().maybeAutoSend(SID, Date.now());
+    assert.equal(r.sent, false);
+    assert.equal(r.reason, "no-eligible");
+    assert.equal(pastes.length, 0);
+  });
+
+  test("a user prompt after the Stop pauses auto-send", () => {
+    writeLinks([card([{ id: "p1", body: "go", sendAutomatically: true }])]);
+    const d = newDaemon();
+    const stopMs = Date.now();
+    // A UserPromptSubmit recorded after the stop should block the send.
+    appendFileSync(
+      hookEventsPath(),
+      JSON.stringify({ sessionId: SID, event: "UserPromptSubmit", timestamp: new Date(stopMs + 200).toISOString() }) + "\n"
+    );
+    d.processEvents();
+    const r = d.maybeAutoSend(SID, stopMs);
+    assert.equal(r.sent, false);
+    assert.equal(r.reason, "user-prompted");
+    assert.equal(pastes.length, 0);
+  });
+
+  test("drops a stale self-compact warning instead of sending it", () => {
+    const warning = DEFAULT_SELF_COMPACT_RULES[0].message; // the 500k warning
+    writeLinks([card([{ id: "p1", body: warning, sendAutomatically: true }])]);
+    writeContextPct(10); // 100k tokens -> below 500k -> stale
+    const r = newDaemon().maybeAutoSend(SID, Date.now());
+    assert.equal(r.sent, false);
+    assert.equal(r.reason, "dropped-stale");
+    assert.equal(pastes.length, 0);
+    assert.equal(readLinks()[0].queuedPrompts?.length, 0, "stale warning dropped from queue");
+  });
+
+  test("auto-compact queues the crossed warning once (no re-queue)", () => {
+    writeLinks([card()]);
+    writeContextPct(55); // 550k -> crosses 500k queuePrompt rule
+    const d = newDaemon();
+    const acted = d.evaluateAutoCompact();
+    assert.deepEqual(acted, [{ sessionId: SID, action: "queuePrompt", thresholdTokens: 500_000 }]);
+    assert.equal(readLinks()[0].queuedPrompts?.[0].body, DEFAULT_SELF_COMPACT_RULES[0].message);
+
+    const again = d.evaluateAutoCompact();
+    assert.equal(again.length, 0, "must not re-trigger the same threshold");
+    assert.equal(readLinks()[0].queuedPrompts?.length, 1, "no duplicate queued warning");
+  });
+
+  test("auto-compact sends /compact at the hard threshold", () => {
+    writeLinks([card()]);
+    writeContextPct(80); // 800k -> crosses 750k compactNow rule
+    const acted = newDaemon().evaluateAutoCompact();
+    assert.deepEqual(acted, [{ sessionId: SID, action: "compactNow", thresholdTokens: 750_000 }]);
+    assert.deepEqual(pastes, [["daemon-agent", "/compact"]]);
+  });
+
+  test("reads appended hook events incrementally", () => {
+    const d = newDaemon();
+    appendFileSync(hookEventsPath(), JSON.stringify({ sessionId: SID, event: "SessionStart", timestamp: isoNow() }) + "\n");
+    appendFileSync(hookEventsPath(), JSON.stringify({ sessionId: SID, event: "Stop", timestamp: isoNow() }) + "\n");
+    assert.equal(d.readNewHookEvents().length, 2);
+    assert.equal(d.readNewHookEvents().length, 0, "offset advanced; nothing new");
+    appendFileSync(hookEventsPath(), JSON.stringify({ sessionId: SID, event: "Stop", timestamp: isoNow() }) + "\n");
+    assert.equal(d.readNewHookEvents().length, 1);
+  });
+});

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync, existsSync, statSync, openSync, readSync, closeSync, readdirSync } from "node:fs";
 import { execSync, spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join, basename, matchesGlob } from "node:path";
@@ -12,17 +12,14 @@ import {
   TranscriptTurn,
   KanbanColumn,
 } from "./types.js";
-
-const KANBAN_DIR = join(homedir(), ".kanban-code");
-const CONTEXT_DIR = join(KANBAN_DIR, "context");
-const LINKS_PATH = join(KANBAN_DIR, "links.json");
-const SETTINGS_PATH = join(KANBAN_DIR, "settings.json");
+import { linksPath, settingsPath, contextDir, claudeProjectsDir } from "./paths.js";
 
 // ── Reading state files ──────────────────────────────────────────────
 
 export function readLinks(): Link[] {
-  if (!existsSync(LINKS_PATH)) return [];
-  const raw = JSON.parse(readFileSync(LINKS_PATH, "utf-8"));
+  const path = linksPath();
+  if (!existsSync(path)) return [];
+  const raw = JSON.parse(readFileSync(path, "utf-8"));
   // Container format: { links: [...] }
   if (raw && Array.isArray(raw.links)) return raw.links;
   if (Array.isArray(raw)) return raw;
@@ -30,15 +27,16 @@ export function readLinks(): Link[] {
 }
 
 export function readSettings(): Settings {
-  if (!existsSync(SETTINGS_PATH))
+  const path = settingsPath();
+  if (!existsSync(path))
     return { projects: [] };
-  return JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"));
+  return JSON.parse(readFileSync(path, "utf-8"));
 }
 
 // ── Session context (tokens/cost) ────────────────────────────────────
 
 export function readSessionContext(sessionId: string): SessionContext | undefined {
-  const path = join(CONTEXT_DIR, `${sessionId}.json`);
+  const path = join(contextDir(), `${sessionId}.json`);
   if (!existsSync(path)) return undefined;
   try {
     return JSON.parse(readFileSync(path, "utf-8"));
@@ -305,6 +303,79 @@ export function sendTmuxEscape(
   } catch (e) {
     return { ok: false, error: String(e) };
   }
+}
+
+// ── Tmux session lifecycle (headless agent launch/resume) ────────────
+
+export function hasTmuxSession(name: string): boolean {
+  const tmux = findTmux();
+  try {
+    execSync(`${tmux} has-session -t ${shellEscape(name)} 2>/dev/null`, {
+      encoding: "utf-8",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/// Create a detached tmux session named `name` rooted at `cwd` and run
+/// `command` in it. `env` entries are set on the session (and inherited by the
+/// pane's shell) via tmux `-e`, avoiding fragile inline-shell quoting.
+export function createTmuxSession(
+  name: string,
+  cwd: string,
+  command: string,
+  env: Record<string, string> = {}
+): { ok: boolean; error?: string } {
+  const tmux = findTmux();
+  try {
+    const envFlags = Object.entries(env)
+      .map(([k, v]) => `-e ${shellEscape(`${k}=${v}`)}`)
+      .join(" ");
+    execSync(
+      `${tmux} new-session -d -s ${shellEscape(name)} -c ${shellEscape(cwd)} ${envFlags}`,
+      { encoding: "utf-8" }
+    );
+    // Let the pane's shell come up before sending the command.
+    execSync("sleep 0.2");
+    execSync(
+      `${tmux} send-keys -t ${shellEscape(name)} ${shellEscape(command)} Enter`,
+      { encoding: "utf-8" }
+    );
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export function killTmuxSession(name: string): { ok: boolean; error?: string } {
+  const tmux = findTmux();
+  try {
+    execSync(`${tmux} kill-session -t ${shellEscape(name)} 2>/dev/null`, {
+      encoding: "utf-8",
+    });
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+/// Locate a Claude session transcript by scanning ~/.claude/projects/<dir>/.
+/// Encoding-independent: finds <sessionId>.jsonl wherever Claude placed it.
+export function findSessionJsonl(sessionId: string): string | undefined {
+  const root = claudeProjectsDir();
+  if (!existsSync(root)) return undefined;
+  const target = `${sessionId}.jsonl`;
+  try {
+    for (const dir of readdirSync(root)) {
+      const candidate = join(root, dir, target);
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch {
+    // ignore unreadable projects dir
+  }
+  return undefined;
 }
 
 // ── Transcript reading ───────────────────────────────────────────────

--- a/cli/src/e2e-tmux.test.ts
+++ b/cli/src/e2e-tmux.test.ts
@@ -53,7 +53,16 @@ function tmuxNew(session: string, cwd: string): void {
   execSync(`tmux new-session -d -s ${session} -c ${cwd}`);
 }
 
-const skipIfNoTmux = { skip: !hasTmux() };
+// This suite drives a real bare shell and asserts on pasted text rendered in
+// the pane, so it needs an interactive tmux + shell. Reliable locally; skipped
+// in CI where the non-interactive runner does not render pasted keystrokes the
+// same way (the deterministic real-tmux coverage lives in launch/reconcile).
+const skipReason = !hasTmux()
+  ? "tmux unavailable"
+  : process.env.CI
+    ? "needs an interactive shell; not reliable in CI"
+    : false;
+const skipIfNoTmux = { skip: skipReason };
 
 describe("broadcast fan-out (real tmux)", skipIfNoTmux, () => {
   let home: string;

--- a/cli/src/git.ts
+++ b/cli/src/git.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+
+function git(args: string[], cwd?: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+function gitQuiet(args: string[], cwd?: string): boolean {
+  try {
+    execFileSync("git", args, { cwd, stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isGitRepo(dir: string): boolean {
+  return gitQuiet(["-C", dir, "rev-parse", "--is-inside-work-tree"]);
+}
+
+/// The repo's default branch (origin/HEAD target), falling back to "main".
+export function detectDefaultBranch(repoDir: string): string {
+  try {
+    const ref = git(["-C", repoDir, "symbolic-ref", "refs/remotes/origin/HEAD"]);
+    return ref.replace("refs/remotes/origin/", "") || "main";
+  } catch {
+    return "main";
+  }
+}
+
+function branchExists(repoDir: string, branch: string): boolean {
+  return gitQuiet(["-C", repoDir, "show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+}
+
+export interface WorktreeResult {
+  created: boolean;
+  path: string;
+}
+
+/// Ensure a git worktree for `repoDir` exists at `worktreePath` on `branch`.
+///
+/// First creation branches from `baseRef` (default origin/<default>). On
+/// subsequent runs the existing worktree (with whatever WIP the agent has) is
+/// left untouched, so reconcile never clobbers the agent's working state.
+///
+/// Because the IaC-managed canonical clone keeps `main` checked out, git itself
+/// refuses to let this worktree check out `main` — that is the structural
+/// guarantee that an agent is never working on the main branch. Keeping the
+/// canonical clone clean and current is IaC's job, not the reconciler's.
+export function ensureWorktree(
+  repoDir: string,
+  worktreePath: string,
+  branch: string,
+  baseRef?: string
+): WorktreeResult {
+  if (isGitRepo(worktreePath)) {
+    return { created: false, path: worktreePath };
+  }
+  // Drop any stale administrative entry for a path that no longer exists.
+  gitQuiet(["-C", repoDir, "worktree", "prune"]);
+
+  const base = baseRef ?? `origin/${detectDefaultBranch(repoDir)}`;
+  if (branchExists(repoDir, branch)) {
+    git(["-C", repoDir, "worktree", "add", worktreePath, branch]);
+  } else {
+    git(["-C", repoDir, "worktree", "add", "-b", branch, worktreePath, base]);
+  }
+  return { created: true, path: worktreePath };
+}
+
+/// Remove a worktree (used when pruning a de-configured agent).
+export function removeWorktree(repoDir: string, worktreePath: string): void {
+  gitQuiet(["-C", repoDir, "worktree", "remove", "--force", worktreePath]);
+  gitQuiet(["-C", repoDir, "worktree", "prune"]);
+}

--- a/cli/src/hooks.test.ts
+++ b/cli/src/hooks.test.ts
@@ -1,0 +1,68 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { installHooks, areHooksInstalled, HOOK_EVENTS } from "./hooks.js";
+
+describe("hook installer (sandboxed)", () => {
+  let home: string;
+  let claudeDir: string;
+  let settings: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kanban-hooks-home-"));
+    claudeDir = mkdtempSync(join(tmpdir(), "kanban-hooks-claude-"));
+    settings = join(claudeDir, "settings.json");
+    process.env.KANBAN_CODE_HOME = home;
+    process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  });
+  afterEach(() => {
+    delete process.env.KANBAN_CODE_HOME;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(claudeDir, { recursive: true, force: true });
+  });
+
+  test("registers all events + statusline and deploys executable scripts", () => {
+    const r = installHooks();
+    const root = JSON.parse(readFileSync(settings, "utf-8"));
+    for (const event of HOOK_EVENTS) {
+      const cmds = root.hooks[event].flatMap((g: any) => g.hooks.map((h: any) => h.command));
+      assert.ok(cmds.includes(r.hookScriptPath), `${event} missing hook`);
+    }
+    assert.equal(root.statusLine.command, r.statuslinePath);
+    assert.ok(areHooksInstalled(undefined, r.hookScriptPath));
+    // scripts exist and are executable
+    assert.ok(statSync(r.hookScriptPath).mode & 0o111);
+    assert.ok(statSync(r.statuslinePath).mode & 0o111);
+  });
+
+  test("is idempotent: no duplicate hook entries on repeat install", () => {
+    installHooks();
+    const r = installHooks();
+    const root = JSON.parse(readFileSync(settings, "utf-8"));
+    const stopHooks = root.hooks.Stop.flatMap((g: any) => g.hooks).filter(
+      (h: any) => h.command === r.hookScriptPath
+    );
+    assert.equal(stopHooks.length, 1);
+  });
+
+  test("preserves unrelated settings and pre-existing hooks", () => {
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      settings,
+      JSON.stringify({
+        model: "opus",
+        hooks: { Stop: [{ matcher: "", hooks: [{ type: "command", command: "/other/tool.sh" }] }] },
+      })
+    );
+    const r = installHooks();
+    const root = JSON.parse(readFileSync(settings, "utf-8"));
+    assert.equal(root.model, "opus");
+    const stopCmds = root.hooks.Stop.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    assert.ok(stopCmds.includes("/other/tool.sh"), "pre-existing hook preserved");
+    assert.ok(stopCmds.includes(r.hookScriptPath), "ours added");
+  });
+});

--- a/cli/src/hooks.ts
+++ b/cli/src/hooks.ts
@@ -35,9 +35,17 @@ if [ -z "$session_id" ]; then
 fi
 [ -z "$session_id" ] && exit 0
 
+# For UserPromptSubmit, capture the whole payload (base64, so the prompt's
+# quotes/newlines survive) so the daemon can mirror the exact text the agent
+# received once receipt is confirmed.
+payload_b64=""
+if [ "$hook_event" = "UserPromptSubmit" ]; then
+    payload_b64=$(printf '%s' "$input" | base64 | tr -d '\\n')
+fi
+
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-printf '{"sessionId":"%s","event":"%s","timestamp":"%s","transcriptPath":"%s"}\\n' \\
-    "$session_id" "$hook_event" "$timestamp" "$transcript" >> "$EVENTS_FILE"
+printf '{"sessionId":"%s","event":"%s","timestamp":"%s","transcriptPath":"%s","payloadB64":"%s"}\\n' \\
+    "$session_id" "$hook_event" "$timestamp" "$transcript" "$payload_b64" >> "$EVENTS_FILE"
 `;
 
 /// Captures Claude Code's context/token usage per session into

--- a/cli/src/hooks.ts
+++ b/cli/src/hooks.ts
@@ -1,0 +1,151 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { kanbanHome, claudeSettingsPath } from "./paths.js";
+import { sortedStringify } from "./cards.js";
+
+/// Claude Code hook events the runtime relies on. Stop drives auto-send;
+/// UserPromptSubmit lets the daemon detect a human/relay prompt; the rest feed
+/// activity tracking. Mirrors the Swift HookManager.
+export const HOOK_EVENTS = ["Stop", "Notification", "SessionStart", "SessionEnd", "UserPromptSubmit"];
+
+function defaultHookScriptPath(): string {
+  return join(kanbanHome(), "hook.sh");
+}
+
+/// Appends one timestamped line per hook event to hook-events.jsonl. No jq
+/// dependency (lightweight grep parsing). Honors KANBAN_CODE_HOME so the same
+/// script works in tests and in alternate deployments.
+const HOOK_SCRIPT = `#!/usr/bin/env bash
+# Kanban hook handler. Receives JSON on stdin from Claude Code hooks and appends
+# a timestamped event line to <kanban-home>/hook-events.jsonl.
+set -euo pipefail
+
+EVENTS_DIR="\${KANBAN_CODE_HOME:-\$HOME/.kanban-code}"
+EVENTS_FILE="\${EVENTS_DIR}/hook-events.jsonl"
+mkdir -p "$EVENTS_DIR"
+
+input=$(cat)
+
+session_id=$(echo "$input" | grep -o '"session_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+hook_event=$(echo "$input" | grep -o '"hook_event_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+transcript=$(echo "$input" | grep -o '"transcript_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$session_id" ]; then
+    session_id=$(echo "$input" | grep -o '"sessionId":"[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+[ -z "$session_id" ] && exit 0
+
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+printf '{"sessionId":"%s","event":"%s","timestamp":"%s","transcriptPath":"%s"}\\n' \\
+    "$session_id" "$hook_event" "$timestamp" "$transcript" >> "$EVENTS_FILE"
+`;
+
+/// Captures Claude Code's context/token usage per session into
+/// <kanban-home>/context/<sessionId>.json after each assistant response.
+const STATUSLINE_SCRIPT = `#!/usr/bin/env bash
+# Kanban Code statusline - captures context/token usage per session.
+set -euo pipefail
+
+CONTEXT_DIR="\${KANBAN_CODE_HOME:-\$HOME/.kanban-code}/context"
+mkdir -p "$CONTEXT_DIR"
+
+input=$(cat)
+
+session_id=$(echo "$input" | grep -oE '"session_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+[ -z "$session_id" ] && exit 0
+
+used_pct=$(echo "$input" | grep -oE '"used_percentage":[0-9.]+' | head -1 | cut -d: -f2)
+ctx_size=$(echo "$input" | grep -oE '"context_window_size":[0-9]+' | head -1 | cut -d: -f2)
+input_tokens=$(echo "$input" | grep -oE '"total_input_tokens":[0-9]+' | head -1 | cut -d: -f2)
+output_tokens=$(echo "$input" | grep -oE '"total_output_tokens":[0-9]+' | head -1 | cut -d: -f2)
+cost=$(echo "$input" | grep -oE '"total_cost_usd":[0-9.]+' | head -1 | cut -d: -f2)
+model=$(echo "$input" | grep -oE '"display_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+tmp_file="\${CONTEXT_DIR}/.\${session_id}.tmp"
+out_file="\${CONTEXT_DIR}/\${session_id}.json"
+printf '{"usedPercentage":%s,"contextWindowSize":%s,"totalInputTokens":%s,"totalOutputTokens":%s,"totalCostUsd":%s,"model":"%s"}' \\
+    "\${used_pct:-0}" "\${ctx_size:-0}" "\${input_tokens:-0}" "\${output_tokens:-0}" "\${cost:-0}" "\${model:-}" > "$tmp_file"
+mv -f "$tmp_file" "$out_file"
+printf ''
+`;
+
+export interface InstallHooksOptions {
+  settingsPath?: string;
+  hookScriptPath?: string;
+  statuslinePath?: string;
+}
+
+export interface InstallHooksResult {
+  settingsPath: string;
+  hookScriptPath: string;
+  statuslinePath: string;
+  events: string[];
+}
+
+function deployScript(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function readJson(path: string): Record<string, any> {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/// Install Claude Code hooks + statusline for headless operation. Idempotent:
+/// the hook command is added to each event only if not already present, and the
+/// statusline is set only if not already ours. Mirrors HookManager.install.
+export function installHooks(opts: InstallHooksOptions = {}): InstallHooksResult {
+  const settingsPath = opts.settingsPath ?? claudeSettingsPath();
+  const hookScriptPath = opts.hookScriptPath ?? defaultHookScriptPath();
+  const statuslinePath = opts.statuslinePath ?? join(kanbanHome(), "statusline.sh");
+
+  deployScript(hookScriptPath, HOOK_SCRIPT);
+  deployScript(statuslinePath, STATUSLINE_SCRIPT);
+
+  const root = readJson(settingsPath);
+  const hooks = (root.hooks ?? {}) as Record<string, any[]>;
+  const hookEntry = { type: "command", command: hookScriptPath };
+
+  for (const event of HOOK_EVENTS) {
+    const groups: any[] = Array.isArray(hooks[event]) ? hooks[event] : [];
+    // Idempotent by exact script path (robust regardless of where the kanban
+    // home lives), preserving any other tools' hooks already registered.
+    const present = groups.some((g) =>
+      (g?.hooks ?? []).some((h: any) => h?.command === hookScriptPath)
+    );
+    if (!present) {
+      if (groups.length === 0) {
+        groups.push({ matcher: "", hooks: [hookEntry] });
+      } else {
+        groups[0].hooks = [...(groups[0].hooks ?? []), hookEntry];
+      }
+    }
+    hooks[event] = groups;
+  }
+  root.hooks = hooks;
+
+  if (root.statusLine?.command !== statuslinePath) {
+    root.statusLine = { type: "command", command: statuslinePath };
+  }
+
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, sortedStringify(root));
+
+  return { settingsPath, hookScriptPath, statuslinePath, events: HOOK_EVENTS };
+}
+
+/// True if our hook script is registered for every required event.
+export function areHooksInstalled(settingsPath?: string, hookScriptPath?: string): boolean {
+  const root = readJson(settingsPath ?? claudeSettingsPath());
+  const hooks = (root.hooks ?? {}) as Record<string, any[]>;
+  const path = hookScriptPath ?? defaultHookScriptPath();
+  return HOOK_EVENTS.every((event) =>
+    (hooks[event] ?? []).some((g: any) => (g?.hooks ?? []).some((h: any) => h?.command === path))
+  );
+}

--- a/cli/src/kanban.ts
+++ b/cli/src/kanban.ts
@@ -292,7 +292,7 @@ program
   .argument("<card>", "Card ID, ID prefix, or name search")
   .argument("<message>", "Message to send")
   .option("--keys", "Use send-keys instead of paste-buffer (for short single-line)")
-  .option("--announce", "(deprecated: kanban send always mirrors the message to the agent's Slack channel now)")
+  .option("--announce", "(deprecated, no-op: prompts are mirrored to Slack on confirmed receipt by the daemon)")
   .option("-j, --json", "Output as JSON")
   .action(async (cardQuery: string, message: string, opts) => {
     const links = readLinks();
@@ -310,12 +310,10 @@ program
       ? sendTmuxKeys(card.tmuxLink.sessionName, message)
       : pasteTmuxPrompt(card.tmuxLink.sessionName, message);
 
-    // Always mirror the injected prompt to Slack. Messages relayed *from* a
-    // Slack human never reach this command (the bridge pastes them directly),
-    // so they are correctly never re-posted.
-    if (result.ok) {
-      await announceToSlack(card.name ?? cardQuery, message);
-    }
+    // No announce here: the prompt is mirrored to Slack only once the agent's
+    // UserPromptSubmit hook confirms it was actually received (the daemon does
+    // it), so a paste that never becomes a submitted prompt is never falsely
+    // announced as received.
 
     if (opts.json) {
       output(

--- a/cli/src/kanban.ts
+++ b/cli/src/kanban.ts
@@ -292,7 +292,7 @@ program
   .argument("<card>", "Card ID, ID prefix, or name search")
   .argument("<message>", "Message to send")
   .option("--keys", "Use send-keys instead of paste-buffer (for short single-line)")
-  .option("--announce", "Also post this message to the agent's Slack channel (for scheduled/automated sends)")
+  .option("--announce", "(deprecated: kanban send always mirrors the message to the agent's Slack channel now)")
   .option("-j, --json", "Output as JSON")
   .action(async (cardQuery: string, message: string, opts) => {
     const links = readLinks();
@@ -310,7 +310,10 @@ program
       ? sendTmuxKeys(card.tmuxLink.sessionName, message)
       : pasteTmuxPrompt(card.tmuxLink.sessionName, message);
 
-    if (result.ok && opts.announce) {
+    // Always mirror the injected prompt to Slack. Messages relayed *from* a
+    // Slack human never reach this command (the bridge pastes them directly),
+    // so they are correctly never re-posted.
+    if (result.ok) {
       await announceToSlack(card.name ?? cardQuery, message);
     }
 

--- a/cli/src/kanban.ts
+++ b/cli/src/kanban.ts
@@ -28,6 +28,15 @@ import {
   formatCardDetail,
   formatTmuxSessions,
 } from "./format.js";
+import { agentIdentity } from "./agents/identity.js";
+import { ensureAgentSession } from "./agents/launch.js";
+import { loadAgentsConfig } from "./agents/config.js";
+import { reconcileAll } from "./agents/reconcile.js";
+import { installHooks } from "./hooks.js";
+import { Daemon } from "./agents/daemon.js";
+import { slackAppManifest, MANIFEST_INSTRUCTIONS } from "./slack/manifest.js";
+import { runSlackBridge } from "./slack/bridge.js";
+import { announceToSlack } from "./slack/announce.js";
 import type { KanbanColumn, Link } from "./types.js";
 import {
   createChannel,
@@ -283,8 +292,9 @@ program
   .argument("<card>", "Card ID, ID prefix, or name search")
   .argument("<message>", "Message to send")
   .option("--keys", "Use send-keys instead of paste-buffer (for short single-line)")
+  .option("--announce", "Also post this message to the agent's Slack channel (for scheduled/automated sends)")
   .option("-j, --json", "Output as JSON")
-  .action((cardQuery: string, message: string, opts) => {
+  .action(async (cardQuery: string, message: string, opts) => {
     const links = readLinks();
     const card = findCard(links, cardQuery);
     if (!card) {
@@ -299,6 +309,10 @@ program
     const result = opts.keys
       ? sendTmuxKeys(card.tmuxLink.sessionName, message)
       : pasteTmuxPrompt(card.tmuxLink.sessionName, message);
+
+    if (result.ok && opts.announce) {
+      await announceToSlack(card.name ?? cardQuery, message);
+    }
 
     if (opts.json) {
       output(
@@ -318,6 +332,158 @@ program
         process.exit(1);
       }
     }
+  });
+
+// ── kanban launch <slug> ─────────────────────────────────────────────
+
+program
+  .command("launch")
+  .description("Launch or resume a long-lived agent session in tmux with a stable, readable identity")
+  .argument("<slug>", "Readable agent slug, e.g. dependabot-scout")
+  .requiredOption("--cwd <path>", "Working directory for the session (the agent's worktree/workspace)")
+  .option("--model <model>", "Model alias or full name")
+  .option("--no-skip-permissions", "Do NOT pass --dangerously-skip-permissions")
+  .option("-j, --json", "Output as JSON")
+  .action((slug: string, opts) => {
+    try {
+      const cwd = resolve(opts.cwd);
+      if (!existsSync(cwd)) throw new Error(`cwd does not exist: ${cwd}`);
+      const identity = agentIdentity(slug);
+      const result = ensureAgentSession(identity, {
+        cwd,
+        model: opts.model,
+        skipPermissions: opts.skipPermissions,
+      });
+      if (opts.json) {
+        output(result, opts);
+      } else {
+        const verb = {
+          "noop-running": "already running",
+          launched: "launched",
+          resumed: "resumed",
+        }[result.action];
+        output(
+          `Agent "${slug}" ${verb} (session ${result.sessionId}, tmux ${result.tmuxName}, card ${result.card.id})`,
+          opts
+        );
+      }
+    } catch (e) {
+      process.stderr.write(`Error: ${(e as Error).message}\n`);
+      process.exit(1);
+    }
+  });
+
+// ── kanban reconcile ─────────────────────────────────────────────────
+
+program
+  .command("reconcile")
+  .description("Idempotently reconcile all configured agents: clean+pull repos, ensure worktrees, launch/resume sessions")
+  .option(
+    "--config <path>",
+    "Path to agents.yaml",
+    process.env.KANBAN_AGENTS_CONFIG || join(homedir(), ".kanban-code", "agents.yaml")
+  )
+  .option("--prune", "Tear down agent sessions/cards no longer in the config")
+  .option("-j, --json", "Output as JSON")
+  .action((opts) => {
+    try {
+      const file = loadAgentsConfig(opts.config);
+      const result = reconcileAll(file, { prune: !!opts.prune });
+      if (opts.json) {
+        output(result, opts);
+        return;
+      }
+      const lines: string[] = [];
+      for (const a of result.agents) {
+        const repoNote = a.repos
+          .map((r) => `${r.name}${r.worktreeCreated ? " (worktree+)" : ""}`)
+          .join(", ");
+        lines.push(`${a.slug}: ${a.launch.action} [${repoNote}]`);
+      }
+      if (result.pruned.length) lines.push(`pruned: ${result.pruned.join(", ")}`);
+      output(lines.join("\n") || "no agents configured", opts);
+    } catch (e) {
+      process.stderr.write(`Error: ${(e as Error).message}\n`);
+      process.exit(1);
+    }
+  });
+
+// ── kanban hooks install ─────────────────────────────────────────────
+
+const hooksCmd = program.command("hooks").description("Manage Claude Code hooks for headless operation");
+hooksCmd
+  .command("install")
+  .description("Install the Kanban hook + statusline scripts and register them in Claude settings")
+  .option("-j, --json", "Output as JSON")
+  .action((opts) => {
+    try {
+      const result = installHooks();
+      output(
+        opts.json
+          ? result
+          : `Installed hooks (${result.events.join(", ")})\n  hook:       ${result.hookScriptPath}\n  statusline: ${result.statuslinePath}\n  settings:   ${result.settingsPath}`,
+        opts
+      );
+    } catch (e) {
+      process.stderr.write(`Error: ${(e as Error).message}\n`);
+      process.exit(1);
+    }
+  });
+
+// ── kanban daemon ────────────────────────────────────────────────────
+
+program
+  .command("daemon")
+  .description("Run the headless engine: auto-send queued prompts on Stop, auto-compact long sessions")
+  .option("--poll-interval <ms>", "Auto-compact poll interval in ms", "30000")
+  .option("--no-self-compact", "Disable auto-compaction")
+  .action((opts) => {
+    const daemon = new Daemon({
+      pollIntervalMs: parseInt(opts.pollInterval, 10),
+      selfCompact: { enabled: opts.selfCompact },
+      announce: process.env.SLACK_BOT_TOKEN
+        ? (slug, text) => {
+            void announceToSlack(slug, text);
+          }
+        : undefined,
+    });
+    daemon.start();
+    process.stdout.write(
+      `kanban daemon started (poll ${opts.pollInterval}ms, self-compact ${opts.selfCompact ? "on" : "off"})\n`
+    );
+    const shutdown = () => {
+      daemon.stop();
+      process.exit(0);
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+
+// ── kanban slack ─────────────────────────────────────────────────────
+
+const slackCmd = program.command("slack").description("Slack bridge for observing and steering agents");
+slackCmd
+  .command("manifest")
+  .description("Print a Slack app manifest (Socket Mode) plus setup instructions")
+  .action(() => {
+    process.stdout.write(slackAppManifest() + "\n# ---\n" + MANIFEST_INSTRUCTIONS + "\n");
+  });
+slackCmd
+  .command("bridge")
+  .description("Run the bidirectional Slack <-> agent bridge (needs SLACK_BOT_TOKEN and SLACK_APP_TOKEN)")
+  .option(
+    "--config <path>",
+    "Path to agents.yaml",
+    process.env.KANBAN_AGENTS_CONFIG || join(homedir(), ".kanban-code", "agents.yaml")
+  )
+  .action(async (opts) => {
+    const botToken = process.env.SLACK_BOT_TOKEN;
+    const appToken = process.env.SLACK_APP_TOKEN;
+    if (!botToken || !appToken) {
+      process.stderr.write("Error: SLACK_BOT_TOKEN and SLACK_APP_TOKEN must be set\n");
+      process.exit(1);
+    }
+    await runSlackBridge({ botToken, appToken, configPath: opts.config });
   });
 
 // ── kanban self-compact [follow-up] ─────────────────────────────────

--- a/cli/src/kanban.ts
+++ b/cli/src/kanban.ts
@@ -37,6 +37,8 @@ import { Daemon } from "./agents/daemon.js";
 import { slackAppManifest, MANIFEST_INSTRUCTIONS } from "./slack/manifest.js";
 import { runSlackBridge } from "./slack/bridge.js";
 import { announceToSlack } from "./slack/announce.js";
+import { SlackClient } from "./slack/client.js";
+import { postToSlack } from "./slack/post.js";
 import type { KanbanColumn, Link } from "./types.js";
 import {
   createChannel,
@@ -485,6 +487,34 @@ slackCmd
       process.exit(1);
     }
     await runSlackBridge({ botToken, appToken, configPath: opts.config });
+  });
+slackCmd
+  .command("post")
+  .description("Post a message to a Slack channel as the bot (needs SLACK_BOT_TOKEN)")
+  .argument("<channel>", "Channel name (e.g. #dev) or id")
+  .argument("<message>", "Message text (Slack mrkdwn)")
+  .option("-j, --json", "Output as JSON")
+  .action(async (channel: string, message: string, opts) => {
+    const token = process.env.SLACK_BOT_TOKEN;
+    if (!token) {
+      process.stderr.write("Error: SLACK_BOT_TOKEN must be set\n");
+      process.exit(1);
+    }
+    const result = await postToSlack(new SlackClient(token), channel, message);
+    if (opts.json) {
+      output(result, { json: true });
+      if (!result.ok) process.exit(1);
+      return;
+    }
+    if (result.ok) {
+      process.stdout.write(`Posted to ${channel} (${result.channelId})\n`);
+    } else {
+      process.stderr.write(`Failed to post to ${channel}: ${result.error}\n`);
+      if (String(result.error).includes("not_in_channel")) {
+        process.stderr.write("The bot is not a member of that channel — invite it there first.\n");
+      }
+      process.exit(1);
+    }
   });
 
 // ── kanban self-compact [follow-up] ─────────────────────────────────

--- a/cli/src/ksuid.ts
+++ b/cli/src/ksuid.ts
@@ -1,0 +1,45 @@
+import { randomBytes } from "node:crypto";
+
+/// Lightweight KSUID (K-Sortable Unique Identifier) generator, matching the
+/// Swift implementation in KanbanCodeCore so headless-written cards share the
+/// same id format as app-written ones.
+///
+/// Format: 4-byte big-endian timestamp (seconds since the KSUID epoch
+/// 2014-05-13) + 16-byte random payload, base62-encoded to 27 characters.
+const EPOCH = 1_400_000_000;
+const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const ENCODED_LENGTH = 27;
+
+export function generateKsuid(prefix?: string): string {
+  const timestamp = Math.floor(Date.now() / 1000) - EPOCH;
+
+  const bytes = new Uint8Array(20);
+  bytes[0] = (timestamp >>> 24) & 0xff;
+  bytes[1] = (timestamp >>> 16) & 0xff;
+  bytes[2] = (timestamp >>> 8) & 0xff;
+  bytes[3] = timestamp & 0xff;
+  const rand = randomBytes(16);
+  bytes.set(rand, 4);
+
+  const encoded = base62Encode(bytes);
+  return prefix ? `${prefix}_${encoded}` : encoded;
+}
+
+/// Base62-encode a 20-byte array into a fixed 27-character string using
+/// big-endian arithmetic division (mirrors the Swift implementation).
+function base62Encode(input: Uint8Array): string {
+  const number = Array.from(input);
+  const result: string[] = new Array(ENCODED_LENGTH).fill("0");
+
+  for (let i = ENCODED_LENGTH - 1; i >= 0; i--) {
+    let remainder = 0;
+    for (let j = 0; j < number.length; j++) {
+      const value = number[j] + remainder * 256;
+      number[j] = Math.floor(value / 62);
+      remainder = value % 62;
+    }
+    result[i] = BASE62[remainder];
+  }
+
+  return result.join("");
+}

--- a/cli/src/launch.test.ts
+++ b/cli/src/launch.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Real tmux + filesystem integration test for headless agent launch/resume.
+ * No mocks: spins a real tmux session, writes a real links.json, and exercises
+ * the launch -> idempotent re-run -> resume lifecycle. Uses `true` as a stand-in
+ * for the claude binary so the pane stays a live shell without needing Claude.
+ *
+ * Skipped when tmux is unavailable (CI without tmux).
+ */
+import { test, describe, before, after, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { agentIdentity } from "./agents/identity.js";
+import { ensureAgentSession } from "./agents/launch.js";
+import { readLinks } from "./data.js";
+
+function hasTmux(): boolean {
+  try {
+    execSync("tmux -V", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const skipIfNoTmux = { skip: !hasTmux() };
+
+describe("headless agent launch/resume (real tmux)", skipIfNoTmux, () => {
+  let home: string;
+  let claudeHome: string;
+  let workspace: string;
+  const slug = `kanban-test-${Date.now()}`;
+  const identity = agentIdentity(slug);
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kanban-launch-home-"));
+    claudeHome = mkdtempSync(join(tmpdir(), "kanban-launch-claude-"));
+    workspace = mkdtempSync(join(tmpdir(), "kanban-launch-ws-"));
+    process.env.KANBAN_CODE_HOME = home;
+    process.env.CLAUDE_CONFIG_DIR = claudeHome;
+  });
+
+  afterEach(() => {
+    try { execSync(`tmux kill-session -t ${identity.tmuxName}`, { stdio: "ignore" }); } catch {}
+    delete process.env.KANBAN_CODE_HOME;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(claudeHome, { recursive: true, force: true });
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test("fresh launch creates a tmux session and a stable card", () => {
+    const result = ensureAgentSession(identity, { cwd: workspace, claudeBin: "true" });
+    assert.equal(result.action, "launched");
+    assert.match(result.command!, /true --session-id .* --name /);
+
+    // Real tmux session exists.
+    execSync(`tmux has-session -t ${identity.tmuxName}`);
+
+    const cards = readLinks();
+    assert.equal(cards.length, 1);
+    const card = cards[0];
+    assert.equal(card.name, slug);
+    assert.equal(card.sessionLink?.sessionId, identity.sessionId);
+    assert.equal(card.tmuxLink?.sessionName, identity.tmuxName);
+    assert.equal(card.worktreeLink?.path, workspace);
+    assert.equal(card.column, "in_progress");
+    assert.equal(card.assistant, "claude");
+  });
+
+  test("re-running while alive is a no-op: no restart, no duplicate card", () => {
+    const first = ensureAgentSession(identity, { cwd: workspace, claudeBin: "true" });
+    const firstCardId = first.card.id;
+
+    const second = ensureAgentSession(identity, { cwd: workspace, claudeBin: "true" });
+    assert.equal(second.action, "noop-running");
+    assert.equal(second.command, undefined, "must not build a launch command when already running");
+
+    const cards = readLinks();
+    assert.equal(cards.length, 1, "must not create a duplicate card");
+    assert.equal(cards[0].id, firstCardId, "card id must be stable across reconciles");
+  });
+
+  test("after the tmux session dies but a transcript exists, it resumes", () => {
+    // Simulate a prior session: a transcript file for this session id.
+    const projDir = join(claudeHome, "projects", "some-encoded-cwd");
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(join(projDir, `${identity.sessionId}.jsonl`), '{"type":"user"}\n');
+
+    const result = ensureAgentSession(identity, { cwd: workspace, claudeBin: "true" });
+    assert.equal(result.action, "resumed");
+    assert.match(result.command!, new RegExp(`true --resume ${identity.sessionId}`));
+    execSync(`tmux has-session -t ${identity.tmuxName}`);
+
+    // The card records the discovered transcript path.
+    const card = readLinks()[0];
+    assert.equal(card.sessionLink?.sessionPath, join(projDir, `${identity.sessionId}.jsonl`));
+  });
+});

--- a/cli/src/paths.ts
+++ b/cli/src/paths.ts
@@ -1,0 +1,39 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/// Root of the Kanban Code state dir. Honors KANBAN_CODE_HOME so tests (and
+/// alternate deployments) can sandbox into a temp dir; defaults to ~/.kanban-code.
+export function kanbanHome(): string {
+  return process.env.KANBAN_CODE_HOME || join(homedir(), ".kanban-code");
+}
+
+export function linksPath(): string {
+  return join(kanbanHome(), "links.json");
+}
+
+export function settingsPath(): string {
+  return join(kanbanHome(), "settings.json");
+}
+
+export function contextDir(): string {
+  return join(kanbanHome(), "context");
+}
+
+export function hookEventsPath(): string {
+  return join(kanbanHome(), "hook-events.jsonl");
+}
+
+/// Claude Code's config dir. Honors CLAUDE_CONFIG_DIR so a sandboxed test can
+/// point it elsewhere.
+export function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+/// Where Claude Code writes per-project session transcripts.
+export function claudeProjectsDir(): string {
+  return join(claudeConfigDir(), "projects");
+}
+
+export function claudeSettingsPath(): string {
+  return join(claudeConfigDir(), "settings.json");
+}

--- a/cli/src/reconcile.test.ts
+++ b/cli/src/reconcile.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Real git + tmux integration test for the reconciler. No mocks: builds a local
+ * bare "origin", a canonical clone (standing in for the IaC-provisioned one),
+ * and exercises worktree creation, idempotency, the missing-clone error, and
+ * prune. `true` stands in for the claude binary so panes stay live shells.
+ *
+ * Skipped when tmux is unavailable.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { reconcileAll, reconcileAgent } from "./agents/reconcile.js";
+import { AgentsFile } from "./agents/config.js";
+import { agentIdentity } from "./agents/identity.js";
+import { readLinks } from "./data.js";
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t.dev",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t.dev",
+};
+function g(args: string[], cwd?: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", env: { ...process.env, ...GIT_ENV } }).trim();
+}
+function hasTmux(): boolean {
+  try {
+    execSync("tmux -V", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const skipIfNoTmux = { skip: !hasTmux() };
+
+/// Create a bare origin seeded with one commit on main, plus a canonical clone
+/// at <reposDir>/<name> (what IaC would provision).
+function provisionRepo(root: string, reposDir: string, name: string): void {
+  const origin = join(root, `${name}-origin.git`);
+  g(["init", "--bare", "-b", "main", origin]);
+  const seed = join(root, `${name}-seed`);
+  g(["clone", origin, seed]);
+  writeFileSync(join(seed, "README.md"), "seed\n");
+  g(["add", "."], seed);
+  g(["commit", "-m", "init"], seed);
+  g(["push", "origin", "main"], seed);
+  mkdirSync(reposDir, { recursive: true });
+  g(["clone", origin, join(reposDir, name)]);
+}
+
+describe("reconciler (real git + tmux)", skipIfNoTmux, () => {
+  let root: string;
+  let reposDir: string;
+  let workspacesDir: string;
+  const slugs: string[] = [];
+
+  function makeFile(agents: AgentsFile["agents"]): AgentsFile {
+    return { reposDir, workspacesDir, agents };
+  }
+  function trackSlug(s: string): string {
+    slugs.push(s);
+    return s;
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kanban-recon-"));
+    reposDir = join(root, "repos");
+    workspacesDir = join(root, "workspaces");
+    process.env.KANBAN_CODE_HOME = join(root, "kanban-home");
+    process.env.CLAUDE_CONFIG_DIR = join(root, "claude-home");
+  });
+
+  afterEach(() => {
+    for (const s of slugs) {
+      try { execSync(`tmux kill-session -t ${s}`, { stdio: "ignore" }); } catch {}
+    }
+    slugs.length = 0;
+    delete process.env.KANBAN_CODE_HOME;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("creates a per-agent worktree on agent/<slug> and launches the session", () => {
+    provisionRepo(root, reposDir, "myrepo");
+    const slug = trackSlug(`recon-a-${Date.now()}`);
+    const result = reconcileAll(makeFile([{ slug, repos: ["acme/myrepo"] }]), { claudeBin: "true" });
+
+    const agent = result.agents[0];
+    assert.equal(agent.launch.action, "launched");
+    assert.equal(agent.repos[0].worktreeCreated, true);
+
+    const worktree = join(workspacesDir, slug, "myrepo");
+    assert.ok(existsSync(worktree), "worktree dir should exist");
+    assert.equal(g(["-C", worktree, "rev-parse", "--abbrev-ref", "HEAD"]), `agent/${slug}`);
+
+    execSync(`tmux has-session -t ${slug}`); // real session is live
+
+    const card = readLinks().find((c) => c.name === slug)!;
+    assert.equal(card.sessionLink?.sessionId, agentIdentity(slug).sessionId);
+    assert.equal(card.worktreeLink?.path, join(workspacesDir, slug));
+  });
+
+  test("the agent worktree structurally cannot check out main", () => {
+    provisionRepo(root, reposDir, "myrepo");
+    const slug = trackSlug(`recon-main-${Date.now()}`);
+    reconcileAll(makeFile([{ slug, repos: ["acme/myrepo"] }]), { claudeBin: "true" });
+    const worktree = join(workspacesDir, slug, "myrepo");
+    // main is checked out in the canonical clone, so git refuses it here.
+    assert.throws(() => g(["-C", worktree, "checkout", "main"]), /already (used|checked out)/i);
+  });
+
+  test("re-running is idempotent: no duplicate worktree, card, or tmux session", () => {
+    provisionRepo(root, reposDir, "myrepo");
+    const slug = trackSlug(`recon-idem-${Date.now()}`);
+    const file = makeFile([{ slug, repos: ["acme/myrepo"] }]);
+
+    const first = reconcileAll(file, { claudeBin: "true" });
+    const second = reconcileAll(file, { claudeBin: "true" });
+
+    assert.equal(second.agents[0].launch.action, "noop-running");
+    assert.equal(second.agents[0].repos[0].worktreeCreated, false);
+    assert.equal(readLinks().filter((c) => c.name === slug).length, 1);
+    assert.equal(first.agents[0].launch.card.id, second.agents[0].launch.card.id);
+  });
+
+  test("a missing canonical clone is a loud error (IaC owns provisioning)", () => {
+    const slug = trackSlug(`recon-missing-${Date.now()}`);
+    assert.throws(
+      () => reconcileAgent({ slug, repos: ["acme/nope"] }, makeFile([]), { claudeBin: "true" }),
+      /Canonical clone .* is missing/
+    );
+  });
+
+  test("prune tears down an agent removed from config", () => {
+    provisionRepo(root, reposDir, "myrepo");
+    const slug = trackSlug(`recon-prune-${Date.now()}`);
+    reconcileAll(makeFile([{ slug, repos: ["acme/myrepo"] }]), { claudeBin: "true" });
+    execSync(`tmux has-session -t ${slug}`);
+
+    const pruneResult = reconcileAll(makeFile([]), { claudeBin: "true", prune: true });
+    assert.deepEqual(pruneResult.pruned, [slug]);
+
+    assert.throws(() => execSync(`tmux has-session -t ${slug} 2>/dev/null`), "tmux session should be gone");
+    assert.equal(readLinks().find((c) => c.name === slug)?.manuallyArchived, true);
+    assert.ok(!existsSync(join(workspacesDir, slug)), "workspace should be removed");
+  });
+});

--- a/cli/src/slack-bridge.test.ts
+++ b/cli/src/slack-bridge.test.ts
@@ -1,0 +1,44 @@
+import { test, describe } from "node:test";
+import { strict as assert } from "node:assert";
+import { parse as parseYaml } from "yaml";
+import { routeSlackMessage, slackToPlain } from "./slack/inbound.js";
+import { slackAppManifest } from "./slack/manifest.js";
+
+const MAPPING = { C123: "dependabot-scout", C999: "security-scout" };
+const reasonOf = (d: ReturnType<typeof routeSlackMessage>) => (d.action === "ignore" ? d.reason : undefined);
+
+describe("routeSlackMessage", () => {
+  test("delivers a human message in a mapped channel to the right agent", () => {
+    const d = routeSlackMessage({ type: "message", channel: "C123", user: "U1", text: "focus on the lodash PR" }, MAPPING, "UBOT");
+    assert.deepEqual(d, { action: "deliver", slug: "dependabot-scout", text: "focus on the lodash PR" });
+  });
+
+  test("ignores the bot's own messages (no loops)", () => {
+    assert.equal(routeSlackMessage({ type: "message", channel: "C123", bot_id: "B1", text: "hi" }, MAPPING).action, "ignore");
+    assert.equal(reasonOf(routeSlackMessage({ type: "message", channel: "C123", user: "UBOT", text: "hi" }, MAPPING, "UBOT")), "self");
+  });
+
+  test("ignores edits/joins (subtypes), non-messages, unmapped channels, empties", () => {
+    assert.equal(reasonOf(routeSlackMessage({ type: "message", subtype: "message_changed", channel: "C123" }, MAPPING)), "subtype:message_changed");
+    assert.equal(reasonOf(routeSlackMessage({ type: "reaction_added", channel: "C123" }, MAPPING)), "not-a-message");
+    assert.equal(reasonOf(routeSlackMessage({ type: "message", channel: "CXXX", user: "U1", text: "hi" }, MAPPING)), "unmapped-channel");
+    assert.equal(reasonOf(routeSlackMessage({ type: "message", channel: "C123", user: "U1", text: "   " }, MAPPING)), "empty");
+  });
+
+  test("slackToPlain unwraps links/mentions and unescapes entities", () => {
+    assert.equal(slackToPlain("see <https://x.com|the docs> &amp; retry"), "see the docs (https://x.com) & retry");
+    assert.match(slackToPlain("ping <@U123> now"), /ping\s+now/);
+    assert.equal(slackToPlain("<https://ci.example/run>"), "https://ci.example/run");
+  });
+});
+
+describe("slackAppManifest", () => {
+  test("is Socket Mode with the scopes/events the bridge needs", () => {
+    const m = parseYaml(slackAppManifest());
+    assert.equal(m.settings.socket_mode_enabled, true);
+    assert.equal(m.settings.event_subscriptions.bot_events.includes("message.groups"), true, "private channels");
+    assert.equal(m.settings.event_subscriptions.bot_events.includes("message.channels"), true);
+    assert.ok(m.oauth_config.scopes.bot.includes("chat:write"));
+    assert.ok(m.oauth_config.scopes.bot.includes("groups:history"));
+  });
+});

--- a/cli/src/slack-bridge.test.ts
+++ b/cli/src/slack-bridge.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from "node:assert";
 import { parse as parseYaml } from "yaml";
 import { routeSlackMessage, slackToPlain } from "./slack/inbound.js";
 import { slackAppManifest } from "./slack/manifest.js";
+import { formatSystemAnnouncement, SYSTEM_MESSAGE_PREFIX } from "./slack/announce.js";
 
 const MAPPING = { C123: "dependabot-scout", C999: "security-scout" };
 const reasonOf = (d: ReturnType<typeof routeSlackMessage>) => (d.action === "ignore" ? d.reason : undefined);
@@ -29,6 +30,19 @@ describe("routeSlackMessage", () => {
     assert.equal(slackToPlain("see <https://x.com|the docs> &amp; retry"), "see the docs (https://x.com) & retry");
     assert.match(slackToPlain("ping <@U123> now"), /ping\s+now/);
     assert.equal(slackToPlain("<https://ci.example/run>"), "https://ci.example/run");
+  });
+});
+
+describe("formatSystemAnnouncement", () => {
+  test("prepends the [SYSTEM MESSAGE] marker so automated traffic is distinguishable from agent replies", () => {
+    const out = formatSystemAnnouncement("Good morning, review the open Dependabot PRs.");
+    assert.equal(out, "[SYSTEM MESSAGE]\nGood morning, review the open Dependabot PRs.");
+    assert.ok(out.startsWith(SYSTEM_MESSAGE_PREFIX));
+  });
+
+  test("preserves multi-line bodies verbatim under the marker", () => {
+    const body = "line one\nline two";
+    assert.equal(formatSystemAnnouncement(body), `${SYSTEM_MESSAGE_PREFIX}\n${body}`);
   });
 });
 

--- a/cli/src/slack-bridge.test.ts
+++ b/cli/src/slack-bridge.test.ts
@@ -3,7 +3,7 @@ import { strict as assert } from "node:assert";
 import { parse as parseYaml } from "yaml";
 import { routeSlackMessage, slackToPlain } from "./slack/inbound.js";
 import { slackAppManifest } from "./slack/manifest.js";
-import { formatSystemAnnouncement, SYSTEM_MESSAGE_PREFIX } from "./slack/announce.js";
+import { formatReceivedMessage, RECEIVED_MESSAGE_HEADER } from "./slack/announce.js";
 
 const MAPPING = { C123: "dependabot-scout", C999: "security-scout" };
 const reasonOf = (d: ReturnType<typeof routeSlackMessage>) => (d.action === "ignore" ? d.reason : undefined);
@@ -33,16 +33,16 @@ describe("routeSlackMessage", () => {
   });
 });
 
-describe("formatSystemAnnouncement", () => {
-  test("prepends the [SYSTEM MESSAGE] marker so automated traffic is distinguishable from agent replies", () => {
-    const out = formatSystemAnnouncement("Good morning, review the open Dependabot PRs.");
-    assert.equal(out, "[SYSTEM MESSAGE]\nGood morning, review the open Dependabot PRs.");
-    assert.ok(out.startsWith(SYSTEM_MESSAGE_PREFIX));
+describe("formatReceivedMessage", () => {
+  test("marks the injected prompt as a received message and italicizes the body", () => {
+    const out = formatReceivedMessage("Good morning, review the open Dependabot PRs.");
+    assert.equal(out, ">>> Received user message\n\n_Good morning, review the open Dependabot PRs._");
+    assert.ok(out.startsWith(RECEIVED_MESSAGE_HEADER));
   });
 
-  test("preserves multi-line bodies verbatim under the marker", () => {
+  test("wraps multi-line bodies in italics under the header", () => {
     const body = "line one\nline two";
-    assert.equal(formatSystemAnnouncement(body), `${SYSTEM_MESSAGE_PREFIX}\n${body}`);
+    assert.equal(formatReceivedMessage(body), `${RECEIVED_MESSAGE_HEADER}\n\n_${body}_`);
   });
 });
 

--- a/cli/src/slack-format.test.ts
+++ b/cli/src/slack-format.test.ts
@@ -46,7 +46,16 @@ describe("formatTranscriptLines", () => {
     assert.equal(posts[0].role, "assistant");
     assert.match(posts[0].text, /💭 _let me check the deps_/);
     assert.match(posts[0].text, /Reviewing the bump\./);
-    assert.match(posts[0].text, /`Bash\(run tests\)`/);
+    // Command-style tool labels render in a fenced code block, not inline.
+    assert.match(posts[0].text, /```\nBash\(run tests\)\n```/);
+  });
+
+  test("emoji/prose tool labels are not fenced", () => {
+    const posts = formatTranscriptLines([
+      asst([{ type: "tool_use", name: "AskUserQuestion", input: { questions: [{ question: "Ship it?" }] } }]),
+    ]);
+    assert.doesNotMatch(posts[0].text, /```/);
+    assert.match(posts[0].text, /❓ asking:/);
   });
 
   test("a user turn between assistant turns splits them, and user turns are not emitted", () => {

--- a/cli/src/slack-format.test.ts
+++ b/cli/src/slack-format.test.ts
@@ -1,0 +1,74 @@
+import { test, describe } from "node:test";
+import { strict as assert } from "node:assert";
+import { shortenPath, toolLabel, formatTranscriptLines } from "./slack/format.js";
+
+describe("shortenPath", () => {
+  test("keeps short paths, trims long ones to last 3", () => {
+    assert.equal(shortenPath("src/a.ts"), "src/a.ts");
+    assert.equal(shortenPath("/a/b/c/d/e.ts"), ".../c/d/e.ts");
+  });
+});
+
+describe("toolLabel", () => {
+  test("Bash prefers description, falls back to command", () => {
+    assert.equal(toolLabel("Bash", { description: "run tests", command: "npm test" }), "Bash(run tests)");
+    assert.equal(toolLabel("Bash", { command: "npm test" }), "Bash(npm test)");
+  });
+  test("file tools shorten the path", () => {
+    assert.equal(toolLabel("Read", { file_path: "/x/y/z/w/file.ts" }), "Read(.../z/w/file.ts)");
+    assert.equal(toolLabel("Edit", { file_path: "a/b.ts" }), "Edit(a/b.ts)");
+  });
+  test("Grep shows pattern and optional path", () => {
+    assert.equal(toolLabel("Grep", { pattern: "foo", path: "/a/b/c/d" }), 'Grep("foo" in .../b/c/d)');
+    assert.equal(toolLabel("Grep", { pattern: "foo" }), 'Grep("foo")');
+  });
+  test("Skill, TaskUpdate, plan + question tools", () => {
+    assert.equal(toolLabel("Skill", { skill: "drive-pr" }), "Skill(drive-pr)");
+    assert.equal(toolLabel("TaskUpdate", { taskId: "3", status: "completed" }), "TaskUpdate(3: completed)");
+    assert.equal(toolLabel("EnterPlanMode", {}), "📋 entered plan mode");
+    assert.match(toolLabel("AskUserQuestion", { questions: [{ question: "Ship it?" }] }), /❓ asking:\n• Ship it\?/);
+  });
+});
+
+describe("formatTranscriptLines", () => {
+  const asst = (content: any) => ({ type: "assistant", message: { role: "assistant", content } });
+  const usr = (content: any) => ({ type: "user", message: { role: "user", content } });
+
+  test("merges consecutive assistant lines (thinking + reply + tool) into one post", () => {
+    const posts = formatTranscriptLines([
+      asst([{ type: "thinking", thinking: "let me check the deps" }]),
+      asst([
+        { type: "text", text: "Reviewing the bump." },
+        { type: "tool_use", name: "Bash", input: { description: "run tests" } },
+      ]),
+    ]);
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].role, "assistant");
+    assert.match(posts[0].text, /💭 _let me check the deps_/);
+    assert.match(posts[0].text, /Reviewing the bump\./);
+    assert.match(posts[0].text, /`Bash\(run tests\)`/);
+  });
+
+  test("a user turn between assistant turns splits them, and user turns are not emitted", () => {
+    const posts = formatTranscriptLines([
+      asst([{ type: "text", text: "first" }]),
+      usr("a human steering message"),
+      asst([{ type: "text", text: "second" }]),
+    ]);
+    assert.equal(posts.length, 2);
+    assert.deepEqual(posts.map((p) => p.text), ["first", "second"]);
+    assert.ok(posts.every((p) => p.role === "assistant"));
+  });
+
+  test("empty assistant content produces no post", () => {
+    const posts = formatTranscriptLines([asst([{ type: "text", text: "   " }])]);
+    assert.equal(posts.length, 0);
+  });
+
+  test("tool_result lines (user role) are skipped", () => {
+    const posts = formatTranscriptLines([
+      usr([{ type: "tool_result", tool_use_id: "t1", content: "huge output..." }]),
+    ]);
+    assert.equal(posts.length, 0);
+  });
+});

--- a/cli/src/slack-post.test.ts
+++ b/cli/src/slack-post.test.ts
@@ -1,0 +1,43 @@
+import { test, describe } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { postToSlack } from "./slack/post.js";
+
+function fakeClient(opts: { resolves?: string; postError?: any } = {}) {
+  const posted: [string, string][] = [];
+  const client = {
+    async resolveChannelId(_name: string) {
+      return opts.resolves;
+    },
+    async post(channel: string, text: string) {
+      if (opts.postError) throw opts.postError;
+      posted.push([channel, text]);
+    },
+  } as any;
+  return { client, posted };
+}
+
+describe("postToSlack", () => {
+  test("resolves the channel name and posts to its id", async () => {
+    const { client, posted } = fakeClient({ resolves: "C123" });
+    const r = await postToSlack(client, "#dev", "PR ready: ...");
+    assert.deepEqual(r, { ok: true, channelId: "C123" });
+    assert.deepEqual(posted, [["C123", "PR ready: ..."]]);
+  });
+
+  test("reports an unresolvable channel and does not post", async () => {
+    const { client, posted } = fakeClient({ resolves: undefined });
+    const r = await postToSlack(client, "#nope", "x");
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /not found/);
+    assert.equal(posted.length, 0);
+  });
+
+  test("surfaces the Slack API error (e.g. not_in_channel) so the caller can act", async () => {
+    const { client } = fakeClient({ resolves: "C1", postError: { data: { error: "not_in_channel" } } });
+    const r = await postToSlack(client, "#dev", "x");
+    assert.equal(r.ok, false);
+    assert.equal(r.error, "not_in_channel");
+    assert.equal(r.channelId, "C1");
+  });
+});

--- a/cli/src/slack/announce-suppress.ts
+++ b/cli/src/slack/announce-suppress.ts
@@ -1,0 +1,38 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { kanbanHome } from "../paths.js";
+
+/// "Received user message" is mirrored to Slack when the agent's
+/// UserPromptSubmit hook confirms a prompt was actually received (see the
+/// daemon). A human's Slack message relayed in by the bridge would also fire
+/// UserPromptSubmit, but it already appears in the channel as that person's
+/// message, so it must NOT be echoed. The bridge drops a skip-announce marker
+/// here right before it pastes a relay; the daemon consumes one marker per
+/// confirmed prompt and skips that announce.
+///
+/// Markers carry a timestamp and expire by TTL: if a relayed prompt never
+/// actually gets submitted (e.g. the paste was lost), its marker is dropped
+/// rather than silently suppressing a later automated prompt's announce.
+
+/// How long a skip-announce marker stays valid. Generous on purpose: a relay
+/// pasted while the agent is busy only fires UserPromptSubmit once the agent
+/// picks it up, which can be a while; we still want that echo suppressed.
+export const ANNOUNCE_SUPPRESS_TTL_MS = 10 * 60 * 1000;
+
+export interface SuppressMarker {
+  sessionId: string;
+  ts: number;
+}
+
+export function announceSuppressPath(): string {
+  return join(kanbanHome(), "announce-suppress.jsonl");
+}
+
+/// Record a skip-announce marker for a session. Append-only so the writer (the
+/// bridge) never races the reader (the daemon), which tails by byte offset.
+export function recordAnnounceSuppress(sessionId: string, now = Date.now()): void {
+  if (!sessionId) return;
+  const path = announceSuppressPath();
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, JSON.stringify({ sessionId, ts: now } satisfies SuppressMarker) + "\n");
+}

--- a/cli/src/slack/announce.ts
+++ b/cli/src/slack/announce.ts
@@ -1,0 +1,57 @@
+import { SlackClient } from "./client.js";
+import { loadAgentsConfig } from "../agents/config.js";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/// Posts "automated" agent traffic (scheduled nudges, auto-compact notes,
+/// auto-sent queued prompts) to an agent's Slack channel. Human messages
+/// relayed *from* Slack must NOT go through here (they already appear in Slack).
+
+function defaultConfigPath(): string {
+  return process.env.KANBAN_AGENTS_CONFIG || join(homedir(), ".kanban-code", "agents.yaml");
+}
+
+// slug -> resolved channel id, cached per process.
+const channelCache = new Map<string, string | null>();
+let cachedClient: SlackClient | undefined;
+
+function client(token?: string): SlackClient | undefined {
+  const t = token || process.env.SLACK_BOT_TOKEN;
+  if (!t) return undefined;
+  if (!cachedClient) cachedClient = new SlackClient(t);
+  return cachedClient;
+}
+
+async function channelForSlug(slug: string, configPath: string, c: SlackClient): Promise<string | undefined> {
+  if (channelCache.has(slug)) return channelCache.get(slug) ?? undefined;
+  let id: string | undefined;
+  try {
+    const file = loadAgentsConfig(configPath);
+    const agent = file.agents.find((a) => a.slug === slug);
+    if (agent?.slackChannel) id = await c.resolveChannelId(agent.slackChannel);
+  } catch {
+    /* no config / unresolvable */
+  }
+  channelCache.set(slug, id ?? null);
+  return id;
+}
+
+export interface AnnounceOptions {
+  token?: string;
+  configPath?: string;
+}
+
+/// Announce text to an agent's channel. No-op (returns false) if no token is
+/// configured or the agent has no resolvable channel.
+export async function announceToSlack(slug: string, text: string, opts: AnnounceOptions = {}): Promise<boolean> {
+  const c = client(opts.token);
+  if (!c) return false;
+  const channel = await channelForSlug(slug, opts.configPath ?? defaultConfigPath(), c);
+  if (!channel) return false;
+  try {
+    await c.post(channel, text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/slack/announce.ts
+++ b/cli/src/slack/announce.ts
@@ -7,6 +7,18 @@ import { homedir } from "node:os";
 /// auto-sent queued prompts) to an agent's Slack channel. Human messages
 /// relayed *from* Slack must NOT go through here (they already appear in Slack).
 
+/// Marker prepended to every announced message. Because only automated,
+/// system-originated traffic flows through this module (never messages typed by
+/// a human in Slack), the marker lets anyone reading the channel tell a
+/// system-injected prompt (cron nudge, self-compact, auto-sent queued prompt)
+/// apart from the agent's own replies.
+export const SYSTEM_MESSAGE_PREFIX = "[SYSTEM MESSAGE]";
+
+/// Prepend the system marker to an automated announcement.
+export function formatSystemAnnouncement(text: string): string {
+  return `${SYSTEM_MESSAGE_PREFIX}\n${text}`;
+}
+
 function defaultConfigPath(): string {
   return process.env.KANBAN_AGENTS_CONFIG || join(homedir(), ".kanban-code", "agents.yaml");
 }
@@ -49,7 +61,7 @@ export async function announceToSlack(slug: string, text: string, opts: Announce
   const channel = await channelForSlug(slug, opts.configPath ?? defaultConfigPath(), c);
   if (!channel) return false;
   try {
-    await c.post(channel, text);
+    await c.post(channel, formatSystemAnnouncement(text));
     return true;
   } catch {
     return false;

--- a/cli/src/slack/announce.ts
+++ b/cli/src/slack/announce.ts
@@ -3,20 +3,20 @@ import { loadAgentsConfig } from "../agents/config.js";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
-/// Posts "automated" agent traffic (scheduled nudges, auto-compact notes,
-/// auto-sent queued prompts) to an agent's Slack channel. Human messages
-/// relayed *from* Slack must NOT go through here (they already appear in Slack).
+/// Mirrors every prompt injected into an agent (scheduled nudges, self-compact,
+/// auto-sent queued prompts, and any `kanban send` someone runs by hand) to the
+/// agent's Slack channel. Messages relayed *from* a Slack human must NOT go
+/// through here, they already appear in Slack as that person's message.
 
-/// Marker prepended to every announced message. Because only automated,
-/// system-originated traffic flows through this module (never messages typed by
-/// a human in Slack), the marker lets anyone reading the channel tell a
-/// system-injected prompt (cron nudge, self-compact, auto-sent queued prompt)
-/// apart from the agent's own replies.
-export const SYSTEM_MESSAGE_PREFIX = "[SYSTEM MESSAGE]";
+/// Header shown above each mirrored prompt. It marks the text as the input the
+/// agent received (not the agent's own reply), so a reader can tell the two
+/// apart in the channel.
+export const RECEIVED_MESSAGE_HEADER = ">>> Received user message";
 
-/// Prepend the system marker to an automated announcement.
-export function formatSystemAnnouncement(text: string): string {
-  return `${SYSTEM_MESSAGE_PREFIX}\n${text}`;
+/// Format an injected prompt for the channel: the header, then the body in
+/// italics (Slack mrkdwn uses _underscores_ for italic; * and ** do not work).
+export function formatReceivedMessage(text: string): string {
+  return `${RECEIVED_MESSAGE_HEADER}\n\n_${text}_`;
 }
 
 function defaultConfigPath(): string {
@@ -61,7 +61,7 @@ export async function announceToSlack(slug: string, text: string, opts: Announce
   const channel = await channelForSlug(slug, opts.configPath ?? defaultConfigPath(), c);
   if (!channel) return false;
   try {
-    await c.post(channel, formatSystemAnnouncement(text));
+    await c.post(channel, formatReceivedMessage(text));
     return true;
   } catch {
     return false;

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -5,6 +5,7 @@ import { routeSlackMessage, ChannelMapping } from "./inbound.js";
 import { formatTranscriptLines } from "./format.js";
 import { loadAgentsConfig } from "../agents/config.js";
 import { agentIdentity } from "../agents/identity.js";
+import { recordAnnounceSuppress } from "./announce-suppress.js";
 import { findSessionJsonl, pasteTmuxPrompt } from "../data.js";
 
 export interface BridgeOptions {
@@ -103,6 +104,10 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     if (ack) await ack();
     const decision = routeSlackMessage(event, mapping, botUserId);
     if (decision.action === "deliver") {
+      // Mark this relay so the daemon does not echo it back to the channel
+      // (it already appears there as that person's Slack message). Recorded
+      // before the paste so the marker is in place before UserPromptSubmit.
+      recordAnnounceSuppress(agentIdentity(decision.slug).sessionId);
       pasteTmuxPrompt(decision.slug, decision.text); // tmux session name == slug
     }
   });

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -1,0 +1,111 @@
+import { existsSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { SocketModeClient } from "@slack/socket-mode";
+import { SlackClient } from "./client.js";
+import { routeSlackMessage, ChannelMapping } from "./inbound.js";
+import { formatTranscriptLines } from "./format.js";
+import { loadAgentsConfig } from "../agents/config.js";
+import { agentIdentity } from "../agents/identity.js";
+import { findSessionJsonl, pasteTmuxPrompt } from "../data.js";
+
+export interface BridgeOptions {
+  botToken: string;
+  appToken: string;
+  configPath: string;
+  /// Transcript poll interval (ms). Default 1500.
+  pollMs?: number;
+}
+
+interface TailState {
+  slug: string;
+  sessionId: string;
+  channelId: string;
+  path?: string;
+  offset: number;
+}
+
+function readAppendedLines(path: string, offset: number): { objs: any[]; newOffset: number } {
+  const size = statSync(path).size;
+  if (size <= offset) return { objs: [], newOffset: size };
+  const fd = openSync(path, "r");
+  const buf = Buffer.alloc(size - offset);
+  readSync(fd, buf, 0, buf.length, offset);
+  closeSync(fd);
+  const text = buf.toString("utf-8");
+  const lastNl = text.lastIndexOf("\n");
+  if (lastNl < 0) return { objs: [], newOffset: offset };
+  const consumed = offset + Buffer.byteLength(text.slice(0, lastNl + 1), "utf-8");
+  const objs: any[] = [];
+  for (const line of text.slice(0, lastNl).split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      objs.push(JSON.parse(line));
+    } catch {
+      /* skip malformed */
+    }
+  }
+  return { objs, newOffset: consumed };
+}
+
+/// Run the bidirectional Slack bridge until the process exits.
+///   agent -> slack: tail each agent's transcript and post new assistant turns.
+///   slack -> agent: relay human channel messages into the agent's tmux session.
+export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
+  const pollMs = opts.pollMs ?? 1500;
+  const file = loadAgentsConfig(opts.configPath);
+  const agents = file.agents.filter((a) => a.slackChannel);
+  if (agents.length === 0) {
+    console.error("No agents with a slackChannel configured; nothing to bridge.");
+    return;
+  }
+
+  const client = new SlackClient(opts.botToken);
+  const botUserId = await client.botUserId();
+
+  const mapping: ChannelMapping = {};
+  const tails: TailState[] = [];
+  for (const a of agents) {
+    const channelId = await client.resolveChannelId(a.slackChannel!);
+    if (!channelId) {
+      console.error(`Slack channel not found for ${a.slug}: ${a.slackChannel}`);
+      continue;
+    }
+    mapping[channelId] = a.slug;
+    const sessionId = agentIdentity(a.slug).sessionId;
+    const path = findSessionJsonl(sessionId);
+    // Start at EOF so we mirror only new activity, not the whole backlog.
+    tails.push({ slug: a.slug, sessionId, channelId, path, offset: path ? statSync(path).size : 0 });
+  }
+
+  // agent -> slack
+  setInterval(async () => {
+    for (const t of tails) {
+      if (!t.path) {
+        t.path = findSessionJsonl(t.sessionId);
+        if (t.path) t.offset = statSync(t.path).size; // skip backlog on first discovery
+        continue;
+      }
+      if (!existsSync(t.path)) continue;
+      const { objs, newOffset } = readAppendedLines(t.path, t.offset);
+      t.offset = newOffset;
+      for (const post of formatTranscriptLines(objs)) {
+        try {
+          await client.post(t.channelId, post.text);
+        } catch (e) {
+          console.error(`post to ${t.slug} failed:`, e);
+        }
+      }
+    }
+  }, pollMs);
+
+  // slack -> agent
+  const socket = new SocketModeClient({ appToken: opts.appToken });
+  socket.on("message", async ({ event, ack }: any) => {
+    if (ack) await ack();
+    const decision = routeSlackMessage(event, mapping, botUserId);
+    if (decision.action === "deliver") {
+      pasteTmuxPrompt(decision.slug, decision.text); // tmux session name == slug
+    }
+  });
+  await socket.start();
+  console.error(`Slack bridge connected. Mirroring ${tails.length} agent(s).`);
+}

--- a/cli/src/slack/client.ts
+++ b/cli/src/slack/client.ts
@@ -1,0 +1,43 @@
+import { WebClient } from "@slack/web-api";
+
+/// Thin wrapper over the Slack Web API for what the bridge needs: identify the
+/// bot, post messages, and resolve channel names to ids.
+export class SlackClient {
+  private web: WebClient;
+
+  constructor(botToken: string) {
+    this.web = new WebClient(botToken);
+  }
+
+  async botUserId(): Promise<string | undefined> {
+    const r = await this.web.auth.test();
+    return r.user_id as string | undefined;
+  }
+
+  async post(channel: string, text: string): Promise<void> {
+    await this.web.chat.postMessage({
+      channel,
+      text,
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  }
+
+  /// Resolve "#name" / "name" to a channel id. Ids (C…/G…) are returned as-is.
+  async resolveChannelId(nameOrId: string): Promise<string | undefined> {
+    if (/^[CG][A-Z0-9]+$/.test(nameOrId)) return nameOrId;
+    const name = nameOrId.replace(/^#/, "");
+    let cursor: string | undefined;
+    do {
+      const r = await this.web.conversations.list({
+        types: "public_channel,private_channel",
+        limit: 1000,
+        cursor,
+      });
+      const found = (r.channels ?? []).find((c: any) => c.name === name);
+      if (found?.id) return found.id as string;
+      cursor = r.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+    return undefined;
+  }
+}

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -61,6 +61,16 @@ export function toolLabel(name: string, input: Record<string, any> = {}): string
   }
 }
 
+/// Tools whose label is emoji-prefixed prose (status / plan / questions), not a
+/// command. These render as plain text; everything else is a command-style
+/// label shown in a fenced code block.
+const PROSE_TOOLS = new Set(["EnterPlanMode", "ExitPlanMode", "AskUserQuestion"]);
+
+/// Wrap a command-style tool label in a triple-backtick code block.
+function fenceBlock(label: string): string {
+  return "```\n" + label + "\n```";
+}
+
 /// Render one assistant message's content blocks into Slack mrkdwn.
 function renderAssistantContent(content: any): string {
   if (typeof content === "string") return truncate(content);
@@ -75,9 +85,11 @@ function renderAssistantContent(content: any): string {
       case "thinking":
         if (block.thinking?.trim()) parts.push(`💭 _${truncate(block.thinking, 280)}_`);
         break;
-      case "tool_use":
-        parts.push("`" + toolLabel(block.name, block.input ?? {}) + "`");
+      case "tool_use": {
+        const label = toolLabel(block.name, block.input ?? {});
+        parts.push(PROSE_TOOLS.has(block.name) ? label : fenceBlock(label));
         break;
+      }
       default:
         break;
     }

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -1,0 +1,117 @@
+/// Formats Claude Code transcript (.jsonl) lines into Slack messages, porting
+/// the rendering lessons from Kanban Code's chat view (TranscriptReader):
+/// compact tool labels, merged consecutive assistant lines, summarized results.
+
+export interface SlackPost {
+  role: "assistant" | "user";
+  text: string; // Slack mrkdwn
+}
+
+const MAX_TEXT = 2800; // keep individual posts readable / within Slack block limits
+
+function truncate(s: string, max = MAX_TEXT): string {
+  const t = s.trim();
+  return t.length > max ? t.slice(0, max) + "…" : t;
+}
+
+/// Keep the last 3 path components (mirrors TranscriptReader.shortenPath).
+export function shortenPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length <= 3) return path;
+  return ".../" + parts.slice(-3).join("/");
+}
+
+/// Compact one-line label for a tool_use block (mirrors extractToolInfo +
+/// the special-tool cases of parseToolUse).
+export function toolLabel(name: string, input: Record<string, any> = {}): string {
+  switch (name) {
+    case "Bash": {
+      const display = input.description || String(input.command ?? "").slice(0, 200);
+      return `Bash(${display})`;
+    }
+    case "Read":
+    case "Write":
+    case "Edit":
+    case "NotebookEdit":
+      return `${name}(${shortenPath(String(input.file_path ?? ""))})`;
+    case "Grep": {
+      const pathPart = input.path ? ` in ${shortenPath(String(input.path))}` : "";
+      return `Grep("${input.pattern ?? ""}"${pathPart})`;
+    }
+    case "Glob":
+      return `Glob(${input.pattern ?? ""})`;
+    case "Agent":
+      return `Agent(${input.description || String(input.prompt ?? "").slice(0, 80)})`;
+    case "Skill":
+      return `Skill(${input.skill ?? ""})`;
+    case "TaskCreate":
+      return `TaskCreate(${input.subject ?? ""})`;
+    case "TaskUpdate":
+      return `TaskUpdate(${input.status ? `${input.taskId}: ${input.status}` : input.taskId ?? ""})`;
+    case "EnterPlanMode":
+      return "📋 entered plan mode";
+    case "ExitPlanMode":
+      return `📋 exit plan mode${input.plan ? `\n${truncate(String(input.plan), 1500)}` : ""}`;
+    case "AskUserQuestion": {
+      const qs = (input.questions ?? []).map((q: any) => `• ${q.question}`).join("\n");
+      return `❓ asking:\n${qs}`;
+    }
+    default:
+      return `${name}(…)`;
+  }
+}
+
+/// Render one assistant message's content blocks into Slack mrkdwn.
+function renderAssistantContent(content: any): string {
+  if (typeof content === "string") return truncate(content);
+  if (!Array.isArray(content)) return "";
+
+  const parts: string[] = [];
+  for (const block of content) {
+    switch (block?.type) {
+      case "text":
+        if (block.text?.trim()) parts.push(truncate(block.text));
+        break;
+      case "thinking":
+        if (block.thinking?.trim()) parts.push(`💭 _${truncate(block.thinking, 280)}_`);
+        break;
+      case "tool_use":
+        parts.push("`" + toolLabel(block.name, block.input ?? {}) + "`");
+        break;
+      default:
+        break;
+    }
+  }
+  return parts.join("\n");
+}
+
+function role(obj: any): string | undefined {
+  return obj?.type ?? obj?.message?.role;
+}
+
+/// Convert a batch of transcript lines into Slack posts, merging consecutive
+/// assistant lines (Claude writes thinking and the reply on separate lines) into
+/// one logical message. User turns and tool_result lines are not emitted here —
+/// the bridge posts agent activity; relayed human messages already appear in
+/// Slack, and automated prompts are announced separately.
+export function formatTranscriptLines(objs: any[]): SlackPost[] {
+  const posts: SlackPost[] = [];
+  let buffer: string[] = [];
+
+  const flush = () => {
+    const text = buffer.join("\n").trim();
+    if (text) posts.push({ role: "assistant", text });
+    buffer = [];
+  };
+
+  for (const obj of objs) {
+    if (role(obj) === "assistant") {
+      const rendered = renderAssistantContent(obj.message?.content ?? obj.content);
+      if (rendered) buffer.push(rendered);
+    } else {
+      flush();
+    }
+  }
+  flush();
+  return posts;
+}

--- a/cli/src/slack/inbound.ts
+++ b/cli/src/slack/inbound.ts
@@ -1,0 +1,55 @@
+/// Pure routing for inbound Slack messages: decide whether a message should be
+/// delivered to an agent's tmux session, and to which agent. Kept side-effect
+/// free so the loop-prevention and channel-mapping rules are unit-testable.
+
+/// Maps a Slack channel id to an agent slug.
+export type ChannelMapping = Record<string, string>;
+
+export interface SlackMessageEvent {
+  type?: string;
+  subtype?: string;
+  channel?: string;
+  user?: string;
+  text?: string;
+  bot_id?: string;
+}
+
+export type InboundDecision =
+  | { action: "ignore"; reason: string }
+  | { action: "deliver"; slug: string; text: string };
+
+/// Convert Slack mrkdwn to plain text for the agent: unwrap links/mentions and
+/// unescape HTML entities Slack adds.
+export function slackToPlain(text: string): string {
+  return text
+    .replace(/<(https?:[^|>]+)\|([^>]+)>/g, "$2 ($1)") // <url|label> -> label (url)
+    .replace(/<(https?:[^>]+)>/g, "$1") // <url> -> url
+    .replace(/<@[^>]+>/g, "") // drop user mentions
+    .replace(/<#[^|>]+\|([^>]+)>/g, "#$1") // channel mention -> #name
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .trim();
+}
+
+/// Decide what to do with a Slack message event. Ignores anything that would
+/// cause a loop (our own / any bot message), non-message events, edits/joins
+/// (subtypes), unmapped channels, and empties.
+export function routeSlackMessage(
+  event: SlackMessageEvent | undefined,
+  mapping: ChannelMapping,
+  botUserId?: string
+): InboundDecision {
+  if (!event || event.type !== "message") return { action: "ignore", reason: "not-a-message" };
+  if (event.subtype) return { action: "ignore", reason: `subtype:${event.subtype}` };
+  if (event.bot_id) return { action: "ignore", reason: "bot-message" };
+  if (botUserId && event.user === botUserId) return { action: "ignore", reason: "self" };
+
+  const slug = event.channel ? mapping[event.channel] : undefined;
+  if (!slug) return { action: "ignore", reason: "unmapped-channel" };
+
+  const text = slackToPlain(event.text ?? "");
+  if (!text) return { action: "ignore", reason: "empty" };
+
+  return { action: "deliver", slug, text };
+}

--- a/cli/src/slack/manifest.ts
+++ b/cli/src/slack/manifest.ts
@@ -1,0 +1,58 @@
+import { stringify } from "yaml";
+
+export interface ManifestOptions {
+  name?: string;
+  displayName?: string;
+}
+
+/// Generate a modern Slack app manifest (v2 YAML) for the agents bridge. Socket
+/// Mode (no public webhook), scoped to post and read messages in the channels
+/// it is invited to (private channels use the `groups:*` scopes + message.groups).
+export function slackAppManifest(opts: ManifestOptions = {}): string {
+  const manifest = {
+    display_information: {
+      name: opts.name ?? "LangWatch Agents",
+      description: "Observe and steer LangWatch's headless Claude Code agents",
+      background_color: "#1a1a2e",
+    },
+    features: {
+      bot_user: {
+        display_name: opts.displayName ?? "langwatch-agents",
+        always_online: true,
+      },
+    },
+    oauth_config: {
+      scopes: {
+        bot: [
+          "chat:write",
+          "channels:history",
+          "groups:history",
+          "channels:read",
+          "groups:read",
+          "app_mentions:read",
+          "users:read",
+        ],
+      },
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: ["message.channels", "message.groups", "app_mention"],
+      },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+  return stringify(manifest);
+}
+
+export const MANIFEST_INSTRUCTIONS = `To create the Slack app:
+  1. Go to https://api.slack.com/apps  ->  "Create New App"  ->  "From a manifest"
+  2. Pick the workspace, paste the manifest above, create the app.
+  3. Under "Basic Information" -> "App-Level Tokens", generate a token with the
+     "connections:write" scope. That is your SLACK_APP_TOKEN (xapp-...).
+  4. Under "Install App", install to the workspace. Copy the Bot User OAuth Token.
+     That is your SLACK_BOT_TOKEN (xoxb-...).
+  5. Invite the bot to each agent's private channel: /invite @langwatch-agents
+  6. Map each channel to an agent via the agents config (slackChannel: "#channel" or the channel id).`;

--- a/cli/src/slack/manifest.ts
+++ b/cli/src/slack/manifest.ts
@@ -23,14 +23,24 @@ export function slackAppManifest(opts: ManifestOptions = {}): string {
     },
     oauth_config: {
       scopes: {
+        // Full read + write in any channel the bot is invited to (public,
+        // private, DMs, group DMs), plus posting to public channels it is not a
+        // member of. Agents read broader channels (e.g. #dev) on demand via the
+        // Slack CLI with this same bot token.
         bot: [
-          "chat:write",
-          "channels:history",
-          "groups:history",
           "channels:read",
+          "channels:history",
           "groups:read",
-          "app_mentions:read",
+          "groups:history",
+          "im:read",
+          "im:history",
+          "mpim:read",
+          "mpim:history",
+          "chat:write",
+          "chat:write.public",
+          "files:read",
           "users:read",
+          "app_mentions:read",
         ],
       },
     },
@@ -54,5 +64,8 @@ export const MANIFEST_INSTRUCTIONS = `To create the Slack app:
      "connections:write" scope. That is your SLACK_APP_TOKEN (xapp-...).
   4. Under "Install App", install to the workspace. Copy the Bot User OAuth Token.
      That is your SLACK_BOT_TOKEN (xoxb-...).
-  5. Invite the bot to each agent's private channel: /invite @langwatch-agents
-  6. Map each channel to an agent via the agents config (slackChannel: "#channel" or the channel id).`;
+  5. Invite the bot to each agent's private channel, and to any channel you want
+     it to read/post in (e.g. #dev):  /invite @langwatch-agents
+  6. Map each AGENT channel to an agent in the agents config (slackChannel). Other
+     channels the bot is in (like #dev) are readable/writable on demand by agents,
+     they are just not relayed into a session.`;

--- a/cli/src/slack/post.ts
+++ b/cli/src/slack/post.ts
@@ -1,0 +1,24 @@
+import { SlackClient } from "./client.js";
+
+export interface PostResult {
+  ok: boolean;
+  channelId?: string;
+  error?: string;
+}
+
+/// Resolve a channel name/id and post text as the bot. Returns a structured
+/// result so callers can print a clear, actionable error — most importantly
+/// `not_in_channel`, which means the bot must be invited to that channel first.
+export async function postToSlack(client: SlackClient, channel: string, text: string): Promise<PostResult> {
+  const channelId = await client.resolveChannelId(channel);
+  if (!channelId) {
+    return { ok: false, error: `channel not found or not visible to the bot: ${channel}` };
+  }
+  try {
+    await client.post(channelId, text);
+    return { ok: true, channelId };
+  } catch (e: any) {
+    const error = e?.data?.error || e?.message || String(e);
+    return { ok: false, channelId, error };
+  }
+}

--- a/cli/src/uuid.ts
+++ b/cli/src/uuid.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+
+/// Namespace for deriving deterministic agent session ids. Fixed forever so a
+/// given agent slug always maps to the same Claude session UUID.
+export const AGENT_UUID_NAMESPACE = "b0c0ffee-a9e0-5e1d-9c0a-1a2b3c4d5e6f";
+
+function parseUuid(uuid: string): Buffer {
+  const hex = uuid.replace(/-/g, "");
+  if (hex.length !== 32) throw new Error(`Invalid UUID: ${uuid}`);
+  return Buffer.from(hex, "hex");
+}
+
+function formatUuid(bytes: Buffer): string {
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+/// RFC 4122 v5 (SHA-1, name-based) UUID. Deterministic: same name + namespace
+/// always yields the same UUID.
+export function uuidv5(name: string, namespace = AGENT_UUID_NAMESPACE): string {
+  const ns = parseUuid(namespace);
+  const hash = createHash("sha1")
+    .update(ns)
+    .update(Buffer.from(name, "utf8"))
+    .digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  return formatUuid(bytes);
+}

--- a/specs/sessions/headless-reconcile.feature
+++ b/specs/sessions/headless-reconcile.feature
@@ -1,0 +1,59 @@
+Feature: Headless agent session reconciliation (CLI)
+  As an operator running Kanban Code headless on a server (no macOS app)
+  I want long-lived agent sessions defined declaratively and reconciled idempotently
+  So that sessions are stable, survive reboots, and never get duplicated
+
+  Background:
+    Given an agents config listing agents by readable slug, each with target repos
+    And canonical repo clones are provisioned and kept clean + current externally (not by Kanban Code)
+
+  Scenario: Stable identity is derived from the readable slug
+    When the reconciler computes the identity for an agent slug
+    Then the Claude session id is a deterministic UUIDv5 of the slug
+    And the same slug always yields the same session id
+    And the session display name (--name), tmux session name, kanban card name and worktree name are all the slug
+
+  Scenario: First reconcile launches once
+    Given no tmux session, card, or worktree exists for the agent
+    When the reconciler runs
+    Then a per-agent git worktree of each target repo is created from the canonical clone
+    And a tmux session named after the slug is created
+    And Claude is launched with "--session-id <uuid> --name <slug>" in the workspace
+    And a card linking the session and tmux session is written to links.json
+
+  Scenario: Re-running while healthy is a true no-op
+    Given the agent is already running and healthy
+    When the reconciler runs again
+    Then no second tmux session, card, or worktree is created
+    And the live Claude session is left running and is not restarted
+    And links.json is not rewritten when nothing meaningful changed
+
+  Scenario: A dead session is resumed, not started fresh
+    Given the card and worktree still exist but the tmux session was killed
+    And a transcript for the session id exists on disk
+    When the reconciler runs
+    Then a tmux session is recreated
+    And Claude is started with "--resume <uuid>" in the existing worktree
+    And prior conversation history is preserved
+
+  Scenario: Kanban Code does not clean or clone repos
+    Given a canonical clone is missing
+    When the reconciler runs for that agent
+    Then it fails loudly rather than cloning the repo
+    And the reconciler never stashes, pulls, or resets any repo (that is the deployer's IaC job)
+
+  Scenario: The working directory is always a worktree
+    When Claude is launched for an agent
+    Then its working directory is the per-agent workspace of worktrees
+    And it is never the canonical clone, so the agent cannot dirty that clone
+
+  Scenario: Adding an agent provisions only the new one
+    Given two agents are configured and only the first is running
+    When the reconciler runs
+    Then the second agent is launched and the first is left untouched
+
+  Scenario: Pruning tears down a de-configured agent
+    Given an agent is running whose workspace is the managed path but whose slug is no longer configured
+    When the reconciler runs with pruning enabled
+    Then that agent's tmux session is killed, its card is archived, and its workspace is removed
+    And cards whose worktree path is not the managed path are never touched

--- a/specs/slack/slack-bridge.feature
+++ b/specs/slack/slack-bridge.feature
@@ -17,11 +17,19 @@ Feature: Bidirectional Slack bridge for agent observability and steering
     And consecutive assistant lines (thinking + reply) are merged into one logical message
     And tool results are summarized rather than dumped in full
 
-  Scenario: Every injected prompt is mirrored and marked, human relays are not
-    When any prompt is injected into the agent (a scheduled nudge, a self-compact, an auto-sent queued prompt, or a manual kanban send on the box)
-    Then it is posted to the channel under the header ">>> Received user message" with the body in italics
+  Scenario: A prompt is mirrored only once the agent actually receives it
+    When a prompt is injected into the agent (a scheduled nudge, a self-compact, an auto-sent queued prompt, or a manual kanban send on the box)
+    Then it is NOT posted to the channel merely because the keystrokes were pasted into the tmux pane
+    And it is posted only when the agent's UserPromptSubmit hook confirms the prompt was actually received
+    And it is posted under the header ">>> Received user message" with the body in italics, using the exact text the agent received
+    And so a paste that never becomes a submitted prompt (e.g. the session was mid-restart) is never falsely announced as received
+
+  Scenario: Human relays from Slack are not echoed back
     When a human's Slack message is relayed into the agent
-    Then it is NOT re-posted by the bridge (it already appears as that person's Slack message)
+    Then the bridge records a skip-announce marker for that agent's session before pasting it
+    And when the relayed prompt's UserPromptSubmit arrives, the daemon consumes the marker and does NOT re-post it (it already appears as that person's Slack message)
+    And the marker is consumed by exactly one received prompt, so several rapid relays each suppress their own echo
+    And the marker expires after a TTL, so a relay that never gets submitted cannot accidentally suppress a later automated prompt
     And so the marker only ever appears on injected prompts, letting a reader tell the agent's input apart from its own replies
 
   Scenario: A team member steers the agent from Slack

--- a/specs/slack/slack-bridge.feature
+++ b/specs/slack/slack-bridge.feature
@@ -38,6 +38,12 @@ Feature: Bidirectional Slack bridge for agent observability and steering
     Then the message text is sent into the agent's tmux session as a user prompt
     And messages the bridge itself posted (bot messages) are ignored to avoid loops
 
+  Scenario: An agent can announce to a team channel on request
+    Given the agent is asked to announce something (e.g. a finished PR) in a shared channel like #dev
+    When it runs "kanban slack post #dev <message>"
+    Then the bot posts the message to that channel using its bot token
+    And if the bot is not a member of the channel, the command fails with a clear "invite the bot" error instead of silently dropping it
+
   Scenario: Multiple people observe and steer the same agent
     Given several team members are in the channel
     Then all of them see the same agent activity

--- a/specs/slack/slack-bridge.feature
+++ b/specs/slack/slack-bridge.feature
@@ -1,0 +1,42 @@
+Feature: Bidirectional Slack bridge for agent observability and steering
+  As a team member
+  I want each headless agent mirrored into a Slack channel I can read and post into
+  So that anyone can follow, unblock, steer, or give feedback to an agent
+
+  Background:
+    Given a Slack app installed via manifest with Socket Mode enabled
+    And one Slack bot backs all agent channels
+    And each agent maps to exactly one channel by channel id
+    And the bridge runs on the box and connects to Slack over a websocket (no public webhook)
+
+  Scenario: Agent activity is mirrored to Slack
+    When the agent produces an assistant message
+    Then it is posted to the agent's channel
+    When the agent runs a tool call
+    Then a compact human-readable line is posted, e.g. "Bash(npm test)", "Read(.../path)", "Edit(...)"
+    And consecutive assistant lines (thinking + reply) are merged into one logical message
+    And tool results are summarized rather than dumped in full
+
+  Scenario: Automated prompts are mirrored, human relays are not
+    When the runtime auto-sends a queued prompt (e.g. an auto-compact warning) to the agent
+    Then that prompt is posted to the channel
+    When a scheduled nudge is delivered to the agent
+    Then that nudge is posted to the channel
+    When a human's Slack message is relayed into the agent
+    Then it is NOT re-posted by the bridge (it already appears as that person's Slack message)
+
+  Scenario: A team member steers the agent from Slack
+    Given a team member posts a message in the agent's channel
+    When the bridge receives the Slack message event
+    Then the message text is sent into the agent's tmux session as a user prompt
+    And messages the bridge itself posted (bot messages) are ignored to avoid loops
+
+  Scenario: Multiple people observe and steer the same agent
+    Given several team members are in the channel
+    Then all of them see the same agent activity
+    And any of them can post a steering message, delivered to the agent in order
+
+  Scenario: Formatting reuses Kanban Code chat-rendering lessons
+    Then assistant text, tool_use, tool_result, thinking, plan-mode and ask-user-question blocks
+      are parsed from the transcript the same way the Kanban Code chat view parses them
+    And long content is truncated for Slack readability

--- a/specs/slack/slack-bridge.feature
+++ b/specs/slack/slack-bridge.feature
@@ -17,14 +17,12 @@ Feature: Bidirectional Slack bridge for agent observability and steering
     And consecutive assistant lines (thinking + reply) are merged into one logical message
     And tool results are summarized rather than dumped in full
 
-  Scenario: Automated prompts are mirrored and marked, human relays are not
-    When the runtime auto-sends a queued prompt (e.g. an auto-compact warning) to the agent
-    Then that prompt is posted to the channel prefixed with "[SYSTEM MESSAGE]"
-    When a scheduled nudge is delivered to the agent
-    Then that nudge is posted to the channel prefixed with "[SYSTEM MESSAGE]"
+  Scenario: Every injected prompt is mirrored and marked, human relays are not
+    When any prompt is injected into the agent (a scheduled nudge, a self-compact, an auto-sent queued prompt, or a manual kanban send on the box)
+    Then it is posted to the channel under the header ">>> Received user message" with the body in italics
     When a human's Slack message is relayed into the agent
     Then it is NOT re-posted by the bridge (it already appears as that person's Slack message)
-    And so the "[SYSTEM MESSAGE]" marker only ever appears on system-originated traffic, letting a reader tell injected prompts apart from the agent's own replies
+    And so the marker only ever appears on injected prompts, letting a reader tell the agent's input apart from its own replies
 
   Scenario: A team member steers the agent from Slack
     Given a team member posts a message in the agent's channel

--- a/specs/slack/slack-bridge.feature
+++ b/specs/slack/slack-bridge.feature
@@ -17,13 +17,14 @@ Feature: Bidirectional Slack bridge for agent observability and steering
     And consecutive assistant lines (thinking + reply) are merged into one logical message
     And tool results are summarized rather than dumped in full
 
-  Scenario: Automated prompts are mirrored, human relays are not
+  Scenario: Automated prompts are mirrored and marked, human relays are not
     When the runtime auto-sends a queued prompt (e.g. an auto-compact warning) to the agent
-    Then that prompt is posted to the channel
+    Then that prompt is posted to the channel prefixed with "[SYSTEM MESSAGE]"
     When a scheduled nudge is delivered to the agent
-    Then that nudge is posted to the channel
+    Then that nudge is posted to the channel prefixed with "[SYSTEM MESSAGE]"
     When a human's Slack message is relayed into the agent
     Then it is NOT re-posted by the bridge (it already appears as that person's Slack message)
+    And so the "[SYSTEM MESSAGE]" marker only ever appears on system-originated traffic, letting a reader tell injected prompts apart from the agent's own replies
 
   Scenario: A team member steers the agent from Slack
     Given a team member posts a message in the agent's channel

--- a/specs/slack/slack-bridge.feature
+++ b/specs/slack/slack-bridge.feature
@@ -46,4 +46,6 @@ Feature: Bidirectional Slack bridge for agent observability and steering
   Scenario: Formatting reuses Kanban Code chat-rendering lessons
     Then assistant text, tool_use, tool_result, thinking, plan-mode and ask-user-question blocks
       are parsed from the transcript the same way the Kanban Code chat view parses them
+    And a command-style tool call (Bash, Read, TaskCreate, ...) is shown in a fenced ``` code block
+    And emoji/prose tool labels (entered/exit plan mode, asking a question) are shown as plain text, not fenced
     And long content is truncated for Slack readability

--- a/specs/system/headless-runtime.feature
+++ b/specs/system/headless-runtime.feature
@@ -1,0 +1,45 @@
+Feature: Headless runtime engine (no macOS app)
+  As an operator running agents headless on a server
+  I want the always-on engine (hooks, auto-send, auto-compaction) to run as a daemon
+  So that agents keep working forever without the macOS Kanban Code app open
+
+  Background:
+    Given the headless kanban daemon is running on the box
+    And Claude Code hooks and the statusline script are installed for the agents
+
+  Scenario: Hooks are installed headlessly
+    When the daemon installs hooks
+    Then ~/.claude/settings.json registers Stop, Notification, SessionStart, SessionEnd and UserPromptSubmit hooks pointing at ~/.kanban-code/hook.sh
+    And a statusline command writes context usage to ~/.kanban-code/context/<sessionId>.json
+    And hook events are appended to ~/.kanban-code/hook-events.jsonl
+    And re-installing is idempotent (no duplicate hook entries)
+
+  Scenario: Queued prompts auto-send when the agent goes idle
+    Given a prompt is queued for an agent with sendAutomatically true
+    When the agent emits a Stop hook event and no user prompt arrives shortly after
+    Then the queued prompt is sent to the agent's tmux session
+    And it is removed from the queue
+
+  Scenario: A recent user prompt pauses auto-send
+    Given a prompt is queued for an agent
+    When a UserPromptSubmit event is recorded shortly after the Stop
+    Then the queued prompt is not auto-sent (a human or relay is already driving)
+
+  Scenario: Auto-compaction protects long-running sessions
+    Given an agent has been running for a long time
+    When its current context usage crosses 500k tokens
+    Then a prompt instructing it to self-compact is queued
+    When usage crosses the hard threshold (750k)
+    Then "/compact" is sent to the agent automatically
+    And a stale self-compact warning is dropped if context already dropped back below its threshold
+
+  Scenario: The session runs forever across compactions
+    Given the agent has compacted multiple times
+    Then the same Claude session id is retained
+    And the agent continues without a human restart
+
+  Scenario: Reboot and resume survival
+    Given the box reboots, wakes from hibernate, or a spot instance is reclaimed and restored
+    When the box finishes booting
+    Then reconcile-on-boot resumes every configured agent with "--resume <uuid>"
+    And the daemon is restarted by the service manager


### PR DESCRIPTION
## What

Makes Kanban Code able to run **long-lived Claude Code agents headless on a server** (no macOS app), so we can run our software-development-lifecycle chores as always-on agents. This is the runtime layer; the AWS box, agent definitions and schedules live as IaC in `langwatch-saas`.

## New CLI surface

| Command | Purpose |
|---|---|
| `kanban launch <slug>` | Launch or resume an agent session in tmux with a stable, readable identity |
| `kanban reconcile` | Idempotently ensure each configured agent's worktree + session + card |
| `kanban daemon` | Always-on engine: auto-send queued prompts on Stop, auto-compact long sessions |
| `kanban hooks install` | Install Claude hooks + statusline headlessly |
| `kanban slack manifest` | Print a Socket Mode app manifest + setup steps |
| `kanban slack bridge` | Mirror agent activity to Slack and relay channel messages back to the agent |
| `kanban send --announce` | Also post an automated send to the agent's Slack channel |

## Design highlights

- **Stable, readable identity.** An agent slug (e.g. `dependabot-scout`) deterministically maps to a Claude session id via UUIDv5; the slug is also the `--name`, tmux session, card name and worktree name. `claude --session-id` requires a UUID, so we derive it from the slug but keep everything human-facing readable.
- **Idempotent reconciliation.** Re-running never duplicates a session, card, or worktree; a dead session is resumed via `--resume`, a live one is left alone. Cards are written byte-compatibly with the Swift `CoordinationStore` (container, sorted keys, ISO8601, atomic, daily backups).
- **Worktree-only.** An agent's working directory is always its per-agent worktree workspace, never the canonical clone, so it can never dirty that clone. Keeping canonical clones clean and current is the deployer's IaC job, not Kanban Code's; the reconciler errors loudly if a clone is missing rather than cloning or resetting anything.
- **Headless engine.** Ports the macOS app's `BackgroundOrchestrator` + auto-compaction to a Node daemon: tails `hook-events.jsonl` to auto-send queued prompts after a Stop (paused by a recent user prompt), and polls context usage to queue self-compact warnings (500k/600k/700k) and send `/compact` (750k), dropping stale warnings once context drops back down.
- **Slack bridge.** Socket Mode (no public webhook). Agent activity is mirrored to a channel using a TS port of the chat view's transcript formatting (compact tool labels like `Bash(npm test)`, merged consecutive assistant lines). Human channel messages are relayed into the agent's tmux session; the bot's own messages are ignored to avoid loops; automated sends (scheduled nudges, auto-compact, auto-sent prompts) are announced, human relays are not (they already appear in Slack).

## Tests

122 tests pass, with **real tmux and real git integration** (no mocks for the tmux / git / filesystem layers): launch -> idempotent no-op -> resume; reconcile worktree creation + the structural worktree guarantee + prune; hook install idempotency; daemon auto-send / pause-on-prompt / drop-stale / auto-compact; Slack transcript formatting and inbound routing; manifest scopes.

Specs added under `specs/sessions/headless-reconcile.feature`, `specs/system/headless-runtime.feature`, `specs/slack/slack-bridge.feature`.
