### PR TITLE
slack: drop the eyes-emoji ack post; light the pill on the prior anchor

### DIFF
--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -518,34 +518,30 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     recentRelays.set(decision.slug, relays);
     pasteTmuxPrompt(decision.slug, prompt); // tmux session name == slug
 
-    // Post a tiny bot-authored anchor so the working pill has something to
-    // attach to immediately. Without this the channel looks dead for the
-    // 10-20s between the human typing and the agent's first text post (which
-    // is the natural pill anchor for the existing flow). Slack's
-    // assistant.threads.setStatus only accepts thread roots authored by the
-    // app itself, so we cannot pin the pill to the human's own message
-    // (that would 400 with invalid_thread_ts).
+    // Light the working pill immediately so the channel shows activity
+    // within seconds of the relay, instead of looking dead until the
+    // agent's first text post (10-20s later). Slack's
+    // assistant.threads.setStatus only accepts thread roots authored by
+    // the app itself, so the human's own message ts is not a valid
+    // anchor. Instead, reuse the most recent app-authored anchor for the
+    // slug (the previous turn's text post). No new bot message is
+    // posted — the pill rides on the existing prior reply. The agent's
+    // first text post in this turn will then become the new anchor via
+    // the existing post loop, moving the pill onto it.
     //
-    // The eyes emoji is chosen for minimal noise: a single character that
-    // reads as "received, on it" and renders cleanly next to the working
-    // pill ("is working…"). The agent's first real text post will become
-    // the new thread root via the existing post loop, draining any tools
-    // accumulated in the meantime under this anchor and moving the pill
-    // onto the narrative text.
+    // If there is no prior anchor (very first interaction with the
+    // agent), skip: the pill will appear the natural way on the first
+    // reply. That happens once per agent lifetime, so the one-time
+    // delay is acceptable to avoid a noise-only bot post.
     if (event.channel) {
-      try {
-        const ts = await client.post(event.channel, "👀");
-        if (ts) {
-          writeThreadRoot(decision.slug, ts);
-          try {
-            await client.setStatus(event.channel, ts, WORKING_LABEL);
-            setActivePill(decision.slug, { channelId: event.channel, threadTs: ts, label: WORKING_LABEL, lastSetMs: Date.now() });
-          } catch (e) {
-            console.error(`setStatus on relay anchor for ${decision.slug} failed:`, e);
-          }
+      const prevAnchor = readThreadRoot(decision.slug);
+      if (prevAnchor) {
+        try {
+          await client.setStatus(event.channel, prevAnchor, WORKING_LABEL);
+          setActivePill(decision.slug, { channelId: event.channel, threadTs: prevAnchor, label: WORKING_LABEL, lastSetMs: Date.now() });
+        } catch (e) {
+          console.error(`setStatus on prior anchor for ${decision.slug} failed:`, e);
         }
-      } catch (e) {
-        console.error(`relay anchor post for ${decision.slug} failed:`, e);
       }
     }
   });


### PR DESCRIPTION
## Summary
- Removes the 👀 bot post that PR #85 introduced as the pill anchor for Slack-relayed prompts. It was visible noise in every channel.
- Reuses the most recent app-authored thread root for the slug (the prior turn's text post) as the setStatus anchor. The pill rides on that existing post until the agent's first reply in this turn lands, at which point the existing post loop drains buffered tools under the prior anchor and moves the pill onto the new narrative text. Same end-state, zero new posts.
- First-ever interaction with an agent (no prior anchor): skips. The pill appears the natural way on the agent's first reply. One-time delay per agent install.

## Test plan
- [ ] All 242 existing CLI tests pass.
- [ ] Box bridge restart on this branch: typing a prompt in an agent channel lights the working pill on the previous bot post within a second, no new bot message appears, and the pill migrates onto the agent's first real reply when it lands.
- [ ] First interaction with a fresh agent: no pill until the agent's first reply, no errors in `journalctl -u agents-slack-bridge.service`.

See: https://github.com/langwatch/kanban-code/pull/85 (eyes-emoji ack original) and https://github.com/langwatch/kanban-code/pull/86 (codex turn-end pill drop).