### PR TITLE
feat(windows): DM panel + chat notifications + drafts watcher

### DIFF
--- a/windows/src-tauri/src/channels_watcher.rs
+++ b/windows/src-tauri/src/channels_watcher.rs
@@ -13,6 +13,7 @@ pub mod events {
     pub const CHANNEL_MESSAGES_CHANGED: &str = "channel-messages-changed";
     pub const DM_LOGS_CHANGED: &str = "dm-logs-changed";
     pub const READ_STATE_CHANGED: &str = "read-state-changed";
+    pub const DRAFTS_CHANGED: &str = "drafts-changed";
 }
 
 /// Spin up a background thread that watches the channels dir + the dm subdir,
@@ -98,6 +99,9 @@ fn dispatch(app: &AppHandle, base_dir: &Path, path: &Path) {
         }
         "read-state.json" => {
             let _ = app.emit(events::READ_STATE_CHANGED, ());
+        }
+        "drafts.json" => {
+            let _ = app.emit(events::DRAFTS_CHANGED, ());
         }
         _ if name.ends_with(".jsonl") => {
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -884,6 +884,64 @@ async fn save_drafts(
     state.channels_store.save_drafts(&drafts).await.map_err(|e| e.to_string())
 }
 
+/// Dispatch an OS + Pushover notification for an inbound chat message. The
+/// frontend decides *whether* to notify (foreground suppression, debounce,
+/// SELF-skip etc); this command just executes the dispatch, gated by the same
+/// settings toggles the card-finish path honors.
+#[tauri::command]
+async fn notify_chat_message(
+    app: tauri::AppHandle,
+    title: String,
+    body: String,
+    thread_id: Option<String>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let settings = state.settings_store.read().await.ok();
+    let os_enabled = settings
+        .as_ref()
+        .map(|s| s.notifications.notifications_enabled)
+        .unwrap_or(true);
+    let push_cfg = settings.and_then(|s| {
+        if s.notifications.pushover_enabled {
+            Some((
+                s.notifications.pushover_token.clone(),
+                s.notifications.pushover_user_key.clone(),
+            ))
+        } else {
+            None
+        }
+    });
+
+    if os_enabled {
+        let _ = app
+            .notification()
+            .builder()
+            .title(title.clone())
+            .body(body.clone())
+            .show();
+    }
+    if let Some((Some(token), Some(user))) =
+        push_cfg.as_ref().map(|(t, u)| (t.clone(), u.clone()))
+    {
+        let t = title.clone();
+        let b = body.clone();
+        let tid = thread_id.clone();
+        tokio::spawn(async move {
+            match pushover::send(&token, &user, &t, &b, tid.as_deref()).await {
+                Ok(()) => logging::info(
+                    "pushover",
+                    &format!("chat notification sent ({})", tid.as_deref().unwrap_or("-")),
+                ),
+                Err(e) => logging::warn(
+                    "pushover",
+                    &format!("chat notification failed: {e}"),
+                ),
+            }
+        });
+    }
+    Ok(())
+}
+
 // ── Background polling ───────────────────────────────────────────────────────
 
 fn start_polling(app: tauri::AppHandle) {
@@ -1509,6 +1567,7 @@ pub fn run() {
             save_read_state,
             get_drafts,
             save_drafts,
+            notify_chat_message,
         ])
         .setup(|app| {
             logging::info(

--- a/windows/src/components/Channels.tsx
+++ b/windows/src/components/Channels.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useChannelsStore } from "../store/channelsStore";
+import {
+  otherPartyOfPair,
+  partyDisplayName,
+  useChannelsStore,
+} from "../store/channelsStore";
 import { useBoardStore } from "../store/boardStore";
 import { useTheme, t } from "../theme";
 import type { Channel, ChannelMessage } from "../types";
@@ -11,15 +15,23 @@ export default function Channels() {
   const {
     channels,
     selectedChannel,
+    selectedDm,
     messagesByChannel,
+    messagesByDm,
+    dmPairs,
     drafts,
     error,
     init,
     selectChannel,
+    selectDm,
     sendMessage,
+    sendDm,
     createChannel,
+    openDmTo,
     saveDraft,
+    saveDmDraft,
     unreadCount,
+    unreadDmCount,
     clearError,
   } = useChannelsStore();
   const { setChatOpen } = useBoardStore();
@@ -27,6 +39,7 @@ export default function Channels() {
   const c = t(theme);
 
   const [newChannelOpen, setNewChannelOpen] = useState(false);
+  const [newDmOpen, setNewDmOpen] = useState(false);
 
   useEffect(() => {
     init();
@@ -34,19 +47,26 @@ export default function Channels() {
     // lets the unread counts update even when the chat panel is closed.
   }, []);
 
-  // Auto-select the first channel on first render if none is selected.
+  // Auto-select the first channel on first render if nothing is selected.
   useEffect(() => {
-    if (!selectedChannel && channels.length > 0) {
+    if (!selectedChannel && !selectedDm && channels.length > 0) {
       selectChannel(channels[0].name);
     }
-  }, [channels, selectedChannel, selectChannel]);
+  }, [channels, selectedChannel, selectedDm, selectChannel]);
 
   const selected = useMemo(
     () => channels.find((ch) => ch.name === selectedChannel) ?? null,
     [channels, selectedChannel]
   );
-  const messages = selectedChannel ? messagesByChannel[selectedChannel] ?? [] : [];
-  const draft = selectedChannel ? drafts.channels[selectedChannel] ?? "" : "";
+  const channelMessages = selectedChannel
+    ? messagesByChannel[selectedChannel] ?? []
+    : [];
+  const channelDraft = selectedChannel
+    ? drafts.channels[selectedChannel] ?? ""
+    : "";
+
+  const dmMessages = selectedDm ? messagesByDm[selectedDm] ?? [] : [];
+  const dmDraft = selectedDm ? drafts.dms[selectedDm] ?? "" : "";
 
   return (
     <div className="flex-1 flex overflow-hidden">
@@ -73,35 +93,21 @@ export default function Channels() {
               </svg>
             </button>
             <span className="text-[13px] font-semibold" style={{ color: c.textPrimary }}>
-              Channels
+              Chat
             </span>
           </div>
-          <button
-            onClick={() => setNewChannelOpen(true)}
-            className="p-1 rounded transition-colors"
-            style={{ color: c.textMuted }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = c.hoverBg;
-              e.currentTarget.style.color = c.textPrimary;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = "";
-              e.currentTarget.style.color = c.textMuted;
-            }}
-            title="Create channel"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-            </svg>
-          </button>
         </div>
 
         <div className="flex-1 overflow-y-auto py-2">
+          <SidebarHeader
+            label="Channels"
+            onAdd={() => setNewChannelOpen(true)}
+            addTitle="Create channel"
+            c={c}
+          />
           {channels.length === 0 ? (
-            <div className="px-4 py-6 text-[12px] text-center" style={{ color: c.textMuted }}>
+            <div className="px-4 py-3 text-[12px]" style={{ color: c.textMuted }}>
               No channels yet.
-              <br />
-              Create one to start coordinating with agents.
             </div>
           ) : (
             channels.map((ch) => (
@@ -115,6 +121,29 @@ export default function Channels() {
               />
             ))
           )}
+
+          <SidebarHeader
+            label="Direct Messages"
+            onAdd={() => setNewDmOpen(true)}
+            addTitle="Start a DM"
+            c={c}
+          />
+          {dmPairs.length === 0 ? (
+            <div className="px-4 py-3 text-[12px]" style={{ color: c.textMuted }}>
+              No direct messages yet.
+            </div>
+          ) : (
+            dmPairs.map((key) => (
+              <DmRow
+                key={key}
+                pairKey={key}
+                selected={selectedDm === key}
+                unread={unreadDmCount(key)}
+                onClick={() => selectDm(key)}
+                c={c}
+              />
+            ))
+          )}
         </div>
       </aside>
 
@@ -123,16 +152,26 @@ export default function Channels() {
         {selected ? (
           <ChannelPane
             channel={selected}
-            messages={messages}
-            draft={draft}
+            messages={channelMessages}
+            draft={channelDraft}
             onSend={(body) => sendMessage(selected.name, body)}
             onDraftChange={(body) => saveDraft(selected.name, body)}
             c={c}
             theme={theme}
           />
+        ) : selectedDm ? (
+          <DmPane
+            pairKey={selectedDm}
+            messages={dmMessages}
+            draft={dmDraft}
+            onSend={(body) => sendDm(selectedDm, body)}
+            onDraftChange={(body) => saveDmDraft(selectedDm, body)}
+            c={c}
+            theme={theme}
+          />
         ) : (
           <div className="flex-1 flex items-center justify-center text-[13px]" style={{ color: c.textMuted }}>
-            Select a channel to start chatting.
+            Select a channel or DM to start chatting.
           </div>
         )}
       </main>
@@ -143,6 +182,18 @@ export default function Channels() {
           onCreate={async (name) => {
             const ch = await createChannel(name);
             if (ch) setNewChannelOpen(false);
+          }}
+          c={c}
+          theme={theme}
+        />
+      )}
+
+      {newDmOpen && (
+        <NewDmDialog
+          onCancel={() => setNewDmOpen(false)}
+          onOpen={async (target) => {
+            const key = await openDmTo(target);
+            if (key) setNewDmOpen(false);
           }}
           c={c}
           theme={theme}
@@ -166,7 +217,50 @@ export default function Channels() {
   );
 }
 
-// ── Sidebar row ──────────────────────────────────────────────────────────────
+// ── Sidebar section header with an inline "+" affordance ────────────────────
+
+function SidebarHeader({
+  label,
+  onAdd,
+  addTitle,
+  c,
+}: {
+  label: string;
+  onAdd: () => void;
+  addTitle: string;
+  c: ReturnType<typeof t>;
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 pt-3 pb-1">
+      <span
+        className="text-[10px] uppercase tracking-wider font-semibold"
+        style={{ color: c.textMuted }}
+      >
+        {label}
+      </span>
+      <button
+        onClick={onAdd}
+        className="p-0.5 rounded transition-colors"
+        style={{ color: c.textMuted }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = c.hoverBg;
+          e.currentTarget.style.color = c.textPrimary;
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "";
+          e.currentTarget.style.color = c.textMuted;
+        }}
+        title={addTitle}
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// ── Sidebar rows ─────────────────────────────────────────────────────────────
 
 function ChannelRow({
   channel,
@@ -198,20 +292,67 @@ function ChannelRow({
       }}
     >
       <span className="truncate"># {channel.name}</span>
-      {unread > 0 && (
-        <span
-          className="ml-2 shrink-0 inline-flex items-center justify-center text-[10px] font-semibold rounded-full px-1.5"
-          style={{
-            background: "#4f8ef7",
-            color: "white",
-            minWidth: 18,
-            height: 18,
-          }}
-        >
-          {unread > 99 ? "99+" : unread}
-        </span>
-      )}
+      {unread > 0 && <UnreadBadge count={unread} />}
     </button>
+  );
+}
+
+function DmRow({
+  pairKey,
+  selected,
+  unread,
+  onClick,
+  c,
+}: {
+  pairKey: string;
+  selected: boolean;
+  unread: number;
+  onClick: () => void;
+  c: ReturnType<typeof t>;
+}) {
+  const other = useMemo(() => otherPartyOfPair(pairKey), [pairKey]);
+  const label = partyDisplayName(other);
+  return (
+    <button
+      onClick={onClick}
+      className="w-full flex items-center justify-between px-4 py-1.5 text-[13px] transition-colors text-left"
+      style={{
+        background: selected ? c.bgCardSelected : "transparent",
+        color: selected ? c.textPrimary : unread > 0 ? c.textPrimary : c.textSecondary,
+        fontWeight: unread > 0 ? 600 : 400,
+      }}
+      onMouseEnter={(e) => {
+        if (!selected) e.currentTarget.style.background = c.hoverBg;
+      }}
+      onMouseLeave={(e) => {
+        if (!selected) e.currentTarget.style.background = "transparent";
+      }}
+    >
+      <span className="truncate flex items-center gap-1.5">
+        <span
+          className="inline-block w-1.5 h-1.5 rounded-full"
+          style={{ background: other.cardId ? "#a78bfa" : "#4f8ef7" }}
+        />
+        {label}
+      </span>
+      {unread > 0 && <UnreadBadge count={unread} />}
+    </button>
+  );
+}
+
+function UnreadBadge({ count }: { count: number }) {
+  return (
+    <span
+      className="ml-2 shrink-0 inline-flex items-center justify-center text-[10px] font-semibold rounded-full px-1.5"
+      style={{
+        background: "#4f8ef7",
+        color: "white",
+        minWidth: 18,
+        height: 18,
+      }}
+    >
+      {count > 99 ? "99+" : count}
+    </span>
   );
 }
 
@@ -227,6 +368,76 @@ function ChannelPane({
   theme,
 }: {
   channel: Channel;
+  messages: ChannelMessage[];
+  draft: string;
+  onSend: (body: string) => void;
+  onDraftChange: (body: string) => void;
+  c: ReturnType<typeof t>;
+  theme: "dark" | "light";
+}) {
+  return (
+    <ThreadPane
+      title={`#${channel.name}`}
+      subtitle={`${channel.members.length} member${channel.members.length === 1 ? "" : "s"}`}
+      placeholder={`Message #${channel.name}`}
+      messages={messages}
+      draft={draft}
+      onSend={onSend}
+      onDraftChange={onDraftChange}
+      c={c}
+      theme={theme}
+    />
+  );
+}
+
+function DmPane({
+  pairKey,
+  messages,
+  draft,
+  onSend,
+  onDraftChange,
+  c,
+  theme,
+}: {
+  pairKey: string;
+  messages: ChannelMessage[];
+  draft: string;
+  onSend: (body: string) => void;
+  onDraftChange: (body: string) => void;
+  c: ReturnType<typeof t>;
+  theme: "dark" | "light";
+}) {
+  const other = useMemo(() => otherPartyOfPair(pairKey), [pairKey]);
+  const label = partyDisplayName(other);
+  return (
+    <ThreadPane
+      title={label}
+      subtitle={other.cardId ? "Card" : "Direct message"}
+      placeholder={`Message ${label}`}
+      messages={messages}
+      draft={draft}
+      onSend={onSend}
+      onDraftChange={onDraftChange}
+      c={c}
+      theme={theme}
+    />
+  );
+}
+
+function ThreadPane({
+  title,
+  subtitle,
+  placeholder,
+  messages,
+  draft,
+  onSend,
+  onDraftChange,
+  c,
+  theme,
+}: {
+  title: string;
+  subtitle: string;
+  placeholder: string;
   messages: ChannelMessage[];
   draft: string;
   onSend: (body: string) => void;
@@ -250,6 +461,11 @@ function ChannelPane({
     lastSeenRef.current = messages.length;
   }, [messages.length]);
 
+  // Reset auto-scroll tracking when thread changes.
+  useEffect(() => {
+    lastSeenRef.current = 0;
+  }, [title]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!draft.trim()) return;
@@ -264,10 +480,10 @@ function ChannelPane({
       >
         <div className="flex items-center gap-3">
           <span className="text-[15px] font-semibold" style={{ color: c.textPrimary }}>
-            #{channel.name}
+            {title}
           </span>
           <span className="text-[12px]" style={{ color: c.textMuted }}>
-            {channel.members.length} member{channel.members.length === 1 ? "" : "s"}
+            {subtitle}
           </span>
         </div>
       </div>
@@ -296,7 +512,7 @@ function ChannelPane({
               if (draft.trim()) onSend(draft);
             }
           }}
-          placeholder={`Message #${channel.name}`}
+          placeholder={placeholder}
           rows={1}
           className="flex-1 resize-none rounded-lg px-3 py-2 text-[13px] focus:outline-none"
           style={{
@@ -320,8 +536,6 @@ function ChannelPane({
           Send
         </button>
       </form>
-      {/* `theme` is currently informational; kept on the signature so we can
-          add theme-specific message rendering without changing call sites. */}
       <span style={{ display: "none" }}>{theme}</span>
     </>
   );
@@ -430,6 +644,92 @@ function NewChannelDialog({
             }}
           >
             Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── New DM modal ────────────────────────────────────────────────────────────
+
+function NewDmDialog({
+  onCancel,
+  onOpen,
+  c,
+  theme,
+}: {
+  onCancel: () => void;
+  onOpen: (target: string) => Promise<void>;
+  c: ReturnType<typeof t>;
+  theme: "dark" | "light";
+}) {
+  const [target, setTarget] = useState("");
+  const trimmed = target.trim();
+  // Allow `@handle`, `handle`, or `card_<ksuid>`. Reject the empty string and
+  // the literal "user" (DMing yourself).
+  const isCard = /^card_[a-zA-Z0-9]+$/.test(trimmed);
+  const isHandle = /^@?[a-zA-Z0-9_-]+$/.test(trimmed);
+  const isSelf = trimmed === "@user" || trimmed === "user";
+  const valid = (isCard || isHandle) && !isSelf;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: c.bgOverlay }}
+      onClick={onCancel}
+    >
+      <div
+        className="rounded-xl p-6 w-[440px] max-w-[90vw]"
+        style={{
+          background: c.bgDialog,
+          border: `1px solid ${c.border}`,
+          boxShadow: theme === "dark" ? "0 16px 48px rgba(0,0,0,0.6)" : "0 16px 48px rgba(0,0,0,0.18)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-[15px] font-semibold mb-1" style={{ color: c.textPrimary }}>
+          Start a direct message
+        </h2>
+        <p className="text-[12px] mb-4" style={{ color: c.textSecondary }}>
+          Enter <code>@handle</code> for a user, or <code>card_…</code> for a card session.
+        </p>
+        <input
+          autoFocus
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+          placeholder="@agent-a or card_2abc…"
+          className="w-full rounded-lg px-3 py-2 text-[13px] focus:outline-none mb-4"
+          style={{
+            background: c.bgInput,
+            border: `1px solid ${c.border}`,
+            color: c.text,
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && valid) onOpen(trimmed);
+            if (e.key === "Escape") onCancel();
+          }}
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded-lg text-[13px] transition-colors"
+            style={{ color: c.textSecondary, background: c.bgInput, border: `1px solid ${c.border}` }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => valid && onOpen(trimmed)}
+            disabled={!valid}
+            className="px-3 py-1.5 rounded-lg text-[13px] font-semibold transition-colors"
+            style={{
+              background: valid ? "#4f8ef7" : c.bgInput,
+              color: valid ? "white" : c.textMuted,
+              cursor: valid ? "pointer" : "not-allowed",
+              border: `1px solid ${c.border}`,
+            }}
+          >
+            Open
           </button>
         </div>
       </div>

--- a/windows/src/store/channelsStore.ts
+++ b/windows/src/store/channelsStore.ts
@@ -14,11 +14,49 @@ import type {
 /// `kanban` CLI from a tmux session, never from the GUI.
 export const SELF: ChannelParticipant = { cardId: null, handle: "user" };
 
+/// `party_key` (matches Rust ChannelParticipant::party_key + Swift partyKey):
+/// `@<handle>` for users, the card_id for cards.
+export function partyKey(p: ChannelParticipant): string {
+  return p.cardId ?? `@${p.handle}`;
+}
+
+export function parsePartyKey(key: string): ChannelParticipant {
+  if (key.startsWith("@")) return { cardId: null, handle: key.slice(1) };
+  return { cardId: key, handle: key };
+}
+
+/// `<sortedA>__<sortedB>` — same encoding the Rust backend writes.
+export function dmPairKey(a: ChannelParticipant, b: ChannelParticipant): string {
+  const keys = [partyKey(a), partyKey(b)].sort();
+  return `${keys[0]}__${keys[1]}`;
+}
+
+/// Given a stored pair key, return the "other" half (i.e. not SELF).
+export function otherPartyOfPair(
+  pairKey: string,
+  self: ChannelParticipant = SELF
+): ChannelParticipant {
+  const [a, b] = pairKey.split("__");
+  const selfKey = partyKey(self);
+  const other = a === selfKey ? b : a;
+  return parsePartyKey(other);
+}
+
+export function partyDisplayName(p: ChannelParticipant): string {
+  if (p.cardId) return p.cardId;
+  return `@${p.handle}`;
+}
+
 interface ChannelsStore {
   channels: Channel[];
   selectedChannel: string | null;
+  selectedDm: string | null;
   /// channel name → messages (most recent at the bottom)
   messagesByChannel: Record<string, ChannelMessage[]>;
+  /// dm pair key → messages
+  messagesByDm: Record<string, ChannelMessage[]>;
+  /// All known DM pair keys (from `list_dm_pairs` + any ad-hoc created).
+  dmPairs: string[];
   readState: ChannelReadState;
   drafts: ChannelDrafts;
   error: string | null;
@@ -30,22 +68,33 @@ interface ChannelsStore {
   teardown: () => void;
 
   refreshChannels: () => Promise<void>;
+  refreshDmPairs: () => Promise<void>;
   selectChannel: (name: string | null) => Promise<void>;
+  selectDm: (pairKey: string | null) => Promise<void>;
   loadMessages: (name: string) => Promise<void>;
+  loadDmMessages: (pairKey: string) => Promise<void>;
   sendMessage: (name: string, body: string) => Promise<void>;
+  sendDm: (pairKey: string, body: string) => Promise<void>;
   createChannel: (name: string) => Promise<Channel | null>;
   deleteChannel: (name: string) => Promise<void>;
+  openDmTo: (target: string) => Promise<string | null>;
   saveDraft: (name: string, body: string) => Promise<void>;
+  saveDmDraft: (pairKey: string, body: string) => Promise<void>;
   markRead: (name: string) => Promise<void>;
+  markDmRead: (pairKey: string) => Promise<void>;
   clearError: () => void;
 
   unreadCount: (name: string) => number;
+  unreadDmCount: (pairKey: string) => number;
 }
 
 export const useChannelsStore = create<ChannelsStore>((set, get) => ({
   channels: [],
   selectedChannel: null,
+  selectedDm: null,
   messagesByChannel: {},
+  messagesByDm: {},
+  dmPairs: [],
   readState: { channels: {}, dms: {} },
   drafts: { channels: {}, dms: {} },
   error: null,
@@ -55,6 +104,7 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
   init: async () => {
     if (get().unlisten.length > 0) return; // already initialized
     await get().refreshChannels();
+    await get().refreshDmPairs();
     try {
       const [rs, drafts] = await Promise.all([
         invoke<ChannelReadState>("get_read_state"),
@@ -96,23 +146,23 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
         // best-effort
       }
     });
-    // DM logs — the watcher emits this when a per-pair JSONL changes. The
-    // store doesn't currently track in-memory DM messages (the DM view loads
-    // them on demand via read_dm_messages), so this listener just bumps a
-    // global event the DM view subscribes to. For now we forward the raw event
-    // so consumers can subscribe to channelsStore subscribers; refetching is
-    // the consumer's job. Wiring this in completes the 4-event watcher
-    // contract — otherwise live DM updates were silently dropped.
     const unsubDmLogs = await listen<{ dmKey: string }>(
       "dm-logs-changed",
-      (event) => {
+      async (event) => {
         const key = event.payload?.dmKey;
         if (!key) return;
-        // Re-emit on the window so DM view components can listen without
-        // needing to import the Tauri event API directly.
+        // Re-emit on the window so anything outside the store can still hook in.
         window.dispatchEvent(
           new CustomEvent("kanban:dm-logs-changed", { detail: { dmKey: key } })
         );
+        if (!get().dmPairs.includes(key)) {
+          await get().refreshDmPairs();
+        }
+        const loaded = get().messagesByDm[key] !== undefined;
+        const isSelected = key === get().selectedDm;
+        if (loaded || isSelected) {
+          await get().loadDmMessages(key);
+        }
       }
     );
     set({
@@ -147,11 +197,32 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     }
   },
 
+  refreshDmPairs: async () => {
+    try {
+      const pairs = await invoke<string[]>("list_dm_pairs");
+      // Merge with any locally-created pairs the backend doesn't know about
+      // yet (a brand-new "Start DM" thread won't have a log file until the
+      // first message is sent, so it would drop out of the sidebar mid-compose).
+      const merged = Array.from(new Set([...pairs, ...get().dmPairs])).sort();
+      set({ dmPairs: merged });
+    } catch (e) {
+      set({ error: String(e) });
+    }
+  },
+
   selectChannel: async (name) => {
-    set({ selectedChannel: name });
+    set({ selectedChannel: name, selectedDm: null });
     if (name) {
       await get().loadMessages(name);
       await get().markRead(name);
+    }
+  },
+
+  selectDm: async (pairKey) => {
+    set({ selectedDm: pairKey, selectedChannel: null });
+    if (pairKey) {
+      await get().loadDmMessages(pairKey);
+      await get().markDmRead(pairKey);
     }
   },
 
@@ -167,6 +238,25 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
       // Auto-mark-read on refresh of the currently-open channel.
       if (get().selectedChannel === name) {
         get().markRead(name);
+      }
+    } catch (e) {
+      set({ error: String(e) });
+    }
+  },
+
+  loadDmMessages: async (pairKey) => {
+    try {
+      const other = otherPartyOfPair(pairKey, SELF);
+      const msgs = await invoke<ChannelMessage[]>("read_dm_messages", {
+        a: SELF,
+        b: other,
+        limit: 500,
+      });
+      set((state) => ({
+        messagesByDm: { ...state.messagesByDm, [pairKey]: msgs },
+      }));
+      if (get().selectedDm === pairKey) {
+        get().markDmRead(pairKey);
       }
     } catch (e) {
       set({ error: String(e) });
@@ -212,6 +302,45 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     }
   },
 
+  sendDm: async (pairKey, body) => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    try {
+      const other = otherPartyOfPair(pairKey, SELF);
+      const optimistic: ChannelMessage = {
+        id: `local_${crypto.randomUUID().slice(0, 12)}`,
+        ts: new Date().toISOString(),
+        from: SELF,
+        body: trimmed,
+        type: "message",
+      };
+      set((state) => ({
+        messagesByDm: {
+          ...state.messagesByDm,
+          [pairKey]: [...(state.messagesByDm[pairKey] ?? []), optimistic],
+        },
+      }));
+      await invoke<ChannelMessage>("send_dm", {
+        from: SELF,
+        to: other,
+        body: trimmed,
+        imagePaths: null,
+      });
+      const newDrafts: ChannelDrafts = {
+        ...get().drafts,
+        dms: { ...get().drafts.dms, [pairKey]: "" },
+      };
+      set({ drafts: newDrafts });
+      await invoke("save_drafts", { drafts: newDrafts });
+      if (!get().dmPairs.includes(pairKey)) {
+        set((state) => ({ dmPairs: [...state.dmPairs, pairKey].sort() }));
+      }
+    } catch (e) {
+      set({ error: String(e) });
+      get().loadDmMessages(pairKey);
+    }
+  },
+
   createChannel: async (rawName) => {
     // Mirror Rust's normalize_channel_name: trim → strip leading '#' → trim
     // again → lowercase. The second trim catches "# foo" → "foo" rather than
@@ -250,6 +379,31 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     }
   },
 
+  openDmTo: async (target) => {
+    // Accept "@handle", "handle", or "card_<ksuid>"
+    const trimmed = target.trim();
+    if (!trimmed) return null;
+    let other: ChannelParticipant;
+    if (trimmed.startsWith("card_")) {
+      other = { cardId: trimmed, handle: trimmed };
+    } else if (trimmed.startsWith("@")) {
+      other = { cardId: null, handle: trimmed.slice(1) };
+    } else {
+      other = { cardId: null, handle: trimmed };
+    }
+    if (!other.cardId && !other.handle) return null;
+    if (other.cardId === null && other.handle === SELF.handle) {
+      set({ error: "Can't DM yourself." });
+      return null;
+    }
+    const key = dmPairKey(SELF, other);
+    if (!get().dmPairs.includes(key)) {
+      set((state) => ({ dmPairs: [...state.dmPairs, key].sort() }));
+    }
+    await get().selectDm(key);
+    return key;
+  },
+
   saveDraft: async (name, body) => {
     const newDrafts: ChannelDrafts = {
       ...get().drafts,
@@ -260,6 +414,19 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
       await invoke("save_drafts", { drafts: newDrafts });
     } catch {
       // Drafts are best-effort; failing to persist shouldn't block typing.
+    }
+  },
+
+  saveDmDraft: async (pairKey, body) => {
+    const newDrafts: ChannelDrafts = {
+      ...get().drafts,
+      dms: { ...get().drafts.dms, [pairKey]: body },
+    };
+    set({ drafts: newDrafts });
+    try {
+      await invoke("save_drafts", { drafts: newDrafts });
+    } catch {
+      // best-effort
     }
   },
 
@@ -280,12 +447,39 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     }
   },
 
+  markDmRead: async (pairKey) => {
+    const msgs = get().messagesByDm[pairKey] ?? [];
+    if (msgs.length === 0) return;
+    const lastId = msgs[msgs.length - 1].id;
+    if (get().readState.dms[pairKey] === lastId) return;
+    const newReadState: ChannelReadState = {
+      ...get().readState,
+      dms: { ...get().readState.dms, [pairKey]: lastId },
+    };
+    set({ readState: newReadState });
+    try {
+      await invoke("save_read_state", { stateData: newReadState });
+    } catch {
+      // best-effort
+    }
+  },
+
   clearError: () => set({ error: null }),
 
   unreadCount: (name) => {
     const msgs = get().messagesByChannel[name] ?? [];
     if (msgs.length === 0) return 0;
     const lastReadId = get().readState.channels[name];
+    if (!lastReadId) return msgs.length;
+    const idx = msgs.findIndex((m) => m.id === lastReadId);
+    if (idx < 0) return msgs.length;
+    return msgs.length - 1 - idx;
+  },
+
+  unreadDmCount: (pairKey) => {
+    const msgs = get().messagesByDm[pairKey] ?? [];
+    if (msgs.length === 0) return 0;
+    const lastReadId = get().readState.dms[pairKey];
     if (!lastReadId) return msgs.length;
     const idx = msgs.findIndex((m) => m.id === lastReadId);
     if (idx < 0) return msgs.length;

--- a/windows/src/store/channelsStore.ts
+++ b/windows/src/store/channelsStore.ts
@@ -88,6 +88,14 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
         // best-effort
       }
     });
+    const unsubDrafts = await listen("drafts-changed", async () => {
+      try {
+        const drafts = await invoke<ChannelDrafts>("get_drafts");
+        set({ drafts });
+      } catch {
+        // best-effort
+      }
+    });
     // DM logs — the watcher emits this when a per-pair JSONL changes. The
     // store doesn't currently track in-memory DM messages (the DM view loads
     // them on demand via read_dm_messages), so this listener just bumps a
@@ -107,7 +115,15 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
         );
       }
     );
-    set({ unlisten: [unsubChannels, unsubMessages, unsubReadState, unsubDmLogs] });
+    set({
+      unlisten: [
+        unsubChannels,
+        unsubMessages,
+        unsubReadState,
+        unsubDrafts,
+        unsubDmLogs,
+      ],
+    });
   },
 
   teardown: () => {

--- a/windows/src/store/channelsStore.ts
+++ b/windows/src/store/channelsStore.ts
@@ -8,6 +8,7 @@ import type {
   ChannelParticipant,
   ChannelReadState,
 } from "../types";
+import { useBoardStore } from "./boardStore";
 
 /// The local identity the Tauri app sends as — matches macOS where the GUI
 /// always posts as the human user. Card-scoped sends come through the
@@ -45,6 +46,149 @@ export function otherPartyOfPair(
 export function partyDisplayName(p: ChannelParticipant): string {
   if (p.cardId) return p.cardId;
   return `@${p.handle}`;
+}
+
+// ── Notification dispatch ───────────────────────────────────────────────────
+//
+// State below is module-scoped (not zustand) because it's pure bookkeeping:
+// `lastSeenIdByThread` lets us identify *which* tail messages are new since
+// the last event, and `lastNotifyAtByThread` enforces the per-thread debounce
+// the issue calls for (5 messages within 2s = 1 notification).
+
+const NOTIFY_DEBOUNCE_MS = 2000;
+const lastSeenIdByThread = new Map<string, string>();
+const lastNotifyAtByThread = new Map<string, number>();
+
+function isSelf(p: ChannelParticipant): boolean {
+  return p.cardId === SELF.cardId && p.handle === SELF.handle;
+}
+
+function selfIsMember(channel: Channel): boolean {
+  return channel.members.some((m) => m.cardId === null && m.handle === SELF.handle);
+}
+
+/// Returns the messages in `msgs` that are newer than the last one we observed
+/// for `threadKey`. Also updates the lastSeenId bookmark. On the very first
+/// event for a thread, only the single newest message is treated as new — that
+/// way historical messages already on disk at app start don't trigger a flood.
+function takeNewMessages(threadKey: string, msgs: ChannelMessage[]): ChannelMessage[] {
+  if (msgs.length === 0) return [];
+  const prev = lastSeenIdByThread.get(threadKey);
+  const latestId = msgs[msgs.length - 1].id;
+  let fresh: ChannelMessage[];
+  if (prev === undefined) {
+    fresh = [msgs[msgs.length - 1]];
+  } else {
+    const idx = msgs.findIndex((m) => m.id === prev);
+    fresh = idx < 0 ? msgs.slice() : msgs.slice(idx + 1);
+  }
+  lastSeenIdByThread.set(threadKey, latestId);
+  return fresh;
+}
+
+async function dispatchChatNotification(
+  threadKey: string,
+  title: string,
+  body: string
+): Promise<void> {
+  const now = performance.now();
+  const last = lastNotifyAtByThread.get(threadKey);
+  if (last !== undefined && now - last < NOTIFY_DEBOUNCE_MS) return;
+  lastNotifyAtByThread.set(threadKey, now);
+  try {
+    await invoke("notify_chat_message", {
+      title,
+      body,
+      threadId: threadKey,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+function chatPanelOpen(): boolean {
+  try {
+    return useBoardStore.getState().chatOpen;
+  } catch {
+    return false;
+  }
+}
+
+function snippet(body: string, max = 120): string {
+  const oneLine = body.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? oneLine.slice(0, max - 1) + "…" : oneLine;
+}
+
+async function maybeNotifyChannel(
+  name: string,
+  get: () => ReturnType<typeof useChannelsStore.getState>
+): Promise<void> {
+  const channel = get().channels.find((c) => c.name === name);
+  if (!channel) return;
+  if (!selfIsMember(channel)) return;
+  let msgs: ChannelMessage[];
+  try {
+    msgs = await invoke<ChannelMessage[]>("read_channel_messages", {
+      channel: name,
+      limit: 20,
+    });
+  } catch {
+    return;
+  }
+  const threadKey = `ch:${name}`;
+  const fresh = takeNewMessages(threadKey, msgs);
+  if (fresh.length === 0) return;
+  const panelOpen = chatPanelOpen();
+  const focused = panelOpen && get().selectedChannel === name;
+  if (focused) return;
+  const candidate = fresh
+    .filter((m) => (m.type ?? "message") === "message")
+    .filter((m) => !isSelf(m.from))
+    .pop();
+  if (!candidate) return;
+  await dispatchChatNotification(
+    threadKey,
+    `#${name} — @${candidate.from.handle}`,
+    snippet(candidate.body)
+  );
+}
+
+async function maybeNotifyDm(
+  pairKey: string,
+  get: () => ReturnType<typeof useChannelsStore.getState>
+): Promise<void> {
+  // SELF must be one of the two parties; pair keys that don't contain SELF
+  // belong to other parties (e.g. card-to-card) and aren't ours to notify on.
+  const halves = pairKey.split("__");
+  const selfKey = partyKey(SELF);
+  if (!halves.includes(selfKey)) return;
+  const other = otherPartyOfPair(pairKey, SELF);
+  let msgs: ChannelMessage[];
+  try {
+    msgs = await invoke<ChannelMessage[]>("read_dm_messages", {
+      a: SELF,
+      b: other,
+      limit: 20,
+    });
+  } catch {
+    return;
+  }
+  const threadKey = `dm:${pairKey}`;
+  const fresh = takeNewMessages(threadKey, msgs);
+  if (fresh.length === 0) return;
+  const panelOpen = chatPanelOpen();
+  const focused = panelOpen && get().selectedDm === pairKey;
+  if (focused) return;
+  const candidate = fresh
+    .filter((m) => (m.type ?? "message") === "message")
+    .filter((m) => !isSelf(m.from))
+    .pop();
+  if (!candidate) return;
+  await dispatchChatNotification(
+    threadKey,
+    `DM from ${partyDisplayName(candidate.from)}`,
+    snippet(candidate.body)
+  );
 }
 
 interface ChannelsStore {
@@ -119,15 +263,15 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     });
     const unsubMessages = await listen<{ channelName: string }>(
       "channel-messages-changed",
-      (event) => {
+      async (event) => {
         const name = event.payload?.channelName;
         if (!name) return;
-        // Only refetch if this channel is currently loaded — avoids burning
-        // I/O for channels the user hasn't opened yet.
         const loaded = get().messagesByChannel[name] !== undefined;
-        if (loaded || name === get().selectedChannel) {
-          get().loadMessages(name);
+        const isSelected = name === get().selectedChannel;
+        if (loaded || isSelected) {
+          await get().loadMessages(name);
         }
+        await maybeNotifyChannel(name, get);
       }
     );
     const unsubReadState = await listen("read-state-changed", async () => {
@@ -151,7 +295,6 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
       async (event) => {
         const key = event.payload?.dmKey;
         if (!key) return;
-        // Re-emit on the window so anything outside the store can still hook in.
         window.dispatchEvent(
           new CustomEvent("kanban:dm-logs-changed", { detail: { dmKey: key } })
         );
@@ -163,6 +306,7 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
         if (loaded || isSelected) {
           await get().loadDmMessages(key);
         }
+        await maybeNotifyDm(key, get);
       }
     );
     set({
@@ -235,7 +379,6 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
       set((state) => ({
         messagesByChannel: { ...state.messagesByChannel, [name]: msgs },
       }));
-      // Auto-mark-read on refresh of the currently-open channel.
       if (get().selectedChannel === name) {
         get().markRead(name);
       }
@@ -267,8 +410,6 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     const trimmed = body.trim();
     if (!trimmed) return;
     try {
-      // Optimistic: append locally; the watcher will trigger a refetch shortly
-      // and replace the optimistic entry with the canonical row.
       const optimistic: ChannelMessage = {
         id: `local_${crypto.randomUUID().slice(0, 12)}`,
         ts: new Date().toISOString(),
@@ -288,7 +429,6 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
         body: trimmed,
         imagePaths: null,
       });
-      // Clear the draft on successful send.
       const newDrafts = {
         ...get().drafts,
         channels: { ...get().drafts.channels, [name]: "" },
@@ -297,7 +437,6 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
       await invoke("save_drafts", { drafts: newDrafts });
     } catch (e) {
       set({ error: String(e) });
-      // Roll back the optimistic entry by refetching.
       get().loadMessages(name);
     }
   },
@@ -352,7 +491,6 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
         name,
         by: SELF,
       });
-      // Auto-join the creator so messages we send aren't from a non-member.
       await invoke("join_channel", { name: channel.name, member: SELF });
       await get().refreshChannels();
       await get().selectChannel(channel.name);


### PR DESCRIPTION
## Summary

Three follow-ups that round out the Phase 7 channels work shipped in #105:

- **#109 — DM panel in chat UI.** Adds a Direct Messages section to the chat sidebar. Threads from `list_dm_pairs` show up under the channel list; selecting one loads the thread via `read_dm_messages` and renders the same layout as a channel. Send goes through `send_dm` with `from = SELF`. Drafts + read-state for DMs persist under their `dms.<pairKey>` slots, mirroring the channel flow. A "Start DM" button accepts `@handle` or `card_<ksuid>` and opens (or creates) the thread.

- **#110 — notifications for inbound chat messages.** Channel and DM events now fire OS + Pushover notifications, reusing the existing `pushover` module and `tauri-plugin-notification` (same dispatch path as the card-finish toast at `lib.rs:907–979`). Suppression rules: SELF-sends, system/join/leave messages, non-member channels, foreground-focused threads. Per-thread 2s debounce coalesces bursts.

- **#111 — drafts-changed watcher event.** Closes the gap in the 4-event watcher contract: `drafts.json` writes now emit `DRAFTS_CHANGED`, and the store refetches via `get_drafts` within ~100ms.

Closes #109, closes #110, closes #111.

## Verification

`npm run build` and `cargo build` both green (existing-warnings-only).

CLI round-trip on the worktree:

```
$ kanban dm send --as some-other-handle @user "ping from CLI part2 verify"
@some-other-handle → @user: ping from CLI part2 verify

$ kanban dm list
@some-other-handle__@user

$ kanban dm read --as some-other-handle @user
[2026-06-13T22:20:44.358+00:00] @some-other-handle: ping from CLI part2 verify
```

The on-disk pair-key format (`@some-other-handle__@user.jsonl`) matches the `parsePartyKey` / `otherPartyOfPair` helpers the frontend uses to render the sidebar and resolve the `to` party on send.

### Debounce validation (#110)

Module-scoped `lastNotifyAtByThread: Map<string, number>` is keyed by `ch:<name>` / `dm:<pairKey>` and read inside `dispatchChatNotification`. If `now - lastAt < 2000`, the dispatch returns early *without* updating `lastNotifyAtByThread` — so the 2 s window is anchored at the first notification, not the most recent. A burst of 5 messages within 2 s = 1 notification; the 6th message after the window starts a fresh debounce. `lastSeenIdByThread` updates regardless so we still track what's been observed for the next event.

Other suppression paths (each verified at the code level):
- self-send filter via `isSelf` (matches `cardId === null && handle === "user"`)
- system/join/leave filter via `(m.type ?? "message") === "message"`
- foreground suppression via `useBoardStore.getState().chatOpen && selectedThread === thread`
- channel membership via `channel.members.some(m => m.cardId === null && m.handle === SELF.handle)`

### DM panel screenshots

Screenshots best captured from a local `npm run tauri dev` session — the GUI is functional but I can't reliably screenshot a Tauri window from this environment. The sidebar gains a "Direct Messages" section under the existing "Channels" section, each row showing `@handle` (blue dot) or `card_<id>` (purple dot) with an unread badge identical in styling to channel rows. Selecting a row swaps the main pane to a thread layout identical to a channel.

## Test plan

- [ ] `cd windows && npm run build` green
- [ ] `cd windows/src-tauri && cargo build` green
- [ ] Run `npm run tauri dev`; open chat panel; verify DM section renders existing threads
- [ ] From another shell: `kanban dm send --as agent-A @user "ping"` → DM appears in sidebar within ~100ms with unread badge; click → reads, badge clears
- [ ] Enable OS + Pushover toggles in Settings; send 5 DMs from CLI within 2 s → 1 notification fires
- [ ] Open the thread + leave the panel focused on it; send another DM from CLI → no notification (foreground suppression)
- [ ] Edit `drafts.json` on disk: store re-fetches and the relevant draft field updates without a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)