### PR TITLE
slack: drop the working pill when a codex turn ends (task_complete)

### DIFF
--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -250,6 +250,18 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
       const { objs, newOffset } = readAppendedLines(t.path, t.offset);
       t.offset = newOffset;
       const posts = t.runtime === "codex" ? formatCodexRolloutLines(objs) : formatTranscriptLines(objs);
+      // Cross-batch turn-end safety net. The same-batch case is handled by
+      // format.ts marking the final agent_message terminal, but if the rollout
+      // tail picks up the agent_message in one poll and the task_complete in
+      // the next (rare, but possible if the rollout fsync straddles a poll),
+      // the bridge would have already attached a fresh pill to the assistant
+      // text and the refresh loop would keep it lit forever. Detect a bare
+      // task_complete and clear the active pill without posting anything.
+      const codexTurnEnded =
+        t.runtime === "codex" &&
+        objs.some(
+          (o: any) => o?.type === "event_msg" && o?.payload?.type === "task_complete"
+        );
       for (const post of posts) {
         // Don't echo a prompt we just relayed from a Slack human (it's already
         // in the channel as their message).
@@ -278,11 +290,13 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
             const ts = await client.post(t.channelId, post.text);
             if (ts) writeThreadRoot(t.slug, ts);
             dropActivePill(t.slug);
-            // `terminal: true` posts (currently only the codex out-of-credits
-            // sentinel) are the final word of the turn — no more work coming.
-            // Skip the WORKING pill entirely so the channel doesn't show a
-            // perpetual "is working…" against a state that's already finished.
-            // The previous anchor's pill was already cleared above.
+            // `terminal: true` posts are the final word of the turn — no more
+            // work coming. Skip the WORKING pill entirely so the channel
+            // doesn't show a perpetual "is working…" against a state that's
+            // already finished. Codex sets this on its final agent_message
+            // when task_complete lands in the same poll batch, and on the
+            // out-of-credits sentinel. The previous anchor's pill was already
+            // cleared above.
             if (ts && !post.terminal) {
               try {
                 await client.setStatus(t.channelId, ts, WORKING_LABEL);
@@ -301,6 +315,20 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
           }
         } catch (e) {
           console.error(`post to ${t.slug} failed:`, e);
+        }
+      }
+      // After the per-post loop: if this codex batch carried a task_complete
+      // but none of the posts above were terminal text (i.e. the agent_message
+      // landed in a prior batch and got its pill), clear the pill now.
+      if (codexTurnEnded) {
+        const pill = active.get(t.slug);
+        if (pill) {
+          try {
+            await client.setStatus(pill.channelId, pill.threadTs, "");
+          } catch (e) {
+            console.error(`clear pill on codex task_complete for ${t.slug} failed:`, e);
+          }
+          dropActivePill(t.slug);
         }
       }
     }

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -13,9 +13,9 @@ export interface SlackPost {
   text: string; // Slack mrkdwn
   /// True when this post is the final output of the turn — no more work is
   /// coming. The bridge uses this to suppress the "is working…" pill that
-  /// would otherwise sit on the channel indefinitely. Currently set on the
-  /// codex out-of-credits sentinel; could be extended to normal task_complete
-  /// once we're sure Claude-runtime parity is covered.
+  /// would otherwise sit on the channel indefinitely. Set on the codex
+  /// out-of-credits sentinel AND on the final assistant text post of any
+  /// normal codex turn (when task_complete lands in the same poll batch).
   terminal?: boolean;
 }
 
@@ -200,21 +200,36 @@ export function formatCodexRolloutLines(objs: any[]): SlackPost[] {
     } else if (p.type === "token_count" && p.rate_limits?.credits) {
       credits = p.rate_limits.credits;
       planType = p.rate_limits.plan_type;
-    } else if (p.type === "task_complete" && p.last_agent_message == null && credits?.has_credits === false) {
-      // Prompt was received but the turn produced no output because Codex ran
-      // out of credits. Surface it instead of mirroring silence. Routed as
-      // text so it anchors at the channel root (operators need to see it).
-      // `terminal: true` tells the bridge not to attach the working pill to
-      // this anchor — no more output is coming this turn, the pill would
-      // otherwise sit on the channel indefinitely (Slack auto-clears the
-      // built-in 2-min TTL but the refresh loop re-applies it forever).
-      const plan = planType ? ` (plan: ${planType}, balance ${credits.balance ?? "0"})` : "";
-      posts.push({
-        role: "assistant",
-        kind: "text",
-        terminal: true,
-        text: `:warning: Codex is out of credits${plan}. The prompt was received but no output was produced, and this will keep failing until credits are topped up at https://chatgpt.com/codex/settings/usage`,
-      });
+    } else if (p.type === "task_complete") {
+      if (p.last_agent_message == null && credits?.has_credits === false) {
+        // Prompt was received but the turn produced no output because Codex ran
+        // out of credits. Surface it instead of mirroring silence. Routed as
+        // text so it anchors at the channel root (operators need to see it).
+        // `terminal: true` tells the bridge not to attach the working pill to
+        // this anchor — no more output is coming this turn, the pill would
+        // otherwise sit on the channel indefinitely (Slack auto-clears the
+        // built-in 2-min TTL but the refresh loop re-applies it forever).
+        const plan = planType ? ` (plan: ${planType}, balance ${credits.balance ?? "0"})` : "";
+        posts.push({
+          role: "assistant",
+          kind: "text",
+          terminal: true,
+          text: `:warning: Codex is out of credits${plan}. The prompt was received but no output was produced, and this will keep failing until credits are topped up at https://chatgpt.com/codex/settings/usage`,
+        });
+      } else {
+        // Normal end of turn. Mark the most recent assistant text post in this
+        // batch as terminal so the bridge clears the working pill on it
+        // instead of setting a new one. The agent_message and task_complete
+        // events are written back-to-back in the rollout, so the same poll
+        // tick almost always sees both; the cross-batch case is covered by
+        // bridge.ts watching the raw objs for task_complete.
+        for (let i = posts.length - 1; i >= 0; i--) {
+          if (posts[i].role === "assistant" && posts[i].kind === "text") {
+            posts[i] = { ...posts[i], terminal: true };
+            break;
+          }
+        }
+      }
     }
   }
   return coalesceTools(posts);


### PR DESCRIPTION
## Summary
Codex writes a `task_complete` event_msg to its rollout the moment a turn finishes; the assistant's final text is the `agent_message` immediately before it. The bridge only watched for the out-of-credits flavour of `task_complete` (where `last_agent_message == null`), so any normal completed turn left the working pill lit on the assistant's last post forever — the refresh loop kept re-setting it every minute and the channel showed "is working…" on a turn that ended hours ago.

Two paths cover the in-batch and cross-batch cases:
1. `format.ts`: when a non-out-of-credits `task_complete` lands in the same poll batch as the final `agent_message`, mark that text post terminal. The bridge's existing terminal-text path skips the new pill and the previous anchor's pill is cleared in the normal flow. This is the common case — `agent_message` and `task_complete` are written back-to-back in the rollout, so a single poll tick sees both.
2. `bridge.ts`: cross-batch safety net. If a poll tick sees a `task_complete` but emits no terminal text (because the `agent_message` was already posted in a prior tick), clear the active pill directly.

## Test plan
- [ ] All 242 existing CLI tests pass.
- [ ] Deploy to the dev box, restart `agents-slack-bridge.service`.
- [ ] Trigger a normal pr-reviewer turn end to end via Slack. The "is working…" pill clears within `pollMs` of the agent's last text post.
- [ ] No `clear pill on codex task_complete` errors in `journalctl -u agents-slack-bridge.service`.