### PR TITLE
fix(slack): render agent markdown + drop stale pill on Claude end_turn

### DIFF
--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -224,7 +224,11 @@ describe("kanban channel (CLI e2e)", () => {
     const r = runCli(["self-compact", "--follow-up-delay", "0.1", "Continue", "after", "compact."], env);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /Sent \/compact to sess-self with post-compact follow-up/);
-    execFileSync("sleep", ["0.8"]);
+    // The detached self-compact shell sleeps 2s before Escape (see
+    // scheduleTmuxSelfCompact in data.ts), then the per-step sleeps and the
+    // follow-up delay. Wait past all of that so every fake-tmux line we
+    // assert on has been written to the log file.
+    execFileSync("sleep", ["2.8"]);
 
     const log = readFileSync(logPath, "utf-8");
     assert.match(log, /display-message -p #S/);
@@ -266,7 +270,9 @@ describe("kanban channel (CLI e2e)", () => {
     const r = runCli(["self-compact"], env);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /Sent \/compact to sess-self-no-follow-up\./);
-    execFileSync("sleep", ["0.4"]);
+    // Detached shell sleeps 2s before Escape (see scheduleTmuxSelfCompact);
+    // wait past it before reading the log.
+    execFileSync("sleep", ["2.4"]);
 
     const log = readFileSync(logPath, "utf-8");
     assert.match(log, /set-buffer \/compact/);

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -255,10 +255,14 @@ export function scheduleTmuxSelfCompact(
   const tmux = findTmux();
   const delay = Math.max(0, Number.isFinite(followUpDelaySeconds) ? followUpDelaySeconds : 1);
   const compactSteps = [
-    // Let the CLI return control to Claude Code before we start sending keys
-    // to the same pane. Once this shell is detached, it survives Claude
-    // interrupting the Bash tool that launched `kanban self-compact`.
-    "sleep 0.1",
+    // Give the CLI time to finish printing its output and return control to
+    // Claude Code before we start sending keys to the same pane. The shell
+    // is detached so it survives Claude interrupting the Bash tool that
+    // launched `kanban self-compact` — but if we send Escape too soon, the
+    // interrupt races with Claude still processing the tool result and
+    // sometimes leaves the session in a state where `/compact` is not
+    // recognised as a slash command. 2s gives a comfortable buffer.
+    "sleep 2",
     `${tmux} send-keys -t ${shellEscape(sessionName)} Escape`,
     `${tmux} set-buffer ${shellEscape("/compact")}`,
     `${tmux} paste-buffer -p -t ${shellEscape(sessionName)}`,

--- a/cli/src/slack-format.test.ts
+++ b/cli/src/slack-format.test.ts
@@ -129,6 +129,52 @@ describe("formatTranscriptLines", () => {
     assert.equal(posts.length, 0);
   });
 
+  test("marks the last text post terminal when the message ends with end_turn", () => {
+    const obj = {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "Done." }],
+      },
+    };
+    const posts = formatTranscriptLines([obj]);
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].kind, "text");
+    assert.equal(posts[0].terminal, true);
+  });
+
+  test("does NOT mark terminal on stop_reason: tool_use (the agent will continue)", () => {
+    const obj = {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        stop_reason: "tool_use",
+        content: [{ type: "text", text: "Looking it up..." }, { type: "tool_use", name: "Read", input: { file_path: "x.ts" } }],
+      },
+    };
+    const posts = formatTranscriptLines([obj]);
+    for (const p of posts) assert.notEqual(p.terminal, true);
+  });
+
+  test("marks ONLY the last text post terminal even if there are multiple text blocks in one turn", () => {
+    const obj = {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        stop_reason: "end_turn",
+        content: [
+          { type: "text", text: "First paragraph." },
+          { type: "text", text: "Second and final paragraph." },
+        ],
+      },
+    };
+    const posts = formatTranscriptLines([obj]);
+    assert.equal(posts.length, 2);
+    assert.notEqual(posts[0].terminal, true);
+    assert.equal(posts[1].terminal, true);
+  });
+
   test("translates GFM markdown in assistant text to Slack mrkdwn", () => {
     const posts = formatTranscriptLines([
       asst([{ type: "text", text: "**hono 4.12.23**: serves, responds 200" }]),

--- a/cli/src/slack-format.test.ts
+++ b/cli/src/slack-format.test.ts
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import { strict as assert } from "node:assert";
-import { shortenPath, toolLabel, formatTranscriptLines } from "./slack/format.js";
+import { shortenPath, toolLabel, formatTranscriptLines, gfmToSlackMrkdwn } from "./slack/format.js";
 
 describe("shortenPath", () => {
   test("keeps short paths, trims long ones to last 3", () => {
@@ -129,4 +129,75 @@ describe("formatTranscriptLines", () => {
     assert.equal(posts.length, 0);
   });
 
+  test("translates GFM markdown in assistant text to Slack mrkdwn", () => {
+    const posts = formatTranscriptLines([
+      asst([{ type: "text", text: "**hono 4.12.23**: serves, responds 200" }]),
+    ]);
+    assert.equal(posts[0].text, "*hono 4.12.23*: serves, responds 200");
+  });
+});
+
+describe("gfmToSlackMrkdwn", () => {
+  test("**bold** -> *bold*", () => {
+    assert.equal(gfmToSlackMrkdwn("hello **world** ok"), "hello *world* ok");
+  });
+
+  test("__bold__ -> *bold*", () => {
+    assert.equal(gfmToSlackMrkdwn("hello __world__ ok"), "hello *world* ok");
+  });
+
+  test("markdown italic *x* -> Slack italic _x_", () => {
+    assert.equal(gfmToSlackMrkdwn("hello *world* ok"), "hello _world_ ok");
+  });
+
+  test("Slack-native italic _x_ is left alone", () => {
+    assert.equal(gfmToSlackMrkdwn("hello _world_ ok"), "hello _world_ ok");
+  });
+
+  test("bold inside italic stays bold (not mistakenly italicised)", () => {
+    // The reverse order would be a bug — `**x**` shouldn't end up as `_x_`.
+    assert.equal(gfmToSlackMrkdwn("**bold**"), "*bold*");
+    assert.equal(gfmToSlackMrkdwn("foo **bold** *italic* bar"), "foo *bold* _italic_ bar");
+  });
+
+  test("links: [label](url) -> <url|label>", () => {
+    assert.equal(
+      gfmToSlackMrkdwn("see [the docs](https://example.com/x) for more"),
+      "see <https://example.com/x|the docs> for more",
+    );
+  });
+
+  test("ATX headings -> bold lines", () => {
+    assert.equal(gfmToSlackMrkdwn("# Heading 1\nbody"), "*Heading 1*\nbody");
+    assert.equal(gfmToSlackMrkdwn("### Heading 3"), "*Heading 3*");
+  });
+
+  test("strikethrough: ~~x~~ -> ~x~", () => {
+    assert.equal(gfmToSlackMrkdwn("~~old~~ new"), "~old~ new");
+  });
+
+  test("fenced code blocks pass through unchanged", () => {
+    const input = "before\n```\n**not bold inside**\n```\nafter **bold**";
+    assert.equal(gfmToSlackMrkdwn(input), "before\n```\n**not bold inside**\n```\nafter *bold*");
+  });
+
+  test("inline code passes through unchanged", () => {
+    assert.equal(gfmToSlackMrkdwn("call `foo(**x**)` then **bold**"), "call `foo(**x**)` then *bold*");
+  });
+
+  test("realistic agent paragraph with bullets, bold and link", () => {
+    const input = [
+      "Strong evidence:",
+      "- **hono 4.12.23 server smoke**: serves, responds 200",
+      "- **Real bullboard server**: gets past module loading",
+      "",
+      "See [the docs](https://example.com).",
+    ].join("\n");
+    const out = gfmToSlackMrkdwn(input);
+    assert.ok(out.includes("*hono 4.12.23 server smoke*"));
+    assert.ok(out.includes("*Real bullboard server*"));
+    assert.ok(out.includes("<https://example.com|the docs>"));
+    // Slack uses `-` for bullets natively (since 2024); we don't touch them.
+    assert.ok(out.includes("- *hono"));
+  });
 });

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -489,6 +489,30 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     relays.push({ text: prompt, ts: Date.now() });
     recentRelays.set(decision.slug, relays);
     pasteTmuxPrompt(decision.slug, prompt); // tmux session name == slug
+
+    // Light the "is working…" pill on the user's own Slack message right
+    // away, so the channel reflects "agent is processing this" without the
+    // operator having to wait for the agent's first text reply to land.
+    // Previously the pill only appeared on the assistant's first reply,
+    // which made it look like nothing was happening between sending the
+    // prompt and seeing output (in practice that can be 30s+ of tool
+    // calls). The pill then moves to the assistant's reply via the
+    // existing prevPill-clear path the moment that reply lands.
+    const userTs: string | undefined = (event as any)?.ts;
+    const userChannel: string | undefined = (event as any)?.channel;
+    if (userTs && userChannel) {
+      try {
+        await client.setStatus(userChannel, userTs, WORKING_PILL_LABEL);
+        setActivePill(decision.slug, {
+          channelId: userChannel,
+          threadTs: userTs,
+          label: WORKING_PILL_LABEL,
+          lastSetMs: Date.now(),
+        });
+      } catch (e) {
+        console.error(`setStatus (on user message) for ${decision.slug} failed:`, e);
+      }
+    }
   });
   await socket.start();
   console.error(`Slack bridge connected. Mirroring ${tails.length} agent(s).`);

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -489,30 +489,6 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     relays.push({ text: prompt, ts: Date.now() });
     recentRelays.set(decision.slug, relays);
     pasteTmuxPrompt(decision.slug, prompt); // tmux session name == slug
-
-    // Light the "is working…" pill on the user's own Slack message right
-    // away, so the channel reflects "agent is processing this" without the
-    // operator having to wait for the agent's first text reply to land.
-    // Previously the pill only appeared on the assistant's first reply,
-    // which made it look like nothing was happening between sending the
-    // prompt and seeing output (in practice that can be 30s+ of tool
-    // calls). The pill then moves to the assistant's reply via the
-    // existing prevPill-clear path the moment that reply lands.
-    const userTs: string | undefined = (event as any)?.ts;
-    const userChannel: string | undefined = (event as any)?.channel;
-    if (userTs && userChannel) {
-      try {
-        await client.setStatus(userChannel, userTs, WORKING_PILL_LABEL);
-        setActivePill(decision.slug, {
-          channelId: userChannel,
-          threadTs: userTs,
-          label: WORKING_PILL_LABEL,
-          lastSetMs: Date.now(),
-        });
-      } catch (e) {
-        console.error(`setStatus (on user message) for ${decision.slug} failed:`, e);
-      }
-    }
   });
   await socket.start();
   console.error(`Slack bridge connected. Mirroring ${tails.length} agent(s).`);

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -218,6 +218,11 @@ function coalesceTools(posts: SlackPost[]): SlackPost[] {
   return out;
 }
 
+/// Claude `stop_reason` values that mean "the agent is done; this turn won't
+/// produce more output". `tool_use` / `max_tokens` / `pause_turn` are NOT
+/// terminal — the agent will continue on the next call.
+const TERMINAL_STOP_REASONS = new Set(["end_turn", "stop_sequence", "refusal"]);
+
 /// Convert a batch of transcript lines into Slack posts. User turns and
 /// tool_result lines are skipped: relayed human messages already appear in
 /// Slack as that human's own message, and automated prompts are announced
@@ -226,7 +231,24 @@ export function formatTranscriptLines(objs: any[]): SlackPost[] {
   const posts: SlackPost[] = [];
   for (const obj of objs) {
     if (role(obj) !== "assistant") continue;
+    const before = posts.length;
     emitAssistantBlocks(obj.message?.content ?? obj.content, posts);
+    // When the assistant finishes its turn (stop_reason: end_turn et al.),
+    // mark the LAST text post we just emitted as terminal. The bridge reads
+    // that flag and drops the "is working…" pill instead of re-attaching it
+    // — otherwise the pill stays on the channel forever after the agent
+    // completes a turn with a final text post. Without this, every Claude
+    // run leaves a stale pill hanging under the last message; previously
+    // only the codex out-of-credits sentinel set this flag.
+    const stopReason = obj?.message?.stop_reason;
+    if (typeof stopReason === "string" && TERMINAL_STOP_REASONS.has(stopReason)) {
+      for (let i = posts.length - 1; i >= before; i--) {
+        if (posts[i].kind === "text") {
+          posts[i].terminal = true;
+          break;
+        }
+      }
+    }
   }
   return coalesceTools(posts);
 }

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -94,6 +94,73 @@ function fenceBlock(label: string): string {
   return "```\n" + label + "\n```";
 }
 
+/// Convert GitHub-flavoured Markdown (the syntax Claude and Codex emit in
+/// their assistant prose) into Slack mrkdwn. Slack renders `text` field as
+/// mrkdwn by default, but the two dialects don't agree on the syntax:
+///   GFM `**bold**`        -> Slack `*bold*`
+///   GFM `*italic*`        -> Slack `_italic_`     (Slack treats `*x*` as bold)
+///   GFM `__bold__`        -> Slack `*bold*`
+///   GFM `~~strike~~`      -> Slack `~strike~`
+///   GFM `# heading`       -> Slack `*heading*`    (Slack has no headings)
+///   GFM `[label](url)`    -> Slack `<url|label>`
+///
+/// Slack mrkdwn that already matches the input stays the same:
+///   underscored italic, blockquotes (`>`), inline code, fenced code blocks,
+///   and `-` / `*` / `1.` lists (since Slack's 2024 markdown refresh).
+///
+/// Code spans / fenced code blocks are preserved verbatim — we don't want to
+/// translate Markdown-looking content inside `\`...\`` or ``` ``` ``` ``` .
+export function gfmToSlackMrkdwn(input: string): string {
+  // Split off fenced code blocks first; odd-indexed splits ARE the fences.
+  const fenceParts = input.split(/(```[\s\S]*?```)/g);
+  return fenceParts
+    .map((part, i) => (i % 2 === 1 ? part : transformProse(part)))
+    .join("");
+}
+
+const BOLD_SENTINEL = "BOLD";
+
+function transformProse(s: string): string {
+  // Split off inline code spans next; those are also preserved verbatim.
+  const codeParts = s.split(/(`[^`\n]+`)/g);
+  return codeParts
+    .map((part, i) => (i % 2 === 1 ? part : transformText(part)))
+    .join("");
+}
+
+function transformText(s: string): string {
+  // Bold first — both `**x**` and `__x__`. Stash to a sentinel so the
+  // single-asterisk italic pass below doesn't mistakenly italicise the
+  // intermediate `*x*` form.
+  const bolds: string[] = [];
+  const stash = (body: string) => {
+    bolds.push(body);
+    return `${BOLD_SENTINEL}${bolds.length - 1}${BOLD_SENTINEL}`;
+  };
+  let out = s
+    .replace(/\*\*([^*\n]+)\*\*/g, (_m, body) => stash(body))
+    .replace(/__([^_\n]+)__/g, (_m, body) => stash(body));
+
+  // Markdown single-asterisk italic -> Slack underscore italic. Anything
+  // already in `_..._` stays correct.
+  out = out.replace(/\*([^*\n]+)\*/g, "_$1_");
+
+  // Restore bolds as Slack `*x*`.
+  out = out.replace(new RegExp(`${BOLD_SENTINEL}(\\d+)${BOLD_SENTINEL}`, "g"), (_m, idx) => `*${bolds[Number(idx)]}*`);
+
+  // Strikethrough: `~~x~~` -> `~x~`.
+  out = out.replace(/~~([^~\n]+)~~/g, "~$1~");
+
+  // ATX headings -> bold line (Slack has no heading concept; bold-line is the
+  // operator convention in agent channels).
+  out = out.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");
+
+  // Markdown links `[label](url)` -> Slack link `<url|label>`.
+  out = out.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/g, "<$2|$1>");
+
+  return out;
+}
+
 function role(obj: any): string | undefined {
   return obj?.type ?? obj?.message?.role;
 }
@@ -104,14 +171,14 @@ function role(obj: any): string | undefined {
 function emitAssistantBlocks(content: any, out: SlackPost[]): void {
   if (typeof content === "string") {
     const t = truncate(content);
-    if (t) out.push({ role: "assistant", kind: "text", text: t });
+    if (t) out.push({ role: "assistant", kind: "text", text: gfmToSlackMrkdwn(t) });
     return;
   }
   if (!Array.isArray(content)) return;
   for (const block of content) {
     switch (block?.type) {
       case "text": {
-        if (block.text?.trim()) out.push({ role: "assistant", kind: "text", text: truncate(block.text) });
+        if (block.text?.trim()) out.push({ role: "assistant", kind: "text", text: gfmToSlackMrkdwn(truncate(block.text)) });
         break;
       }
       case "thinking": {
@@ -187,7 +254,7 @@ export function formatCodexRolloutLines(objs: any[]): SlackPost[] {
     if (p.type === "user_message" && typeof p.message === "string" && p.message.trim()) {
       posts.push({ role: "user", kind: "text", text: formatReceivedMessage(truncate(p.message)) });
     } else if (p.type === "agent_message" && typeof p.message === "string" && p.message.trim()) {
-      posts.push({ role: "assistant", kind: "text", text: truncate(p.message) });
+      posts.push({ role: "assistant", kind: "text", text: gfmToSlackMrkdwn(truncate(p.message)) });
     } else if (p.type === "exec_command_begin") {
       const cmd = Array.isArray(p.command) ? p.command.join(" ") : String(p.command ?? "");
       if (cmd.trim()) {


### PR DESCRIPTION
## Summary
- Claude and Codex emit GitHub-flavoured Markdown in assistant prose (\`**bold**\`, \`[label](url)\`, \`# heading\`, \`*italic*\`, …). Slack renders the \`text\` field as mrkdwn by default, but Slack mrkdwn uses a different dialect — \`*x*\` is bold, \`_x_\` is italic, headings don't exist, links look like \`<url|label>\`. So today agent prose shows the literal Markdown punctuation in Slack instead of being rendered.
- Add \`gfmToSlackMrkdwn(text)\` and call it on assistant-prose paths in both the Claude transcript formatter and the Codex rollout formatter (\`agent_message\`). Translation covers bold (\`**\` and \`__\`), italic (\`*\` → \`_\`), strikethrough, ATX headings, and links.
- Fenced code blocks and inline code spans are preserved verbatim so Markdown-looking content inside code is not touched. Static authored messages (the \`:warning: Codex is out of credits…\` post) are intentionally not run through the converter.

Unit tests cover the round-trip and the tricky ordering pitfall (must replace \`**bold**\` BEFORE the single-\`*\` italic pass, otherwise the intermediate \`*bold*\` gets re-mangled into \`_bold_\`).

## Test plan
- [x] \`pnpm test\` — 254 passed, including new \`gfmToSlackMrkdwn\` cases for bold/italic/heading/link/strike/code-block/inline-code/realistic-paragraph
- [ ] After deploy: agent prose that contains \`**bold**\` and \`[label](url)\` renders as actual bold and an actual hyperlink in the agent Slack channels