### PR TITLE
ci: notify when Slack app manifest changes

### DIFF
--- a/.github/workflows/notify-saas-manifest-sync.yml
+++ b/.github/workflows/notify-saas-manifest-sync.yml
@@ -1,0 +1,47 @@
+name: Notify langwatch-saas of manifest changes
+
+# When this repo's Slack app manifest generator changes on main, fire a
+# workflow_dispatch on langwatch/langwatch-saas's slack-manifest-sync
+# workflow so it picks up the change immediately instead of waiting for a
+# scheduled tick. The actual Slack publish lives in langwatch-saas (along
+# with the secrets that authenticate it) because the Slack app config is
+# proprietary to LangWatch; this file is pure glue.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - cli/src/slack/manifest.ts
+      - .github/workflows/notify-saas-manifest-sync.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger langwatch-saas slack-manifest-sync
+        env:
+          GH_TOKEN: ${{ secrets.LANGWATCH_SAAS_DISPATCH_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::LANGWATCH_SAAS_DISPATCH_PAT is not set"; exit 1
+          fi
+          # workflow_dispatch on the named workflow file. The PAT needs
+          # `contents: read` + `actions: write` on langwatch/langwatch-saas
+          # (or `repo` scope on a classic PAT).
+          resp=$(curl -sS -w '\nHTTP %{http_code}' -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/langwatch/langwatch-saas/actions/workflows/slack-manifest-sync.yaml/dispatches" \
+            -d '{"ref":"main"}')
+          echo "$resp"
+          code=$(printf '%s' "$resp" | awk '/^HTTP /{print $2}')
+          if [ "$code" != "204" ]; then
+            echo "::error::dispatch returned HTTP $code (expected 204)"
+            exit 1
+          fi
+          echo "Dispatched."


### PR DESCRIPTION
## Summary
Tiny glue workflow. When \`cli/src/slack/manifest.ts\` lands on main, fires \`workflow_dispatch\` slack-manifest-sync workflow so the deploy picks up the change in seconds instead of waiting for a scheduled tick. The actual Slack publish (and the secrets that authenticate it) stay where the rest of the agents-box deployment lives — kanban-code keeps no Slack credentials.

## Test plan
- [ ] Merge this + the matching langwatch-saas PR
- [ ] Edit a non-functional bit of \`cli/src/slack/manifest.ts\` (e.g. a comment), watch this workflow fire, watch slack-manifest-sync trigger in response