### PR TITLE
feat(slack): announce self-compact in the channel

### DIFF
--- a/cli/src/kanban.ts
+++ b/cli/src/kanban.ts
@@ -36,7 +36,7 @@ import { installHooks } from "./hooks.js";
 import { Daemon } from "./agents/daemon.js";
 import { slackAppManifest, MANIFEST_INSTRUCTIONS } from "./slack/manifest.js";
 import { runSlackBridge } from "./slack/bridge.js";
-import { announceToSlack } from "./slack/announce.js";
+import { announceToSlack, announceRawToSlack } from "./slack/announce.js";
 import { SlackClient } from "./slack/client.js";
 import { postToSlack } from "./slack/post.js";
 import type { KanbanColumn, Link } from "./types.js";
@@ -605,6 +605,19 @@ Examples:
         "schedule self-compact",
         scheduleTmuxSelfCompact(tmuxSession, followUp, Number.isFinite(followUpDelay) ? followUpDelay : 1)
       );
+
+      // Surface the compact in Slack — the bridge's buffer-until-next-text
+      // would otherwise hold the agent's "I'm compacting" Bash tool entry
+      // until the post-compact session produces a fresh text post, leaving
+      // the channel silent for the entire compact + warm-up window. Also
+      // opens a new thread anchor for the resumed session and lights the
+      // pill so the post-compact tool calls don't end up under a stale
+      // pre-compact thread. Fire-and-forget; the CLI exits when scheduling
+      // is done, the announce flushes in the background.
+      const announceText = followUp.trim()
+        ? `:arrows_counterclockwise: Self-compact triggered — context refresh, resuming with: _${followUp.trim()}_`
+        : ":arrows_counterclockwise: Self-compact triggered — context refresh in progress.";
+      void announceRawToSlack(tmuxSession, announceText);
 
       const result = {
         ok: true,

--- a/cli/src/slack/announce.ts
+++ b/cli/src/slack/announce.ts
@@ -14,6 +14,12 @@ export { RECEIVED_MESSAGE_HEADER, formatReceivedMessage } from "./format.js";
 import { formatReceivedMessage } from "./format.js";
 import { writeThreadRoot } from "./thread-root.js";
 
+/// Single plain label shown for the entire "agent is working" state — no
+/// tool name, no emoji. Slack's setStatus already renders its own animated
+/// indicator next to the text. Shared between announce + bridge so they
+/// don't drift.
+export const WORKING_PILL_LABEL = "is working…";
+
 function defaultConfigPath(): string {
   return process.env.KANBAN_AGENTS_CONFIG || join(homedir(), ".kanban-code", "agents.yaml");
 }
@@ -51,23 +57,25 @@ export interface AnnounceOptions {
 /// Announce text to an agent's channel. No-op (returns false) if no token is
 /// configured or the agent has no resolvable channel.
 export async function announceToSlack(slug: string, text: string, opts: AnnounceOptions = {}): Promise<boolean> {
+  return announceRawToSlack(slug, formatReceivedMessage(text), opts);
+}
+
+/// Same as announceToSlack but posts the body verbatim (no "Received user
+/// message" header). Used for system-style notifications like self-compact
+/// triggers where the wording is fully owned by the caller. Still opens the
+/// thread for the turn and lights the pill so the bridge's later assistant
+/// posts thread under this anchor.
+export async function announceRawToSlack(slug: string, text: string, opts: AnnounceOptions = {}): Promise<boolean> {
   const c = client(opts.token);
   if (!c) return false;
   const channel = await channelForSlug(slug, opts.configPath ?? defaultConfigPath(), c);
   if (!channel) return false;
   try {
-    // The received-prompt message opens the thread for this turn; record its
-    // ts so the bridge threads the agent's assistant turns under it.
-    const ts = await c.post(channel, formatReceivedMessage(text));
+    const ts = await c.post(channel, text);
     if (ts) {
       writeThreadRoot(slug, ts);
-      // Light the "💭 thinking…" pill immediately so the channel reflects
-      // that the agent has started before its first tool call appears in
-      // the transcript a couple of poll ticks later. The bridge takes over
-      // refreshing (and updating with tool labels) once it sees activity.
-      // Failures are non-fatal — the pill is a UX nicety, not the message.
       try {
-        await c.setStatus(channel, ts, "💭 thinking…");
+        await c.setStatus(channel, ts, WORKING_PILL_LABEL);
       } catch {
         /* setStatus is best-effort; channel + thread already exist */
       }

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -8,6 +8,7 @@ import { loadAgentsConfig } from "../agents/config.js";
 import { agentIdentity } from "../agents/identity.js";
 import { Runtime } from "../agents/runtime.js";
 import { recordAnnounceSuppress } from "./announce-suppress.js";
+import { WORKING_PILL_LABEL } from "./announce.js";
 import { writeThreadRoot, readThreadRoot } from "./thread-root.js";
 import { downloadSlackFile, formatPromptWithAttachments, DownloadedFile, sweepInbox, DEFAULT_RETENTION_DAYS } from "./inbox.js";
 import { parsePicker, Picker } from "./picker.js";
@@ -158,10 +159,10 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
   // every REFRESH_MS while a turn is open so the TTL does not drop the pill
   // mid-turn during long bash bursts or large diffs.
   const REFRESH_MS = 60_000;
-  /// Single plain label shown for the entire "agent is working" state — no
-  /// tool name, no emoji. Slack's setStatus already shows its own animated
-  /// indicator next to the text.
-  const WORKING_LABEL = "is working…";
+  /// Alias for the shared pill label (kept local for readability in the
+  /// dense post loop below). Defined in announce.ts so the bridge and the
+  /// kanban CLI's announce path can't drift on what text the pill carries.
+  const WORKING_LABEL = WORKING_PILL_LABEL;
   interface ActivePill { channelId: string; threadTs: string; label: string; lastSetMs: number; }
   const active = new Map<string /* slug */, ActivePill>();
 


### PR DESCRIPTION
## Summary
- The Slack bridge buffers tool calls until the next text post (the merged PR #79 UX win). That meant a \`kanban self-compact\` was visually invisible: the buffered "I'm compacting" Bash entry held until the resumed session produced a text post, leaving the channel silent for the entire compact + warm-up window with a stale "is working…" pill from before the compact.
- \`kanban self-compact\` now posts \`:arrows_counterclockwise: Self-compact triggered — context refresh, resuming with: <follow-up>\` directly to the agent's channel root, becomes the new thread anchor, and lights the pill.
- New export \`announceRawToSlack(slug, text)\` for system-style messages that own their own wording (no ">>> Received user message" prefix).
- Shared \`WORKING_PILL_LABEL\` constant — \`announce.ts\` had drifted from the bridge and was still setting the old "💭 thinking…" string when the daemon fired a prompt announce. Both paths now read from the same export.

## Test plan
- [x] \`pnpm test\` — 236/236
- [x] \`pnpm build\` clean
- [ ] On the agents box, trigger \`kanban self-compact "<some follow-up>"\` from an agent's tmux session and confirm the channel shows the announce + the post-compact session threads cleanly under it.