### PR TITLE
fix(slack): drop working pill on codex out-of-credits warning

### DIFF
--- a/cli/src/codex-runtime.test.ts
+++ b/cli/src/codex-runtime.test.ts
@@ -165,6 +165,11 @@ describe("formatCodexRolloutLines", () => {
     assert.match(posts[1].text, /out of credits/i);
     assert.match(posts[1].text, /plan: plus, balance 0/);
     assert.match(posts[1].text, /chatgpt\.com\/codex\/settings\/usage/);
+    // Terminal flag tells the bridge to skip the working pill — no more
+    // output is coming this turn, the pill would sit on the channel
+    // indefinitely otherwise. Without this, the channel keeps showing
+    // "is working…" against a state that's already finished.
+    assert.equal(posts[1].terminal, true);
   });
 
   test("does not warn when a turn completes with output", () => {

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -241,7 +241,12 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
             const ts = await client.post(t.channelId, post.text);
             if (ts) writeThreadRoot(t.slug, ts);
             active.delete(t.slug);
-            if (ts) {
+            // `terminal: true` posts (currently only the codex out-of-credits
+            // sentinel) are the final word of the turn — no more work coming.
+            // Skip the WORKING pill entirely so the channel doesn't show a
+            // perpetual "is working…" against a state that's already finished.
+            // The previous anchor's pill was already cleared above.
+            if (ts && !post.terminal) {
               try {
                 await client.setStatus(t.channelId, ts, WORKING_LABEL);
                 active.set(t.slug, { channelId: t.channelId, threadTs: ts, label: WORKING_LABEL, lastSetMs: Date.now() });

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -11,6 +11,12 @@ export interface SlackPost {
   /// "thinking" -> a brief thinking-trace excerpt (also lands in the thread).
   kind: "text" | "tool" | "thinking";
   text: string; // Slack mrkdwn
+  /// True when this post is the final output of the turn — no more work is
+  /// coming. The bridge uses this to suppress the "is working…" pill that
+  /// would otherwise sit on the channel indefinitely. Currently set on the
+  /// codex out-of-credits sentinel; could be extended to normal task_complete
+  /// once we're sure Claude-runtime parity is covered.
+  terminal?: boolean;
 }
 
 const MAX_TEXT = 2800; // keep individual posts readable / within Slack block limits
@@ -198,10 +204,15 @@ export function formatCodexRolloutLines(objs: any[]): SlackPost[] {
       // Prompt was received but the turn produced no output because Codex ran
       // out of credits. Surface it instead of mirroring silence. Routed as
       // text so it anchors at the channel root (operators need to see it).
+      // `terminal: true` tells the bridge not to attach the working pill to
+      // this anchor — no more output is coming this turn, the pill would
+      // otherwise sit on the channel indefinitely (Slack auto-clears the
+      // built-in 2-min TTL but the refresh loop re-applies it forever).
       const plan = planType ? ` (plan: ${planType}, balance ${credits.balance ?? "0"})` : "";
       posts.push({
         role: "assistant",
         kind: "text",
+        terminal: true,
         text: `:warning: Codex is out of credits${plan}. The prompt was received but no output was produced, and this will keep failing until credits are topped up at https://chatgpt.com/codex/settings/usage`,
       });
     }


### PR DESCRIPTION
## Summary

When codex hits its credit ceiling, the rollout emits \`task_complete\` with \`last_agent_message=null\` + \`has_credits=false\`. The bridge already surfaces a clear warning at the channel root:

> :warning: Codex is out of credits (plan: plus, balance 0). The prompt was received but no output was produced, and this will keep failing until credits are topped up at https://chatgpt.com/codex/settings/usage

But then it immediately sets the \"is working…\" pill on that anchor. The refresh loop re-applies every 30s, so the channel keeps showing a working indicator against a state that's already finished. Operators get a mixed signal — warning above, \"Processing…\" below.

This PR adds a \`terminal?: boolean\` flag on \`SlackPost\` and sets it on the out-of-credits emission. In \`bridge.ts\`, when a \`kind: \"text\"\` post arrives with \`terminal: true\`, the previous anchor's pill still gets cleared and the warning still posts as the new root — but the \`setStatus(WORKING_LABEL)\` call is skipped, so nothing claims work is in progress.

## Why a flag, not a text match

Coupling the bridge to specific warning text would be fragile (the wording lives in \`format.ts\`, the pill logic lives in \`bridge.ts\`, and we'd silently drift). A flag on the post shape makes the intent explicit at the emission site and gives us a clean extension point for any future terminal sentinels (normal task_complete with output, Claude end-of-turn, etc.).

## Test plan

- [x] Updated codex-runtime test asserts the out-of-credits post carries \`terminal: true\`.
- [x] \`pnpm test\` clean (236/236).
- [x] \`tsc\` build clean.
- [ ] Once merged + box pulls main, trigger an out-of-credits run on a codex agent and visually confirm the warning posts with no working pill.