### PR TITLE
slack: light working pill immediately when a Slack human relays a prompt

### DIFF
--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -489,6 +489,37 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     relays.push({ text: prompt, ts: Date.now() });
     recentRelays.set(decision.slug, relays);
     pasteTmuxPrompt(decision.slug, prompt); // tmux session name == slug
+
+    // Post a tiny bot-authored anchor so the working pill has something to
+    // attach to immediately. Without this the channel looks dead for the
+    // 10-20s between the human typing and the agent's first text post (which
+    // is the natural pill anchor for the existing flow). Slack's
+    // assistant.threads.setStatus only accepts thread roots authored by the
+    // app itself, so we cannot pin the pill to the human's own message
+    // (that would 400 with invalid_thread_ts).
+    //
+    // The eyes emoji is chosen for minimal noise: a single character that
+    // reads as "received, on it" and renders cleanly next to the working
+    // pill ("is working…"). The agent's first real text post will become
+    // the new thread root via the existing post loop, draining any tools
+    // accumulated in the meantime under this anchor and moving the pill
+    // onto the narrative text.
+    if (event.channel) {
+      try {
+        const ts = await client.post(event.channel, "👀");
+        if (ts) {
+          writeThreadRoot(decision.slug, ts);
+          try {
+            await client.setStatus(event.channel, ts, WORKING_LABEL);
+            setActivePill(decision.slug, { channelId: event.channel, threadTs: ts, label: WORKING_LABEL, lastSetMs: Date.now() });
+          } catch (e) {
+            console.error(`setStatus on relay anchor for ${decision.slug} failed:`, e);
+          }
+        }
+      } catch (e) {
+        console.error(`relay anchor post for ${decision.slug} failed:`, e);
+      }
+    }
   });
   await socket.start();
   console.error(`Slack bridge connected. Mirroring ${tails.length} agent(s).`);


### PR DESCRIPTION
## Summary
- Posts a single eyes emoji as a minimal bot-authored anchor in the agent's channel right after the bridge pastes a relayed Slack-human prompt into tmux, and lights `assistant.threads.setStatus` on that post.
- Without this anchor the channel looks dead for the 10-20s gap between the human typing and the agent's first text post — that text post is what the existing rollout-tail flow uses as the natural pill anchor, so there is no signal in between.
- Slack's setStatus only accepts thread roots authored by the app itself (`invalid_thread_ts` on user-channel ts, see slack-setstatus-app-authored-threads-only memory from the earlier revert), so pinning the pill to the human's own message is not viable. The single-emoji anchor is the lowest-noise placeholder that still gives setStatus something valid to attach to.
- The agent's first real text post supersedes the anchor as the new thread root in the existing post loop, so tool calls accumulated in the interim drain under the eyes anchor and the pill moves onto the narrative reply.

## Test plan
- [ ] All 242 existing CLI tests pass.
- [ ] On the box, after relaunching `agents-slack-bridge.service` on this branch: typing a prompt in any agent channel surfaces an eyes-emoji bot post + working pill within a second, and the pill moves onto the agent's first real text post when it lands.
- [ ] No `invalid_thread_ts` errors in `journalctl -u agents-slack-bridge.service`.