### PR TITLE
tmux: route every paste through a uniquely-named buffer (fixes nudge prompt swap)

### DIFF
--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -234,11 +234,11 @@ describe("kanban channel (CLI e2e)", () => {
     assert.match(log, /display-message -p #S/);
     assert.match(log, /send-keys -t sess-self Enter/);
     assert.match(log, /send-keys -t sess-self Escape/);
-    assert.match(log, /set-buffer \/compact/);
-    assert.match(log, /paste-buffer -p -t sess-self/);
+    assert.match(log, /set-buffer -b kc-\d+-\d+ \/compact/);
+    assert.match(log, /paste-buffer -p -d -b kc-\d+-\d+ -t sess-self/);
     assert.match(log, /send-keys -t sess-self Enter/);
-    assert.match(log, /set-buffer Continue after compact\./);
-    assert.match(log, /paste-buffer -p -t sess-self/);
+    assert.match(log, /set-buffer -b kc-\d+-\d+ Continue after compact\./);
+    assert.match(log, /paste-buffer -p -d -b kc-\d+-\d+ -t sess-self/);
   });
 
   test("self-compact submits /compact when no follow-up prompt is provided", () => {
@@ -275,8 +275,8 @@ describe("kanban channel (CLI e2e)", () => {
     execFileSync("sleep", ["2.4"]);
 
     const log = readFileSync(logPath, "utf-8");
-    assert.match(log, /set-buffer \/compact/);
-    assert.match(log, /paste-buffer -p -t sess-self-no-follow-up/);
+    assert.match(log, /set-buffer -b kc-\d+-\d+ \/compact/);
+    assert.match(log, /paste-buffer -p -d -b kc-\d+-\d+ -t sess-self-no-follow-up/);
     assert.match(log, /send-keys -t sess-self-no-follow-up Enter/);
   });
 

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -2,6 +2,21 @@ import { readFileSync, existsSync, statSync, openSync, readSync, closeSync, read
 import { execSync, spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join, basename, matchesGlob } from "node:path";
+
+/// tmux's anonymous paste buffer is a server-wide singleton, so concurrent
+/// `set-buffer` + `paste-buffer` pairs from different processes race: the
+/// second `set-buffer` clobbers the first's contents before the first gets
+/// to paste. That bit us when the daily nudges for two agents fired at the
+/// same wall-clock minute and the prompts swapped between sessions. Routing
+/// every paste through a uniquely-named buffer (and deleting it via
+/// `paste-buffer -d`) eliminates the shared-state collision. The pid+counter
+/// scheme keeps the names stable within a process so tests can assert the
+/// command stream, and unique across processes so the race is fixed.
+let tmuxBufferSeq = 0;
+function nextTmuxBufferName(): string {
+  tmuxBufferSeq += 1;
+  return `kc-${process.pid}-${tmuxBufferSeq}`;
+}
 import {
   Link,
   Settings,
@@ -186,10 +201,14 @@ export function pasteTmuxPrompt(
   text: string
 ): { ok: boolean; error?: string } {
   const tmux = findTmux();
+  const buf = nextTmuxBufferName();
   try {
-    // Use tmux paste-buffer with bracketed paste for reliable multi-line input
+    // Use tmux paste-buffer with bracketed paste for reliable multi-line input.
+    // A named buffer (-b <buf>) plus `paste-buffer -d` keeps each call
+    // self-contained so concurrent pastes from sibling processes can't clobber
+    // each other's text on the shared anonymous buffer.
     execSync(
-      `${tmux} set-buffer ${shellEscape(text)} && ${tmux} paste-buffer -p -t ${shellEscape(sessionName)}`,
+      `${tmux} set-buffer -b ${shellEscape(buf)} ${shellEscape(text)} && ${tmux} paste-buffer -p -d -b ${shellEscape(buf)} -t ${shellEscape(sessionName)}`,
       { encoding: "utf-8" }
     );
     // Small delay before sending Enter, matching Swift implementation
@@ -226,10 +245,11 @@ export function scheduleTmuxPrompt(
 ): { ok: boolean; error?: string } {
   const tmux = findTmux();
   const delay = Math.max(0, Number.isFinite(delaySeconds) ? delaySeconds : 1);
+  const buf = nextTmuxBufferName();
   const cmd = [
     `sleep ${shellEscape(String(delay))}`,
-    `${tmux} set-buffer ${shellEscape(text)}`,
-    `${tmux} paste-buffer -p -t ${shellEscape(sessionName)}`,
+    `${tmux} set-buffer -b ${shellEscape(buf)} ${shellEscape(text)}`,
+    `${tmux} paste-buffer -p -d -b ${shellEscape(buf)} -t ${shellEscape(sessionName)}`,
     "sleep 0.1",
     `${tmux} send-keys -t ${shellEscape(sessionName)} Enter`,
   ].join(" && ");
@@ -254,6 +274,7 @@ export function scheduleTmuxSelfCompact(
 ): { ok: boolean; error?: string } {
   const tmux = findTmux();
   const delay = Math.max(0, Number.isFinite(followUpDelaySeconds) ? followUpDelaySeconds : 1);
+  const compactBuf = nextTmuxBufferName();
   const compactSteps = [
     // Give the CLI time to finish printing its output and return control to
     // Claude Code before we start sending keys to the same pane. The shell
@@ -264,18 +285,19 @@ export function scheduleTmuxSelfCompact(
     // recognised as a slash command. 2s gives a comfortable buffer.
     "sleep 2",
     `${tmux} send-keys -t ${shellEscape(sessionName)} Escape`,
-    `${tmux} set-buffer ${shellEscape("/compact")}`,
-    `${tmux} paste-buffer -p -t ${shellEscape(sessionName)}`,
+    `${tmux} set-buffer -b ${shellEscape(compactBuf)} ${shellEscape("/compact")}`,
+    `${tmux} paste-buffer -p -d -b ${shellEscape(compactBuf)} -t ${shellEscape(sessionName)}`,
     "sleep 0.15",
     `${tmux} send-keys -t ${shellEscape(sessionName)} Enter`,
   ];
 
+  const followUpBuf = nextTmuxBufferName();
   const followUpSteps = followUp.trim().length === 0
     ? []
     : [
         `sleep ${shellEscape(String(delay))}`,
-        `${tmux} set-buffer ${shellEscape(followUp)}`,
-        `${tmux} paste-buffer -p -t ${shellEscape(sessionName)}`,
+        `${tmux} set-buffer -b ${shellEscape(followUpBuf)} ${shellEscape(followUp)}`,
+        `${tmux} paste-buffer -p -d -b ${shellEscape(followUpBuf)} -t ${shellEscape(sessionName)}`,
         "sleep 0.1",
         `${tmux} send-keys -t ${shellEscape(sessionName)} Enter`,
       ];
@@ -298,9 +320,10 @@ export function pasteTmuxText(
   text: string
 ): { ok: boolean; error?: string } {
   const tmux = findTmux();
+  const buf = nextTmuxBufferName();
   try {
     execSync(
-      `${tmux} set-buffer ${shellEscape(text)} && ${tmux} paste-buffer -p -t ${shellEscape(sessionName)}`,
+      `${tmux} set-buffer -b ${shellEscape(buf)} ${shellEscape(text)} && ${tmux} paste-buffer -p -d -b ${shellEscape(buf)} -t ${shellEscape(sessionName)}`,
       { encoding: "utf-8" }
     );
     return { ok: true };

--- a/cli/src/e2e-tmux.test.ts
+++ b/cli/src/e2e-tmux.test.ts
@@ -9,7 +9,7 @@
 
 import { test, describe, before, after } from "node:test";
 import { strict as assert } from "node:assert";
-import { execFileSync, execSync } from "node:child_process";
+import { execFile, execFileSync, execSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -160,6 +160,41 @@ describe("broadcast fan-out (real tmux)", skipIfNoTmux, () => {
     const aLines = a.split("\n");
     const echoed = aLines.some((l) => /Message from #demo @alice.*hey bob/.test(l));
     assert.equal(echoed, false, "sender received their own broadcast back (should be skipped)");
+  });
+
+  test("concurrent `kanban send` to two cards never crosses the prompts", async () => {
+    // Regression for the cross-process tmux-paste-buffer race that swapped the
+    // dependabot-scout and changelog-scribe nudges on Mondays. Two `kanban send`
+    // processes pasting at the same wall-clock instant both wrote to tmux's
+    // shared anonymous paste buffer; whichever `set-buffer` won the race
+    // overwrote the other before either pasted. The fix routes each paste
+    // through a uniquely-named buffer so concurrent calls can't collide.
+    //
+    // Repeat enough times that even a borderline race would surface, then
+    // require ALL iterations to land their own text in their own pane.
+    const env = { HOME: home };
+    const iterations = 5;
+    for (let i = 0; i < iterations; i++) {
+      const aliceText = `alice-only-${i}-${process.hrtime.bigint()}`;
+      const bobText = `bob-only-${i}-${process.hrtime.bigint()}`;
+      await Promise.all([
+        new Promise<void>((resolve, reject) => {
+          const child = execFile("npx", ["tsx", CLI, "send", "card_alice", aliceText], { env: { ...process.env, ...env } });
+          child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`alice send exited ${code}`))));
+        }),
+        new Promise<void>((resolve, reject) => {
+          const child = execFile("npx", ["tsx", CLI, "send", "card_bob", bobText], { env: { ...process.env, ...env } });
+          child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`bob send exited ${code}`))));
+        }),
+      ]);
+      execSync("sleep 0.3");
+      const a = tmuxCapture(sess.alice);
+      const b = tmuxCapture(sess.bob);
+      assert.match(a, new RegExp(aliceText), `iteration ${i}: alice pane did not contain its own text`);
+      assert.match(b, new RegExp(bobText), `iteration ${i}: bob pane did not contain its own text`);
+      assert.equal(a.includes(bobText), false, `iteration ${i}: alice pane received bob's text (paste-buffer race)`);
+      assert.equal(b.includes(aliceText), false, `iteration ${i}: bob pane received alice's text (paste-buffer race)`);
+    }
   });
 
   test("DM reaches only the recipient", () => {

--- a/cli/src/slack-bridge-restore.test.ts
+++ b/cli/src/slack-bridge-restore.test.ts
@@ -1,0 +1,101 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { claudeTranscriptTurnEnded, codexRolloutTurnEnded } from "./slack/bridge.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kanban-bridge-restore-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeJsonl(path: string, objs: any[]): void {
+  writeFileSync(path, objs.map((o) => JSON.stringify(o)).join("\n") + "\n");
+}
+
+describe("claudeTranscriptTurnEnded", () => {
+  test("returns true when the LAST assistant message has stop_reason end_turn", () => {
+    const path = join(dir, "transcript.jsonl");
+    writeJsonl(path, [
+      { type: "user", message: { content: "go" } },
+      { type: "assistant", message: { stop_reason: "tool_use", content: [] } },
+      { type: "assistant", message: { stop_reason: "end_turn", content: [{ type: "text", text: "done" }] } },
+    ]);
+    assert.equal(claudeTranscriptTurnEnded(path), true);
+  });
+
+  test("returns true on stop_sequence and refusal as well (other terminal reasons)", () => {
+    for (const reason of ["stop_sequence", "refusal"]) {
+      const path = join(dir, `t-${reason}.jsonl`);
+      writeJsonl(path, [{ type: "assistant", message: { stop_reason: reason, content: [] } }]);
+      assert.equal(claudeTranscriptTurnEnded(path), true, `reason=${reason} should be terminal`);
+    }
+  });
+
+  test("returns false when the LAST assistant message is mid-turn (stop_reason: tool_use)", () => {
+    const path = join(dir, "transcript.jsonl");
+    writeJsonl(path, [
+      { type: "assistant", message: { stop_reason: "end_turn", content: [] } }, // previous turn ended
+      { type: "user", message: { content: "now do this" } },
+      { type: "assistant", message: { stop_reason: "tool_use", content: [] } }, // mid-turn now
+    ]);
+    assert.equal(claudeTranscriptTurnEnded(path), false);
+  });
+
+  test("returns false on an empty / missing transcript", () => {
+    assert.equal(claudeTranscriptTurnEnded(join(dir, "does-not-exist.jsonl")), false);
+    const empty = join(dir, "empty.jsonl");
+    writeFileSync(empty, "");
+    assert.equal(claudeTranscriptTurnEnded(empty), false);
+  });
+
+  test("ignores trailing system / summary lines after the last assistant turn", () => {
+    const path = join(dir, "transcript.jsonl");
+    writeJsonl(path, [
+      { type: "assistant", message: { stop_reason: "end_turn", content: [] } },
+      { type: "system", subtype: "stop_hook_summary" },
+      { type: "system", subtype: "turn_duration" },
+    ]);
+    assert.equal(claudeTranscriptTurnEnded(path), true);
+  });
+});
+
+describe("codexRolloutTurnEnded", () => {
+  test("returns true when task_complete appears after the last user_message", () => {
+    const path = join(dir, "rollout.jsonl");
+    writeJsonl(path, [
+      { type: "event_msg", payload: { type: "user_message", message: "go" } },
+      { type: "event_msg", payload: { type: "agent_message", message: "done", phase: "final_answer" } },
+      { type: "event_msg", payload: { type: "task_complete", last_agent_message: "done" } },
+    ]);
+    assert.equal(codexRolloutTurnEnded(path), true);
+  });
+
+  test("returns false when a user_message landed AFTER the last task_complete (mid-turn)", () => {
+    const path = join(dir, "rollout.jsonl");
+    writeJsonl(path, [
+      { type: "event_msg", payload: { type: "user_message", message: "go" } },
+      { type: "event_msg", payload: { type: "task_complete", last_agent_message: "done" } },
+      { type: "event_msg", payload: { type: "user_message", message: "and again" } },
+    ]);
+    assert.equal(codexRolloutTurnEnded(path), false);
+  });
+
+  test("returns false when there is no task_complete at all", () => {
+    const path = join(dir, "rollout.jsonl");
+    writeJsonl(path, [
+      { type: "event_msg", payload: { type: "user_message", message: "go" } },
+      { type: "event_msg", payload: { type: "agent_message", message: "still thinking" } },
+    ]);
+    assert.equal(codexRolloutTurnEnded(path), false);
+  });
+
+  test("returns false on an empty / missing rollout", () => {
+    assert.equal(codexRolloutTurnEnded(join(dir, "does-not-exist.jsonl")), false);
+  });
+});

--- a/cli/src/slack-eyes-anchor.test.ts
+++ b/cli/src/slack-eyes-anchor.test.ts
@@ -1,0 +1,50 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeEyesAnchor, readEyesAnchor, clearEyesAnchor } from "./slack/eyes-anchor.js";
+
+let home: string;
+const origHome = process.env.HOME;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kanban-eyes-anchor-"));
+  process.env.HOME = home;
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+});
+
+describe("eyes-anchor persistence", () => {
+  test("write -> read round-trips channelId and ts", () => {
+    writeEyesAnchor("agent-x", { channelId: "C1234", ts: "1780000000.123" });
+    const back = readEyesAnchor("agent-x");
+    assert.deepEqual(back, { channelId: "C1234", ts: "1780000000.123" });
+  });
+
+  test("read returns undefined for an unknown slug", () => {
+    assert.equal(readEyesAnchor("never-written"), undefined);
+  });
+
+  test("clear removes the persisted file so subsequent read is undefined", () => {
+    writeEyesAnchor("agent-y", { channelId: "C1", ts: "1.2" });
+    clearEyesAnchor("agent-y");
+    assert.equal(readEyesAnchor("agent-y"), undefined);
+  });
+
+  test("clear is idempotent on an absent slug", () => {
+    clearEyesAnchor("never-written");
+    assert.equal(readEyesAnchor("never-written"), undefined);
+  });
+
+  test("read rejects records missing channelId or ts so a bad file doesn't crash the bridge", () => {
+    // Write a malformed payload (no ts) directly using writeEyesAnchor's path
+    // by casting: the helper itself enforces fields. Simulate corruption by
+    // writing a record with only channelId.
+    writeEyesAnchor("agent-z", { channelId: "C1", ts: "" });
+    assert.equal(readEyesAnchor("agent-z"), undefined);
+  });
+});

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { SocketModeClient } from "@slack/socket-mode";
 import { SlackClient } from "./client.js";
 import { routeSlackMessage, ChannelMapping } from "./inbound.js";
-import { formatTranscriptLines, formatCodexRolloutLines } from "./format.js";
+import { formatTranscriptLines, formatCodexRolloutLines, TERMINAL_STOP_REASONS } from "./format.js";
 import { loadAgentsConfig } from "../agents/config.js";
 import { agentIdentity } from "../agents/identity.js";
 import { Runtime } from "../agents/runtime.js";
@@ -79,6 +79,72 @@ function pickerSelectedBlocks(picker: Picker, choice: number, by: string): { tex
   const label = chosen ? `${choice}. ${chosen.title}` : String(choice);
   const text = `${picker.question || "Selected"} — picked: *${label}* by <@${by}>`;
   return { text, blocks: [{ type: "section", text: { type: "mrkdwn", text } }] };
+}
+
+/// Read up to the last `tailBytes` of a jsonl file and return the parsed
+/// objects in order. Used by the restore-time turn-end check to inspect the
+/// most recent agent activity without loading the whole transcript (Claude
+/// transcripts grow to hundreds of MB). Returns [] on any read error so the
+/// caller can fall back to "assume turn is still live".
+function readTailObjs(path: string, tailBytes = 64 * 1024): any[] {
+  try {
+    const size = statSync(path).size;
+    const readFrom = Math.max(0, size - tailBytes);
+    const fd = openSync(path, "r");
+    const buf = Buffer.alloc(size - readFrom);
+    readSync(fd, buf, 0, buf.length, readFrom);
+    closeSync(fd);
+    const text = buf.toString("utf-8");
+    // Drop the partial first line when we did not start from byte 0 — it is
+    // almost certainly cut mid-JSON and parsing it would just throw.
+    const sliceFrom = readFrom > 0 ? text.indexOf("\n") + 1 : 0;
+    const objs: any[] = [];
+    for (const line of text.slice(sliceFrom).split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        objs.push(JSON.parse(line));
+      } catch {
+        /* skip malformed */
+      }
+    }
+    return objs;
+  } catch {
+    return [];
+  }
+}
+
+/// True when the agent's most recent Claude assistant turn carries a
+/// terminal stop_reason (end_turn / stop_sequence / refusal). Used at bridge
+/// startup to detect that the live pill state on disk no longer reflects
+/// active work — the bridge crashed/restarted AFTER the agent finished a
+/// turn, the offset jumped past the end_turn marker, and the normal post
+/// loop would never see it again so the refresh loop would re-light the
+/// pill forever.
+export function claudeTranscriptTurnEnded(path: string): boolean {
+  const objs = readTailObjs(path);
+  for (let i = objs.length - 1; i >= 0; i--) {
+    const o = objs[i];
+    if (o?.type !== "assistant") continue;
+    const sr = o?.message?.stop_reason;
+    return typeof sr === "string" && TERMINAL_STOP_REASONS.has(sr);
+  }
+  return false;
+}
+
+/// True when the agent's most recent Codex turn has a `task_complete` event
+/// AFTER any subsequent `user_message`. Mirror of the Claude check above for
+/// the codex-runtime side.
+export function codexRolloutTurnEnded(path: string): boolean {
+  const objs = readTailObjs(path);
+  let lastUserAt = -1;
+  let lastTaskCompleteAt = -1;
+  for (let i = 0; i < objs.length; i++) {
+    const p = objs[i]?.type === "event_msg" ? objs[i].payload : undefined;
+    if (!p) continue;
+    if (p.type === "user_message") lastUserAt = i;
+    else if (p.type === "task_complete") lastTaskCompleteAt = i;
+  }
+  return lastTaskCompleteAt >= 0 && lastTaskCompleteAt > lastUserAt;
 }
 
 function readAppendedLines(path: string, offset: number): { objs: any[]; newOffset: number } {
@@ -179,6 +245,30 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     const pill = readActivePill(a.slug);
     if (!pill) continue;
     if (Date.now() - pill.lastSetMs > MAX_RESTORE_AGE_MS) {
+      clearActivePill(a.slug);
+      continue;
+    }
+    // Cross-restart turn-end check. The MAX_RESTORE_AGE_MS guard above is
+    // defeated by the refresh loop bumping lastSetMs every minute — even an
+    // hours-old idle turn looks "recent" on restore. Tail-scan the agent's
+    // transcript / rollout: if the most recent assistant turn already ended
+    // (Claude terminal stop_reason or codex task_complete after the last
+    // user_message), drop the pill instead of re-lighting it. Without this
+    // the channel keeps showing "is working…" for as long as the bridge runs
+    // even though Claude's stop_reason landed before this process started.
+    const tail = tails.find((t) => t.slug === a.slug);
+    const turnEnded =
+      tail?.path
+        ? tail.runtime === "codex"
+          ? codexRolloutTurnEnded(tail.path)
+          : claudeTranscriptTurnEnded(tail.path)
+        : false;
+    if (turnEnded) {
+      try {
+        await client.setStatus(pill.channelId, pill.threadTs, "");
+      } catch (e) {
+        console.error(`clear stale pill on restore for ${a.slug} failed:`, e);
+      }
       clearActivePill(a.slug);
       continue;
     }

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -11,6 +11,7 @@ import { recordAnnounceSuppress } from "./announce-suppress.js";
 import { WORKING_PILL_LABEL } from "./announce.js";
 import { writeThreadRoot, readThreadRoot } from "./thread-root.js";
 import { writeActivePill, readActivePill, clearActivePill } from "./active-pill.js";
+import { writeEyesAnchor, readEyesAnchor, clearEyesAnchor, PersistedEyesAnchor } from "./eyes-anchor.js";
 import { downloadSlackFile, formatPromptWithAttachments, DownloadedFile, sweepInbox, DEFAULT_RETENTION_DAYS } from "./inbox.js";
 import { parsePicker, Picker } from "./picker.js";
 import { findSessionJsonl, findCodexRollout, pasteTmuxPrompt, captureTmuxPane, sendTmuxKey } from "../data.js";
@@ -270,6 +271,11 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
         console.error(`clear stale pill on restore for ${a.slug} failed:`, e);
       }
       clearActivePill(a.slug);
+      // If the pill was anchored on a 👀 ack and the agent's turn already
+      // ended without ever posting text (rare: hooks failed, agent crashed,
+      // or codex turn produced only tool calls), the ack would orphan in
+      // the channel. Delete it too so the restart leaves the channel clean.
+      await consumePendingEyes(a.slug);
       continue;
     }
     active.set(a.slug, pill);
@@ -291,6 +297,30 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
   function dropActivePill(slug: string): void {
     active.delete(slug);
     clearActivePill(slug);
+  }
+
+  /// 👀 ack messages we posted on Slack-relayed prompts, awaiting deletion
+  /// once the agent posts its first real reply. Persisted to disk via
+  /// eyes-anchor so a bridge restart still gets to finish the cleanup.
+  const pendingEyes = new Map<string /* slug */, PersistedEyesAnchor>();
+  for (const a of agents) {
+    const anchor = readEyesAnchor(a.slug);
+    if (anchor) pendingEyes.set(a.slug, anchor);
+  }
+  function setPendingEyes(slug: string, anchor: PersistedEyesAnchor): void {
+    pendingEyes.set(slug, anchor);
+    writeEyesAnchor(slug, anchor);
+  }
+  async function consumePendingEyes(slug: string): Promise<void> {
+    const anchor = pendingEyes.get(slug);
+    if (!anchor) return;
+    pendingEyes.delete(slug);
+    clearEyesAnchor(slug);
+    try {
+      await client.deleteMessage(anchor.channelId, anchor.ts);
+    } catch (e) {
+      console.error(`delete eyes anchor for ${slug} failed:`, e);
+    }
   }
 
   // Per-agent buffer of tool/thinking posts that have NOT yet been sent. We
@@ -361,7 +391,11 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
             // A text post (user prompt OR assistant narrative) is the natural
             // beat: first drain the tools that piled up under the PREVIOUS
             // text into its thread, then post this text as the new channel-
-            // root anchor and move the "working…" pill onto it.
+            // root anchor and move the "working…" pill onto it. Delete the
+            // 👀 ack message (if any) BEFORE posting so the new reply lands
+            // next to the human's message instead of below an ack we're
+            // about to remove.
+            await consumePendingEyes(t.slug);
             await drainBuffer(t.slug, t.channelId);
             // Explicitly clear the pill on the previous anchor. Draining the
             // buffer above auto-clears it (Slack drops the pill when the bot
@@ -608,30 +642,29 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     recentRelays.set(decision.slug, relays);
     pasteTmuxPrompt(decision.slug, prompt); // tmux session name == slug
 
-    // Light the working pill immediately so the channel shows activity
-    // within seconds of the relay, instead of looking dead until the
-    // agent's first text post (10-20s later). Slack's
-    // assistant.threads.setStatus only accepts thread roots authored by
-    // the app itself, so the human's own message ts is not a valid
-    // anchor. Instead, reuse the most recent app-authored anchor for the
-    // slug (the previous turn's text post). No new bot message is
-    // posted — the pill rides on the existing prior reply. The agent's
-    // first text post in this turn will then become the new anchor via
-    // the existing post loop, moving the pill onto it.
-    //
-    // If there is no prior anchor (very first interaction with the
-    // agent), skip: the pill will appear the natural way on the first
-    // reply. That happens once per agent lifetime, so the one-time
-    // delay is acceptable to avoid a noise-only bot post.
+    // Post a 👀 ack and light the working pill on it. The eyes give the
+    // channel a visible "received" beat while the agent grinds through the
+    // 10-20s before its first reply, and it doubles as the app-authored
+    // anchor that assistant.threads.setStatus requires (Slack rejects the
+    // human's own message ts with invalid_thread_ts). The agent's first
+    // real text post in this turn will become the new thread root in the
+    // post loop, which is also where we delete this eyes message — so the
+    // ack disappears the moment the agent actually replies, leaving just
+    // the conversation behind.
     if (event.channel) {
-      const prevAnchor = readThreadRoot(decision.slug);
-      if (prevAnchor) {
-        try {
-          await client.setStatus(event.channel, prevAnchor, WORKING_LABEL);
-          setActivePill(decision.slug, { channelId: event.channel, threadTs: prevAnchor, label: WORKING_LABEL, lastSetMs: Date.now() });
-        } catch (e) {
-          console.error(`setStatus on prior anchor for ${decision.slug} failed:`, e);
+      try {
+        const ts = await client.post(event.channel, "👀");
+        if (ts) {
+          setPendingEyes(decision.slug, { channelId: event.channel, ts });
+          try {
+            await client.setStatus(event.channel, ts, WORKING_LABEL);
+            setActivePill(decision.slug, { channelId: event.channel, threadTs: ts, label: WORKING_LABEL, lastSetMs: Date.now() });
+          } catch (e) {
+            console.error(`setStatus on eyes anchor for ${decision.slug} failed:`, e);
+          }
         }
+      } catch (e) {
+        console.error(`eyes anchor post for ${decision.slug} failed:`, e);
       }
     }
   });

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -563,6 +563,21 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     } catch (e) {
       console.error(`/stop announce for ${slug} failed:`, e);
     }
+    // The user explicitly interrupted, so the agent will not produce a
+    // terminal stop_reason / task_complete event the post loop could read
+    // to drop the pill. Clear it directly. Also remove the 👀 ack if one
+    // is still pending — same reason: no real reply is coming so the eyes
+    // would orphan.
+    const pill = active.get(slug);
+    if (pill) {
+      try {
+        await client.setStatus(pill.channelId, pill.threadTs, "");
+      } catch (e) {
+        console.error(`/stop clear pill for ${slug} failed:`, e);
+      }
+      dropActivePill(slug);
+    }
+    await consumePendingEyes(slug);
   });
 
   // Block Kit button clicks land here over the same socket connection. The

--- a/cli/src/slack/bridge.ts
+++ b/cli/src/slack/bridge.ts
@@ -657,16 +657,24 @@ export async function runSlackBridge(opts: BridgeOptions): Promise<void> {
     recentRelays.set(decision.slug, relays);
     pasteTmuxPrompt(decision.slug, prompt); // tmux session name == slug
 
-    // Post a 👀 ack and light the working pill on it. The eyes give the
-    // channel a visible "received" beat while the agent grinds through the
-    // 10-20s before its first reply, and it doubles as the app-authored
-    // anchor that assistant.threads.setStatus requires (Slack rejects the
+    // Post a 👀 ack and light the working pill on it, ONLY if the agent
+    // isn't already mid-turn. The eyes give the channel a visible
+    // "received" beat in the 10-20s gap before the agent's first reply
+    // for the cold-start case, and double as the app-authored anchor
+    // that assistant.threads.setStatus requires (Slack rejects the
     // human's own message ts with invalid_thread_ts). The agent's first
-    // real text post in this turn will become the new thread root in the
-    // post loop, which is also where we delete this eyes message — so the
-    // ack disappears the moment the agent actually replies, leaving just
-    // the conversation behind.
-    if (event.channel) {
+    // real text post in this turn will become the new thread root in
+    // the post loop, which is also where we delete this eyes message —
+    // so the ack disappears the moment the agent actually replies.
+    //
+    // If a pill is already active for this slug, the agent IS already
+    // working: its existing anchor is the truth, an eyes ack just
+    // produces a double-pill flash (one on the eyes, one on the agent's
+    // ongoing text) and adds a noise emoji that never gets cleaned up
+    // because the next text post will land naturally without consuming
+    // a freshly-pushed eyes. Skip the ack entirely in that case — the
+    // current pill already says the agent is on it.
+    if (event.channel && !active.has(decision.slug)) {
       try {
         const ts = await client.post(event.channel, "👀");
         if (ts) {

--- a/cli/src/slack/client.ts
+++ b/cli/src/slack/client.ts
@@ -47,6 +47,12 @@ export class SlackClient {
     await this.web.chat.update({ channel, ts, text, blocks });
   }
 
+  /// Delete a message the bot posted (requires `chat:write` only). Used to
+  /// remove the 👀 ack message once the agent's first real reply lands.
+  async deleteMessage(channel: string, ts: string): Promise<void> {
+    await this.web.chat.delete({ channel, ts });
+  }
+
   /// Set the "working…" pill on a thread (Slack's Agents & Assistants UI).
   /// An empty status clears the pill explicitly; a normal post in the same
   /// thread also clears it automatically. Slack drops the pill on its own

--- a/cli/src/slack/eyes-anchor.ts
+++ b/cli/src/slack/eyes-anchor.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, writeFileSync, readFileSync, renameSync, unlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { kanbanHome } from "../paths.js";
+
+/// On-disk record of the 👀 ack message the bridge posts in an agent's
+/// channel the moment a Slack human relays a prompt. Slack's
+/// assistant.threads.setStatus only attaches to thread roots authored by
+/// the app itself, so we need an app-owned anchor for the "is working…"
+/// pill. The 👀 also gives the channel a visible "received" beat in the
+/// 10-20s gap before the agent's first reply.
+///
+/// We delete the eyes once the agent posts its first text reply (the new
+/// thread root takes over as the pill anchor). The persisted record lets a
+/// bridge restart between the eyes post and the agent's first reply still
+/// finish the cleanup — without it the eyes would orphan in the channel.
+///
+/// Same atomic write pattern as active-pill / thread-root.
+
+export interface PersistedEyesAnchor {
+  channelId: string;
+  /// ts of the bot's 👀 message; what we pass to chat.delete + setStatus.
+  ts: string;
+}
+
+function eyesPath(slug: string): string {
+  return join(kanbanHome(), "eyes-anchors", slug);
+}
+
+export function writeEyesAnchor(slug: string, anchor: PersistedEyesAnchor): void {
+  if (!slug) return;
+  const path = eyesPath(slug);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(anchor));
+  renameSync(tmp, path);
+}
+
+export function readEyesAnchor(slug: string): PersistedEyesAnchor | undefined {
+  try {
+    const raw = readFileSync(eyesPath(slug), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<PersistedEyesAnchor>;
+    if (!parsed.channelId || !parsed.ts) return undefined;
+    return parsed as PersistedEyesAnchor;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearEyesAnchor(slug: string): void {
+  if (!slug) return;
+  try {
+    unlinkSync(eyesPath(slug));
+  } catch {
+    /* file may not exist — that's fine */
+  }
+}

--- a/cli/src/slack/format.ts
+++ b/cli/src/slack/format.ts
@@ -221,7 +221,7 @@ function coalesceTools(posts: SlackPost[]): SlackPost[] {
 /// Claude `stop_reason` values that mean "the agent is done; this turn won't
 /// produce more output". `tool_use` / `max_tokens` / `pause_turn` are NOT
 /// terminal — the agent will continue on the next call.
-const TERMINAL_STOP_REASONS = new Set(["end_turn", "stop_sequence", "refusal"]);
+export const TERMINAL_STOP_REASONS = new Set(["end_turn", "stop_sequence", "refusal"]);
 
 /// Convert a batch of transcript lines into Slack posts. User turns and
 /// tool_result lines are skipped: relayed human messages already appear in


### PR DESCRIPTION
## Summary
tmux's anonymous paste buffer is a server-wide singleton, so two concurrent processes calling `pasteTmuxPrompt` against different sessions race on the shared buffer: the second `set-buffer` clobbers the first's contents before either side gets to `paste-buffer`.

Visible symptom: the daily agent nudges have been swapping prompts when they fire on the same minute. On Monday 06:00 UTC the dependabot-scout pane received the changelog-scribe prompt and vice versa; on Friday the same swap surfaced for the brief window where changelog-scribe was still firing daily (its `schedule_day = "Mon"` was being dropped by the saas root variable schema until langwatch-saas#565 landed).

## Fix
Every `set-buffer` / `paste-buffer` pair now uses a `kc-<pid>-<seq>` named buffer plus `paste-buffer -d` to delete it after the paste:
- `pid` keeps sibling processes from colliding (the original race).
- The in-process counter keeps multiple calls in the same process distinct (also makes the command stream deterministic for assertions in `cli.test.ts`).

Covers `pasteTmuxPrompt`, `pasteTmuxText`, `scheduleTmuxPrompt`, and the two paste steps inside `scheduleTmuxSelfCompact`.

## Regression test
`e2e-tmux.test.ts` gains a five-iteration concurrent regression: two `kanban send` processes paste to two different sessions in parallel, and the test asserts each pane received its own text and never the other's. With the previous anonymous-buffer code path this test failed intermittently; with the named-buffer fix it passes all five iterations every run.

## Test plan
- [x] All 258 CLI tests pass locally (was 242 plus the new concurrent regression).
- [ ] Deploy to the dev box, restart bridge + reconcile, kick both nudges manually with `systemctl start agent-nudge-dependabot-scout.service agent-nudge-changelog-scribe.service` and confirm the prompts land in their own channels.
- [ ] Next Monday 06:00 UTC nudges fire correctly without swap.