### PR TITLE
Mirror codex out-of-credits to the channel

### DIFF
--- a/cli/src/agents/launch.ts
+++ b/cli/src/agents/launch.ts
@@ -3,6 +3,7 @@ import {
   hasTmuxSession,
   createTmuxSession,
   findSessionJsonl,
+  findCodexRollout,
   readLinks,
 } from "../data.js";
 import { upsertCard, isoNow } from "../cards.js";
@@ -48,10 +49,11 @@ const DEFAULT_OVERRIDES: ManualOverrides = {
 /// Idempotently ensure an agent's session is running in tmux and its kanban card
 /// reflects reality. Decides launch vs resume vs no-op:
 ///   - tmux session already alive            -> no-op (never restart a live agent)
-///   - runtime can resume + transcript exists -> resume
+///   - runtime can resume + prior session     -> resume
 ///   - otherwise                              -> fresh launch
-/// Codex mints its own session id and the reviewer is per-PR, so it always
-/// launches fresh (canResume=false); tmux keeps it alive between prompts.
+/// Claude finds its prior session by our stable id (the transcript jsonl);
+/// Codex mints its own id, so its prior session is detected by the newest
+/// rollout under the launch cwd and resumed with `resume --last`.
 export function ensureAgentSession(
   identity: AgentIdentity,
   opts: LaunchOptions
@@ -61,7 +63,11 @@ export function ensureAgentSession(
   const skipPerms = opts.skipPermissions ?? true;
 
   const tmuxAlive = hasTmuxSession(identity.tmuxName);
-  const sessionExists = spec.canResume && !!findSessionJsonl(identity.sessionId);
+  const sessionExists =
+    spec.canResume &&
+    (identity.runtime === "codex"
+      ? !!findCodexRollout(opts.cwd)
+      : !!findSessionJsonl(identity.sessionId));
 
   let action: LaunchAction;
   let command: string | undefined;

--- a/cli/src/agents/runtime.ts
+++ b/cli/src/agents/runtime.ts
@@ -30,9 +30,10 @@ export interface RuntimeSpec {
   bin: string;
   /// Build the argv after the binary.
   buildArgs(input: BuildArgsInput): string[];
-  /// Whether this runtime can resume a prior session by our session id. Claude
-  /// can (--resume <uuid>); Codex generates its own id and the headless reviewer
-  /// is per-PR, so we always launch it fresh and rely on tmux to keep it alive.
+  /// Whether this runtime can resume a prior session. Claude resumes by our
+  /// stable session id (--resume <uuid>); Codex mints its own id but can resume
+  /// the most recent session for the launch cwd (resume --last), so a box
+  /// restart keeps the agent's context instead of starting from scratch.
   canResume: boolean;
   /// Whether the daemon's context-threshold self-compaction applies. Codex
   /// auto-compacts on its own and exposes no context introspection, so off.
@@ -58,19 +59,28 @@ const claude: RuntimeSpec = {
 
 const codex: RuntimeSpec = {
   bin: "codex",
-  canResume: false,
+  canResume: true,
   selfCompact: false,
   configDirName: ".codex",
-  buildArgs({ skipPermissions, model }) {
+  buildArgs({ resume, skipPermissions, model }) {
     // --no-alt-screen keeps Codex inline so tmux send-keys paste works (no TUI
     // alt-screen). The bypass flags are Codex's equivalent of Claude's
     // --dangerously-skip-permissions; --dangerously-bypass-hook-trust skips the
-    // interactive hook-trust gate so our hooks run unattended.
+    // interactive hook-trust gate so our hooks run unattended. These are global
+    // flags and must come before the `resume` subcommand.
     const args = ["--no-alt-screen"];
     if (skipPermissions) {
       args.push("--dangerously-bypass-approvals-and-sandbox", "--dangerously-bypass-hook-trust");
     }
-    if (model) args.push("-m", model);
+    if (resume) {
+      // Continue the most recent session for the launch cwd. Codex filters
+      // resume candidates by cwd, and each agent runs in its own workspace, so
+      // --last reliably picks this agent's session. The model is whatever the
+      // resumed session already used, so it is not re-passed here.
+      args.push("resume", "--last");
+    } else if (model) {
+      args.push("-m", model);
+    }
     return args;
   },
 };

--- a/cli/src/codex-runtime.test.ts
+++ b/cli/src/codex-runtime.test.ts
@@ -37,7 +37,7 @@ describe("runtime descriptor", () => {
   test("codex builds inline + full-auto bypass args and never uses session-id", () => {
     const x = runtimeSpec("codex");
     assert.equal(x.bin, "codex");
-    assert.equal(x.canResume, false);
+    assert.equal(x.canResume, true);
     assert.equal(x.selfCompact, false);
     const args = x.buildArgs({ sessionId: "sid", slug: "agent", resume: false, skipPermissions: true, model: "gpt-5.5" });
     assert.deepEqual(args, [
@@ -49,6 +49,22 @@ describe("runtime descriptor", () => {
     ]);
     assert.ok(!args.includes("--session-id"));
     assert.ok(!args.includes("--resume"));
+  });
+
+  test("codex resume keeps the global flags before the subcommand and uses resume --last", () => {
+    const x = runtimeSpec("codex");
+    const args = x.buildArgs({ sessionId: "sid", slug: "agent", resume: true, skipPermissions: true });
+    assert.deepEqual(args, [
+      "--no-alt-screen",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--dangerously-bypass-hook-trust",
+      "resume",
+      "--last",
+    ]);
+    // The bypass flags must precede the subcommand (they are global, not
+    // resume-subcommand options), and no model is re-passed on resume.
+    assert.ok(args.indexOf("--dangerously-bypass-approvals-and-sandbox") < args.indexOf("resume"));
+    assert.ok(!args.includes("-m"));
   });
 
   test("isRuntime guards the union", () => {

--- a/cli/src/codex-runtime.test.ts
+++ b/cli/src/codex-runtime.test.ts
@@ -81,6 +81,41 @@ describe("formatCodexRolloutLines", () => {
     assert.equal(posts[3].text, "No blockers; 2 nits.");
     assert.ok(posts.slice(1).every((p) => p.role === "assistant"));
   });
+
+  test("mirrors an out-of-credits failure when a turn produces no output", () => {
+    const objs = [
+      { type: "event_msg", payload: { type: "user_message", message: "Please review PR 4288.", images: [] } },
+      { type: "event_msg", payload: { type: "task_started" } },
+      {
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          rate_limits: { plan_type: "plus", credits: { has_credits: false, balance: "0" } },
+        },
+      },
+      { type: "event_msg", payload: { type: "task_complete", last_agent_message: null } },
+    ];
+    const posts = formatCodexRolloutLines(objs);
+    assert.equal(posts.length, 2);
+    assert.equal(posts[0].role, "user");
+    assert.match(posts[1].text, /out of credits/i);
+    assert.match(posts[1].text, /plan: plus, balance 0/);
+    assert.match(posts[1].text, /chatgpt\.com\/codex\/settings\/usage/);
+  });
+
+  test("does not warn when a turn completes with output", () => {
+    const objs = [
+      {
+        type: "event_msg",
+        payload: { type: "token_count", rate_limits: { plan_type: "plus", credits: { has_credits: true, balance: "5" } } },
+      },
+      { type: "event_msg", payload: { type: "agent_message", message: "Reviewed, LGTM." } },
+      { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Reviewed, LGTM." } },
+    ];
+    const posts = formatCodexRolloutLines(objs);
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].text, "Reviewed, LGTM.");
+  });
 });
 
 describe("agents config runtime field", () => {

--- a/cli/src/codex-runtime.test.ts
+++ b/cli/src/codex-runtime.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 
 import { runtimeSpec, isRuntime } from "./agents/runtime.js";
 import { formatCodexRolloutLines } from "./slack/format.js";
+import { writeThreadRoot, readThreadRoot } from "./slack/thread-root.js";
 import { parseAgentsConfig } from "./agents/config.js";
 import { agentIdentity } from "./agents/identity.js";
 import { ensureAgentSession } from "./agents/launch.js";
@@ -65,6 +66,27 @@ describe("runtime descriptor", () => {
     // resume-subcommand options), and no model is re-passed on resume.
     assert.ok(args.indexOf("--dangerously-bypass-approvals-and-sandbox") < args.indexOf("resume"));
     assert.ok(!args.includes("-m"));
+  });
+
+  test("thread root round-trips per slug and shares across the announce/bridge split", () => {
+    const home = mkdtempSync(join(tmpdir(), "kanban-threads-"));
+    const prev = process.env.KANBAN_CODE_HOME;
+    process.env.KANBAN_CODE_HOME = home;
+    try {
+      assert.equal(readThreadRoot("dependabot-scout"), undefined);
+      // daemon announce records the root; bridge reads it for assistant turns
+      writeThreadRoot("dependabot-scout", "1700000000.000100");
+      assert.equal(readThreadRoot("dependabot-scout"), "1700000000.000100");
+      // a new prompt overwrites the root (start of a new thread)
+      writeThreadRoot("dependabot-scout", "1700000999.000200");
+      assert.equal(readThreadRoot("dependabot-scout"), "1700000999.000200");
+      // roots are per-agent
+      assert.equal(readThreadRoot("pr-reviewer"), undefined);
+    } finally {
+      if (prev === undefined) delete process.env.KANBAN_CODE_HOME;
+      else process.env.KANBAN_CODE_HOME = prev;
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test("isRuntime guards the union", () => {

--- a/cli/src/slack/announce.ts
+++ b/cli/src/slack/announce.ts
@@ -12,6 +12,7 @@ import { homedir } from "node:os";
 // re-exported here so the Claude announce path and existing imports stay stable.
 export { RECEIVED_MESSAGE_HEADER, formatReceivedMessage } from "./format.js";
 import { formatReceivedMessage } from "./format.js";
+import { writeThreadRoot } from "./thread-root.js";
 
 function defaultConfigPath(): string {
   return process.env.KANBAN_AGENTS_CONFIG || join(homedir(), ".kanban-code", "agents.yaml");
@@ -55,7 +56,10 @@ export async function announceToSlack(slug: string, text: string, opts: Announce
   const channel = await channelForSlug(slug, opts.configPath ?? defaultConfigPath(), c);
   if (!channel) return false;
   try {
-    await c.post(channel, formatReceivedMessage(text));
+    // The received-prompt message opens the thread for this turn; record its
+    // ts so the bridge threads the agent's assistant turns under it.
+    const ts = await c.post(channel, formatReceivedMessage(text));
+    if (ts) writeThreadRoot(slug, ts);
     return true;
   } catch {
     return false;

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -27,6 +27,10 @@ interface TailState {
   channelId: string;
   path?: string;
   offset: number;
+  /// ts of the current thread root (the last received-prompt message). Agent
+  /// activity for the turn is posted as replies under it so tool calls and
+  /// messages don't pile up in the channel root.
+  threadTs?: string;
 }
 
 function readAppendedLines(path: string, offset: number): { objs: any[]; newOffset: number } {
@@ -129,7 +133,14 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
         // in the channel as their message).
         if (t.runtime === "codex" && post.role === "user" && consumeRelayEcho(t.slug, post.text)) continue;
         try {
-          await client.post(t.channelId, post.text);
+          if (post.role === "user") {
+            // A received prompt opens a new thread; the agent's work for this
+            // turn replies under it instead of cluttering the channel root.
+            const ts = await client.post(t.channelId, post.text);
+            if (ts) t.threadTs = ts;
+          } else {
+            await client.post(t.channelId, post.text, t.threadTs);
+          }
         } catch (e) {
           console.error(`post to ${t.slug} failed:`, e);
         }

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -8,6 +8,7 @@ import { loadAgentsConfig } from "../agents/config.js";
 import { agentIdentity } from "../agents/identity.js";
 import { Runtime } from "../agents/runtime.js";
 import { recordAnnounceSuppress } from "./announce-suppress.js";
+import { writeThreadRoot, readThreadRoot } from "./thread-root.js";
 import { findSessionJsonl, findCodexRollout, pasteTmuxPrompt } from "../data.js";
 
 export interface BridgeOptions {
@@ -27,10 +28,6 @@ interface TailState {
   channelId: string;
   path?: string;
   offset: number;
-  /// ts of the current thread root (the last received-prompt message). Agent
-  /// activity for the turn is posted as replies under it so tool calls and
-  /// messages don't pile up in the channel root.
-  threadTs?: string;
 }
 
 function readAppendedLines(path: string, offset: number): { objs: any[]; newOffset: number } {
@@ -136,10 +133,12 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
           if (post.role === "user") {
             // A received prompt opens a new thread; the agent's work for this
             // turn replies under it instead of cluttering the channel root.
+            // (Claude's received prompt is posted by the daemon's announce,
+            // which records the same root, so Claude threads too.)
             const ts = await client.post(t.channelId, post.text);
-            if (ts) t.threadTs = ts;
+            if (ts) writeThreadRoot(t.slug, ts);
           } else {
-            await client.post(t.channelId, post.text, t.threadTs);
+            await client.post(t.channelId, post.text, readThreadRoot(t.slug));
           }
         } catch (e) {
           console.error(`post to ${t.slug} failed:`, e);

--- a/cli/src/slack/client.ts
+++ b/cli/src/slack/client.ts
@@ -14,13 +14,17 @@ export class SlackClient {
     return r.user_id as string | undefined;
   }
 
-  async post(channel: string, text: string): Promise<void> {
-    await this.web.chat.postMessage({
+  /// Post a message and return its ts (usable as a thread parent). Pass
+  /// threadTs to reply inside an existing thread.
+  async post(channel: string, text: string, threadTs?: string): Promise<string | undefined> {
+    const r = await this.web.chat.postMessage({
       channel,
       text,
+      thread_ts: threadTs,
       unfurl_links: false,
       unfurl_media: false,
     });
+    return r.ts as string | undefined;
   }
 
   /// Resolve "#name" / "name" to a channel id. Ids (C…/G…) are returned as-is.

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -147,9 +147,15 @@ export function formatTranscriptLines(objs: any[]): SlackPost[] {
 /// a received prompt is announced (the Claude path uses the UserPromptSubmit
 /// hook). Event shapes: event_msg{payload:{type:"user_message",message}} for an
 /// injected prompt, {type:"agent_message",message} for assistant text, and
-/// {type:"exec_command_begin",command} for shell runs.
+/// {type:"exec_command_begin",command} for shell runs. When Codex is out of
+/// credits the turn ends with task_complete{last_agent_message:null} and the
+/// preceding token_count carries rate_limits.credits.has_credits=false; we
+/// mirror that as an explicit warning so the channel does not sit on a bare
+/// "Received user message" with no explanation.
 export function formatCodexRolloutLines(objs: any[]): SlackPost[] {
   const posts: SlackPost[] = [];
+  let credits: { has_credits?: boolean; balance?: string } | undefined;
+  let planType: string | undefined;
   for (const o of objs) {
     if (o?.type !== "event_msg") continue;
     const p = o.payload ?? {};
@@ -160,6 +166,17 @@ export function formatCodexRolloutLines(objs: any[]): SlackPost[] {
     } else if (p.type === "exec_command_begin") {
       const cmd = Array.isArray(p.command) ? p.command.join(" ") : String(p.command ?? "");
       if (cmd.trim()) posts.push({ role: "assistant", text: fenceBlock(`$ ${truncate(cmd, 300)}`) });
+    } else if (p.type === "token_count" && p.rate_limits?.credits) {
+      credits = p.rate_limits.credits;
+      planType = p.rate_limits.plan_type;
+    } else if (p.type === "task_complete" && p.last_agent_message == null && credits?.has_credits === false) {
+      // Prompt was received but the turn produced no output because Codex ran
+      // out of credits. Surface it instead of mirroring silence.
+      const plan = planType ? ` (plan: ${planType}, balance ${credits.balance ?? "0"})` : "";
+      posts.push({
+        role: "assistant",
+        text: `:warning: Codex is out of credits${plan}. The prompt was received but no output was produced, and this will keep failing until credits are topped up at https://chatgpt.com/codex/settings/usage`,
+      });
     }
   }
   return posts;

--- a/cli/src/slack/thread-root.ts
+++ b/cli/src/slack/thread-root.ts
@@ -1,0 +1,36 @@
+import { mkdirSync, writeFileSync, readFileSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { kanbanHome } from "../paths.js";
+
+/// Slack thread root (the parent message ts) for an agent's current turn. A
+/// received-prompt message opens a thread and the agent's activity for that
+/// turn is posted as replies under it, so tool calls don't pile up at the
+/// channel root. The prompt mirror and the assistant-turn mirror can run in
+/// different processes (for Claude the daemon announces the prompt while the
+/// bridge tails the transcript; for Codex the bridge does both), so the ts is
+/// shared through this file rather than in-process state.
+
+function rootPath(slug: string): string {
+  return join(kanbanHome(), "thread-roots", slug);
+}
+
+/// Record the current thread root for an agent. Written atomically (tmp +
+/// rename) so a concurrent reader never sees a partial ts.
+export function writeThreadRoot(slug: string, ts: string): void {
+  if (!slug || !ts) return;
+  const path = rootPath(slug);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, ts);
+  renameSync(tmp, path);
+}
+
+/// The current thread root for an agent, or undefined if none recorded yet.
+export function readThreadRoot(slug: string): string | undefined {
+  try {
+    const ts = readFileSync(rootPath(slug), "utf-8").trim();
+    return ts || undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- When a codex agent is out of credits, the bridge now posts an explicit warning to the channel instead of leaving it on a bare "Received user message".
- Detection is from the rollout: a turn that ends with `task_complete{last_agent_message: null}` whose preceding `token_count` reports `rate_limits.credits.has_credits == false`. The message includes the plan, balance, and the top-up URL.
- Wording is generic ("no output was produced") since `formatCodexRolloutLines` mirrors any codex agent, not just the PR reviewer.

## Why
The codex pr-reviewer hit its usage limit and the channel showed three "Received user message" lines with no follow-up, so there was no way to tell from Slack that it was stuck on credits. The usage-limit text only renders in the codex TUI, never in the rollout, but the credits state is in the structured `token_count` event, so we can surface it cleanly.

## Test plan
- [x] `formatCodexRolloutLines` posts an out-of-credits warning when a turn produces no output and credits are exhausted
- [x] No warning when a turn completes with output (credits present)
- [x] Existing mirror behavior (prompts, agent messages, exec commands) unchanged
- [x] Full `node --test` suite green