### PR TITLE
fix: move ended sessions out of waiting

### DIFF
--- a/Sources/KanbanCodeCore/UseCases/AssignColumn.swift
+++ b/Sources/KanbanCodeCore/UseCases/AssignColumn.swift
@@ -68,8 +68,10 @@ public enum AssignColumn {
                 // Only .activelyWorking should keep a card in In Progress.
                 return .waiting
             case .ended:
-                if hasWorktree { return .waiting }
-                // No worktree: fall through to recency check below
+                // Finished assistant sessions should leave the triage lanes.
+                // PR cards are handled above, and genuinely idle sessions use
+                // `.needsAttention` or `.idleWaiting`.
+                return .allSessions
             case .stale:
                 break // No hook data: fall through to recency check below
             }

--- a/Tests/KanbanCodeCoreTests/AssignColumnTests.swift
+++ b/Tests/KanbanCodeCoreTests/AssignColumnTests.swift
@@ -105,11 +105,11 @@ struct AssignColumnTests {
         #expect(col == .waiting)
     }
 
-    @Test("Ended with worktree → waiting")
+    @Test("Ended with worktree → allSessions")
     func endedWithWorktree() {
         let link = Link(sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .ended, hasWorktree: true)
-        #expect(col == .waiting)
+        #expect(col == .allSessions)
     }
 
     @Test("Stale + recent → waiting (falls through to recency check)")
@@ -126,11 +126,11 @@ struct AssignColumnTests {
         #expect(col == .allSessions)
     }
 
-    @Test("Ended without worktree, recent → waiting")
+    @Test("Ended without worktree, recent → allSessions")
     func endedNoWorktreeRecent() {
         let link = Link(lastActivity: Date.now.addingTimeInterval(-3600), sessionLink: SessionLink(sessionId: "s1"))
         let col = AssignColumn.assign(link: link, activityState: .ended)
-        #expect(col == .waiting)
+        #expect(col == .allSessions)
     }
 
     @Test("Ended without worktree, old → allSessions")

--- a/Tests/KanbanCodeCoreTests/CardLifecycleTests.swift
+++ b/Tests/KanbanCodeCoreTests/CardLifecycleTests.swift
@@ -86,7 +86,7 @@ struct CardLifecycleTests {
         #expect(link.column == .done)
     }
 
-    @Test("Ended session with worktree → waiting")
+    @Test("Ended session with worktree → allSessions")
     func endedWithWorktree() {
         var link = Link(
             column: .inProgress,
@@ -94,7 +94,7 @@ struct CardLifecycleTests {
             worktreeLink: WorktreeLink(path: "", branch: "feature-x")
         )
         UpdateCardColumn.update(link: &link, activityState: .ended, hasWorktree: true)
-        #expect(link.column == .waiting)
+        #expect(link.column == .allSessions)
     }
 
     @Test("Stale session → allSessions")


### PR DESCRIPTION
## Summary
- Move actually ended assistant sessions to All Sessions instead of keeping them in Waiting due to recency/worktree signals
- Update assignment and lifecycle tests for ended sessions

## Tests
- swift test --filter AssignColumnTests --filter CardLifecycleTests --filter ActivityDetectorTests --filter CodexActivityDetectorTests