### PR TITLE
feat(windows): pinned cards + self-compact settings

### DIFF
--- a/windows/src-tauri/src/card_reconciler.rs
+++ b/windows/src-tauri/src/card_reconciler.rs
@@ -267,6 +267,8 @@ fn new_discovered_link(session: &Session) -> Link {
         is_launching: None,
         queued_prompts: None,
         sort_order: None,
+        pinned_at: None,
+        pinned_sort_order: None,
         assistant_id: "claude".to_string(),
     }
 }

--- a/windows/src-tauri/src/context_usage.rs
+++ b/windows/src-tauri/src/context_usage.rs
@@ -1,0 +1,104 @@
+//! Reads context-window usage written by Claude Code's statusline script.
+//! Mirrors Sources/KanbanCodeCore/Adapters/ClaudeCode/ContextUsageReader.swift.
+//!
+//! Files live at `<data_dir>/context/<sessionId>.json` and contain the
+//! fields the statusline emits (camelCase, matching macOS exactly so a
+//! shared statusline binary works on both platforms):
+//!
+//! ```text
+//! { "usedPercentage": 42.5,
+//!   "contextWindowSize": 200000,
+//!   "totalInputTokens": 12345,
+//!   "totalOutputTokens": 6789,
+//!   "totalCostUsd": 0.42,
+//!   "model": "claude-opus-4-7" }
+//! ```
+//!
+//! The polling loop that *generates* self-compact prompts (when usage
+//! crosses a threshold) is not yet ported. This reader is the consumer
+//! side — already enough for the drop-guard path that drops stale
+//! compact prompts when usage drops back below threshold post-compact.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::coordination_store::kanban_data_dir;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextUsage {
+    pub used_percentage: f64,
+    pub context_window_size: i64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    #[serde(default)]
+    pub total_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+impl ContextUsage {
+    /// Claude's current context-window usage in tokens. Mirrors the macOS
+    /// `currentContextTokens` derivation: when percentage data is present
+    /// we trust it (the lifetime input+output sum stays high after a
+    /// compaction, so it's the wrong number to compare against thresholds).
+    pub fn current_context_tokens(&self) -> i64 {
+        if self.context_window_size > 0 && self.used_percentage > 0.0 {
+            ((self.context_window_size as f64) * self.used_percentage / 100.0).round() as i64
+        } else {
+            self.total_input_tokens + self.total_output_tokens
+        }
+    }
+}
+
+fn context_path(session_id: &str, base: Option<&PathBuf>) -> PathBuf {
+    let dir = base
+        .cloned()
+        .unwrap_or_else(|| kanban_data_dir().join("context"));
+    dir.join(format!("{}.json", session_id))
+}
+
+/// Returns `None` when no statusline JSON exists for this session yet
+/// (statusline never ran, or it ran on a host that doesn't share this
+/// data dir). Callers should treat that as "unknown" — they should
+/// not derive any threshold conclusion from absence alone.
+pub fn read(session_id: &str) -> Option<ContextUsage> {
+    read_with_base(session_id, None)
+}
+
+pub fn read_with_base(session_id: &str, base: Option<&PathBuf>) -> Option<ContextUsage> {
+    let path = context_path(session_id, base);
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_context_uses_percentage_when_available() {
+        let u = ContextUsage {
+            used_percentage: 50.0,
+            context_window_size: 200_000,
+            total_input_tokens: 999_999,
+            total_output_tokens: 999_999,
+            total_cost_usd: None,
+            model: None,
+        };
+        assert_eq!(u.current_context_tokens(), 100_000);
+    }
+
+    #[test]
+    fn current_context_falls_back_to_io_sum_without_percentage() {
+        let u = ContextUsage {
+            used_percentage: 0.0,
+            context_window_size: 0,
+            total_input_tokens: 1000,
+            total_output_tokens: 234,
+            total_cost_usd: None,
+            model: None,
+        };
+        assert_eq!(u.current_context_tokens(), 1234);
+    }
+}

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -14,6 +14,11 @@ pub struct QueuedPrompt {
     pub id: String,
     pub body: String,
     pub send_automatically: bool,
+    /// Set only for prompts the self-compact guard enqueued. Manual prompts
+    /// keep this nil so we can drop stale compact nudges without touching
+    /// unrelated queue items. Mirrors macOS QueuedPrompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_compact_threshold_tokens: Option<i64>,
 }
 
 // ── Sub-structs ──────────────────────────────────────────────────────────────
@@ -123,6 +128,15 @@ pub struct Link {
     /// ordering. Set by drag-to-reorder; persisted so it survives refresh.
     #[serde(default)]
     pub sort_order: Option<f64>,
+    /// When set, show this card in the pinned section while preserving its
+    /// real column. The timestamp gives newest-pinned-first as a fallback
+    /// when pinned_sort_order isn't set. Mirrors macOS Link.pinnedAt.
+    #[serde(default)]
+    pub pinned_at: Option<DateTime<Utc>>,
+    /// Manual display order within the pinned section. Kept separate from
+    /// sort_order so rearranging a pin never changes its column position.
+    #[serde(default)]
+    pub pinned_sort_order: Option<i64>,
     /// Coding assistant that owns this card. Drives which CLI binary is
     /// invoked in the embedded terminal. Defaults to "claude" so legacy
     /// links.json files (and files written by macOS without an
@@ -207,8 +221,14 @@ impl Link {
             is_launching: None,
             queued_prompts: None,
             sort_order: None,
+            pinned_at: None,
+            pinned_sort_order: None,
             assistant_id,
         }
+    }
+
+    pub fn is_pinned(&self) -> bool {
+        self.pinned_at.is_some()
     }
 }
 
@@ -218,6 +238,7 @@ impl QueuedPrompt {
             id: ksuid::generate(Some("prompt")),
             body,
             send_automatically,
+            self_compact_threshold_tokens: None,
         }
     }
 }
@@ -326,6 +347,8 @@ impl CoordinationStore {
             link.manual_overrides.column = true;
             if column == "all_sessions" {
                 link.manually_archived = true;
+                link.pinned_at = None;
+                link.pinned_sort_order = None;
             } else if link.manually_archived {
                 link.manually_archived = false;
             }
@@ -357,6 +380,8 @@ impl CoordinationStore {
         if let Some(link) = links.iter_mut().find(|l| l.id == card_id) {
             link.manually_archived = true;
             link.column = "all_sessions".to_string();
+            link.pinned_at = None;
+            link.pinned_sort_order = None;
             link.updated_at = Utc::now();
         }
         self.write_links(&links).await
@@ -445,6 +470,8 @@ impl CoordinationStore {
             is_launching: None,
             queued_prompts: None,
             sort_order: None,
+            pinned_at: None,
+            pinned_sort_order: None,
             assistant_id: default_assistant(),
         };
         self.upsert_link(&link).await?;
@@ -473,6 +500,52 @@ impl CoordinationStore {
         for (idx, id) in ordered_ids.iter().enumerate() {
             if let Some(link) = links.iter_mut().find(|l| &l.id == id) {
                 link.sort_order = Some(idx as f64);
+            }
+        }
+        self.write_links(&links).await
+    }
+
+    /// Pin or unpin a card. Pinning stamps `pinned_at = now` and assigns a
+    /// pinned_sort_order one slot above the current first-pinned (so the
+    /// new pin lands at the top, matching macOS). Unpinning clears both
+    /// fields. No-op when the requested state already matches.
+    pub async fn set_card_pinned(&self, card_id: &str, is_pinned: bool) -> Result<()> {
+        let mut links = self.read_links().await?;
+        let first_order = links
+            .iter()
+            .filter_map(|l| l.pinned_sort_order)
+            .min()
+            .unwrap_or(0);
+        if let Some(link) = links.iter_mut().find(|l| l.id == card_id) {
+            if is_pinned {
+                if link.pinned_at.is_some() {
+                    return Ok(());
+                }
+                link.pinned_at = Some(Utc::now());
+                link.pinned_sort_order = Some(first_order - 1);
+            } else {
+                if link.pinned_at.is_none() {
+                    return Ok(());
+                }
+                link.pinned_at = None;
+                link.pinned_sort_order = None;
+            }
+            link.updated_at = Utc::now();
+        }
+        self.write_links(&links).await
+    }
+
+    /// Persist a manual ordering of pinned cards by assigning each its index
+    /// in `ordered_ids` as `pinned_sort_order`. Like reorder_cards, this does
+    /// NOT bump `updated_at` so the sort doesn't ripple into time-based
+    /// presentations elsewhere.
+    pub async fn reorder_pinned_cards(&self, ordered_ids: &[String]) -> Result<()> {
+        let mut links = self.read_links().await?;
+        for (idx, id) in ordered_ids.iter().enumerate() {
+            if let Some(link) = links.iter_mut().find(|l| &l.id == id) {
+                if link.pinned_at.is_some() {
+                    link.pinned_sort_order = Some(idx as i64);
+                }
             }
         }
         self.write_links(&links).await

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod channels_store;
 mod channels_watcher;
 mod chat_bootstrap;
 mod coding_assistant;
+mod context_usage;
 pub mod crash_handler;
 mod coordination_store;
 mod gh_cli;
@@ -158,6 +159,31 @@ async fn rename_card(
     state
         .coordination_store
         .rename_link(&card_id, &name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn set_card_pinned(
+    card_id: String,
+    is_pinned: bool,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state
+        .coordination_store
+        .set_card_pinned(&card_id, is_pinned)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn reorder_pinned_cards(
+    ordered_ids: Vec<String>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state
+        .coordination_store
+        .reorder_pinned_cards(&ordered_ids)
         .await
         .map_err(|e| e.to_string())
 }
@@ -346,6 +372,91 @@ async fn update_queued_prompt(
         .update_queued_prompt(&card_id, &prompt_id, &body, send_automatically)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// True when the given queued prompt was enqueued by the self-compact
+/// guard AND the session's current context usage has dropped back below
+/// the prompt's threshold (i.e. a compaction already happened and the
+/// nudge would be a false alarm). Mirrors macOS
+/// `BackgroundOrchestrator.shouldDropStaleSelfCompactPrompt`.
+///
+/// Returns false on every uncertainty (settings unreadable, prompt not
+/// found, no statusline JSON yet) — better to deliver a benign nudge
+/// than to silently swallow a real one.
+#[tauri::command]
+async fn should_drop_self_compact_prompt(
+    card_id: String,
+    prompt_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<bool, String> {
+    let settings_store = settings_store::SettingsStore::new(None);
+    let settings = match settings_store.read().await {
+        Ok(s) => s,
+        Err(_) => return Ok(false),
+    };
+    if !settings.self_compact.enabled {
+        return Ok(false);
+    }
+
+    let links = state
+        .coordination_store
+        .read_links()
+        .await
+        .map_err(|e| e.to_string())?;
+    let Some(link) = links.iter().find(|l| l.id == card_id) else {
+        return Ok(false);
+    };
+    let Some(session_id) = link.session_link.as_ref().map(|s| s.session_id.clone()) else {
+        return Ok(false);
+    };
+    let Some(prompt) = link
+        .queued_prompts
+        .as_ref()
+        .and_then(|p| p.iter().find(|p| p.id == prompt_id))
+    else {
+        return Ok(false);
+    };
+
+    let queue_rules: Vec<&settings_store::SelfCompactRule> = settings
+        .self_compact
+        .rules
+        .iter()
+        .filter(|r| r.action == settings_store::SelfCompactAction::QueuePrompt)
+        .collect();
+
+    // Resolve the threshold: prefer the field on the prompt, then fall
+    // back to body-text match for prompts written by older builds (or by
+    // macOS, which always stamps the field).
+    let threshold: Option<i64> = if let Some(t) = prompt.self_compact_threshold_tokens {
+        Some(
+            queue_rules
+                .iter()
+                .find(|r| r.threshold_tokens == t)
+                .map(|r| r.threshold_tokens)
+                .unwrap_or(t),
+        )
+    } else {
+        let body = prompt.body.trim();
+        if body.is_empty() {
+            None
+        } else {
+            queue_rules
+                .iter()
+                .find(|r| r.message.trim() == body)
+                .map(|r| r.threshold_tokens)
+        }
+    };
+
+    let Some(threshold) = threshold else {
+        return Ok(false);
+    };
+
+    // No statusline JSON yet → match macOS: assume the nudge is stale
+    // (the alternative is hounding the user forever in absence of data).
+    let Some(usage) = context_usage::read(&session_id) else {
+        return Ok(true);
+    };
+    Ok(usage.current_context_tokens() < threshold)
 }
 
 #[tauri::command]
@@ -1508,6 +1619,8 @@ pub fn run() {
             get_board_state,
             move_card,
             reorder_cards,
+            set_card_pinned,
+            reorder_pinned_cards,
             create_card,
             delete_card,
             archive_card,
@@ -1521,6 +1634,7 @@ pub fn run() {
             add_queued_prompt,
             update_queued_prompt,
             remove_queued_prompt,
+            should_drop_self_compact_prompt,
             search_transcript,
             check_dependencies,
             resolve_github_base_url,

--- a/windows/src-tauri/src/merge_ops.rs
+++ b/windows/src-tauri/src/merge_ops.rs
@@ -11,8 +11,8 @@
 //! Deliberate Windows-side omissions:
 //! - macOS has a `tmuxLink` precondition rule; Windows `Link` has no such
 //!   field. The rule is dropped, not stubbed.
-//! - macOS `mergeBlocked` covers `pinned_at` and `discovered_repos`. Neither
-//!   exists on the Windows Link. Dropped.
+//! - macOS `mergeBlocked` covers `discovered_repos`, which Windows doesn't
+//!   carry. Dropped.
 //!
 //! Source `queued_prompts` are intentionally discarded — there is no
 //! macOS precedent and the prompts are tied to the source's session_link,
@@ -85,6 +85,14 @@ pub fn merge_into_target(source: &Link, target: &mut Link) {
         target.issue_link = source.issue_link.clone();
     }
 
+    // Inherit the pin from source iff target wasn't already pinned, matching
+    // the macOS BoardStore.mergeCards rule. pinned_sort_order travels with
+    // pinned_at so the inherited card lands in the same slot.
+    if target.pinned_at.is_none() {
+        target.pinned_at = source.pinned_at;
+        target.pinned_sort_order = source.pinned_sort_order;
+    }
+
     // PR links — union deduped by `number`, target wins on conflict so the
     // user-visible enrichment snapshot stays internally consistent.
     let mut existing_numbers: std::collections::HashSet<i64> =
@@ -155,6 +163,8 @@ mod tests {
             is_launching: None,
             queued_prompts: None,
             sort_order: None,
+            pinned_at: None,
+            pinned_sort_order: None,
             assistant_id: "claude".to_string(),
         }
     }

--- a/windows/src-tauri/src/settings_store.rs
+++ b/windows/src-tauri/src/settings_store.rs
@@ -120,6 +120,80 @@ impl Default for SessionTimeoutSettings {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SelfCompactAction {
+    QueuePrompt,
+    CompactNow,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SelfCompactRule {
+    pub id: String,
+    pub threshold_tokens: i64,
+    pub action: SelfCompactAction,
+    pub message: String,
+}
+
+impl SelfCompactRule {
+    /// Byte-compatible defaults with macOS SelfCompactRule.defaults so a
+    /// settings.json round-tripped between platforms keeps the same rule set.
+    pub fn defaults() -> Vec<Self> {
+        vec![
+            Self {
+                id: "ctx-500k".into(),
+                threshold_tokens: 500_000,
+                action: SelfCompactAction::QueuePrompt,
+                message: "You are above the 500k context limit. Whenever it is convenient, use the kanban CLI to send yourself a self-compact.".into(),
+            },
+            Self {
+                id: "ctx-600k".into(),
+                threshold_tokens: 600_000,
+                action: SelfCompactAction::QueuePrompt,
+                message: "You are above the 600k context limit. Please compact yourself soon using the kanban CLI self-compact command.".into(),
+            },
+            Self {
+                id: "ctx-700k".into(),
+                threshold_tokens: 700_000,
+                action: SelfCompactAction::QueuePrompt,
+                message: "You are above the 700k context limit. Compact yourself IMMEDIATELY using the kanban CLI self-compact command.".into(),
+            },
+            Self {
+                id: "ctx-750k".into(),
+                threshold_tokens: 750_000,
+                action: SelfCompactAction::CompactNow,
+                message: "/compact".into(),
+            },
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelfCompactSettings {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_self_compact_poll")]
+    pub poll_interval_seconds: u64,
+    #[serde(default = "SelfCompactRule::defaults")]
+    pub rules: Vec<SelfCompactRule>,
+}
+
+fn default_self_compact_poll() -> u64 {
+    30
+}
+
+impl Default for SelfCompactSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            poll_interval_seconds: default_self_compact_poll(),
+            rules: SelfCompactRule::defaults(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
@@ -153,6 +227,11 @@ pub struct Settings {
     pub terminal_shell: String,
     #[serde(default)]
     pub remote: Option<RemoteSettings>,
+    /// Automatic context-limit guard for Claude sessions. Byte-compatible
+    /// with macOS Settings.selfCompact — a settings.json moved between Mac
+    /// and Windows keeps its rule set.
+    #[serde(default)]
+    pub self_compact: SelfCompactSettings,
 }
 
 fn default_terminal_font_size() -> u32 {

--- a/windows/src/components/BoardView.tsx
+++ b/windows/src/components/BoardView.tsx
@@ -3,7 +3,7 @@ import {
   PointerSensor, useSensor, useSensors, closestCenter,
   type DropAnimation, defaultDropAnimationSideEffects,
 } from "@dnd-kit/core";
-import { arrayMove } from "@dnd-kit/sortable";
+import { arrayMove, SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { useState } from "react";
 import { canMergeCards, mergeCards, useBoardStore } from "../store/boardStore";
 import { COLUMNS, type CardDto, type KanbanColumn } from "../types";
@@ -20,7 +20,8 @@ const dropAnimation: DropAnimation = {
 };
 
 export default function BoardView() {
-  const { moveCard, reorderCards, isLoading, cards, setNewTaskOpen, refresh, setMergeTargetId } = useBoardStore();
+  const { moveCard, reorderCards, reorderPinnedCards, isLoading, cards, setNewTaskOpen, refresh, setMergeTargetId } = useBoardStore();
+  const pinnedCards = useBoardStore((s) => s.pinnedCards());
   const [draggingCard, setDraggingCard] = useState<CardDto | null>(null);
   const { theme } = useTheme();
   const c = t(theme);
@@ -104,6 +105,23 @@ export default function BoardView() {
       return;
     }
 
+    // Reordering inside the Pinned strip is its own sortable scope — both
+    // cards carry pinnedAt regardless of which real column they live in.
+    if (activeCard.link.pinnedAt && overCard.link.pinnedAt) {
+      const pinned = useBoardStore.getState().pinnedCards();
+      const oldIndex = pinned.findIndex((c) => c.id === activeId);
+      const newIndex = pinned.findIndex((c) => c.id === overId);
+      if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+        const newOrder = arrayMove(
+          pinned.map((c) => c.id),
+          oldIndex,
+          newIndex
+        );
+        reorderPinnedCards(newOrder);
+      }
+      return;
+    }
+
     if (activeCard.link.column === overCard.link.column) {
       // Same column → reorder
       const column = activeCard.link.column;
@@ -135,8 +153,40 @@ export default function BoardView() {
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
       >
-        <div className="flex flex-1 gap-1.5 overflow-x-auto p-2">
-          {COLUMNS.map((column) => <ColumnView key={column} column={column} />)}
+        <div className="flex flex-col flex-1 overflow-hidden">
+          {pinnedCards.length > 0 && (
+            <div
+              className="shrink-0 px-2 pt-2 pb-1"
+              style={{ borderBottom: `1px solid ${c.border}` }}
+            >
+              <div className="flex items-center gap-2 mb-1.5 px-1">
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                  style={{ color: c.textDim }}>
+                  <path strokeLinecap="round" strokeLinejoin="round"
+                    d="M12 2l1.5 4.5L18 8l-3.5 3 1 5L12 13.8 8.5 16l1-5L6 8l4.5-1.5L12 2z" />
+                </svg>
+                <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: c.textDim }}>
+                  Pinned
+                </span>
+                <span className="text-[11px]" style={{ color: c.textDim }}>{pinnedCards.length}</span>
+              </div>
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                <SortableContext
+                  items={pinnedCards.map((card) => card.id)}
+                  strategy={horizontalListSortingStrategy}
+                >
+                  {pinnedCards.map((card) => (
+                    <div key={card.id} style={{ minWidth: 220, maxWidth: 260, flex: "0 0 auto" }}>
+                      <CardView card={card} />
+                    </div>
+                  ))}
+                </SortableContext>
+              </div>
+            </div>
+          )}
+          <div className="flex flex-1 gap-1.5 overflow-x-auto p-2">
+            {COLUMNS.map((column) => <ColumnView key={column} column={column} />)}
+          </div>
         </div>
         <DragOverlay dropAnimation={dropAnimation}>
           {draggingCard && (

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -517,7 +517,7 @@ export default function CardDetailView() {
       if (p.eventName !== "Stop") return;
       const stopAt = Date.now();
       if (pending) clearTimeout(pending);
-      pending = setTimeout(() => {
+      pending = setTimeout(async () => {
         // User typed in the meantime — back off.
         if (Date.now() - lastUserPromptAt.current < 1100) return;
         // Resolve the freshest queue from the store (closure value would be
@@ -531,6 +531,29 @@ export default function CardDetailView() {
             (recentlyAutoSent.current.get(qp.id) ?? 0) + 62_000 < now,
         );
         if (!target || !terminalWriteRef.current) return;
+        // Self-compact drop-guard: a queued compact nudge becomes stale once
+        // the session's context usage drops back under its threshold (i.e.
+        // a compact already happened). Removing it here matches the macOS
+        // BackgroundOrchestrator behavior.
+        let drop = false;
+        if (target.selfCompactThresholdTokens != null) {
+          try {
+            drop = await invoke<boolean>("should_drop_self_compact_prompt", {
+              cardId: card.id,
+              promptId: target.id,
+            });
+          } catch {
+            drop = false;
+          }
+        }
+        if (drop) {
+          removeQueuedPrompt(card.id, target.id)
+            .then(() =>
+              setQueuedPrompts((prev) => prev.filter((p) => p.id !== target.id)),
+            )
+            .catch(() => {});
+          return;
+        }
         terminalWriteRef.current(target.body + "\r");
         recentlyAutoSent.current.set(target.id, now);
         // Garbage-collect dedup entries older than 5 minutes.

--- a/windows/src/components/CardView.tsx
+++ b/windows/src/components/CardView.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function CardView({ card, isDragging = false }: Props) {
-  const { selectCard, selectedCardId, moveCard, deleteCard, archiveCard, mergeTargetId } = useBoardStore();
+  const { selectCard, selectedCardId, moveCard, deleteCard, archiveCard, setCardPinned, mergeTargetId } = useBoardStore();
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const { theme } = useTheme();
   const c = t(theme);
@@ -102,6 +102,17 @@ export default function CardView({ card, isDragging = false }: Props) {
 
         {/* Title */}
         <p className="text-[13px] leading-snug line-clamp-2 pr-5 font-medium" style={{ color: c.textPrimary }}>
+          {card.link.pinnedAt && (
+            <svg
+              className="inline-block w-3 h-3 mr-1 -mt-0.5"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              style={{ color: "#d29922" }}
+              aria-label="Pinned"
+            >
+              <path d="M12 2l1.5 4.5L18 8l-3.5 3 1 5L12 13.8 8.5 16l1-5L6 8l4.5-1.5L12 2z" />
+            </svg>
+          )}
           {card.displayTitle}
         </p>
 
@@ -133,6 +144,10 @@ export default function CardView({ card, isDragging = false }: Props) {
           x={contextMenu.x} y={contextMenu.y} card={card}
           onClose={() => setContextMenu(null)}
           onMove={(col) => { moveCard(card.id, col); setContextMenu(null); }}
+          onTogglePin={() => {
+            setCardPinned(card.id, !card.link.pinnedAt);
+            setContextMenu(null);
+          }}
           onDelete={async () => {
             setContextMenu(null);
             const title = card.displayTitle || card.link.name || "this card";
@@ -207,14 +222,16 @@ function Badge({ text, color, theme, title }: { text: string; color: string; the
 }
 
 function ContextMenu({
-  x, y, card, onClose, onMove, onDelete, onArchive,
+  x, y, card, onClose, onMove, onTogglePin, onDelete, onArchive,
 }: {
   x: number; y: number; card: CardDto; onClose: () => void;
-  onMove: (col: KanbanColumn) => void; onDelete: () => void; onArchive: () => void;
+  onMove: (col: KanbanColumn) => void; onTogglePin: () => void;
+  onDelete: () => void; onArchive: () => void;
 }) {
   const { theme } = useTheme();
   const c = t(theme);
   const moveTargets = COLUMNS.filter((col) => col !== card.link.column);
+  const isPinned = card.link.pinnedAt != null;
 
   return (
     <>
@@ -223,6 +240,16 @@ function ContextMenu({
         className="fixed z-50 rounded-lg shadow-2xl py-1 min-w-[180px] animate-fade-in"
         style={{ left: x, top: y, background: c.bgContext, border: `1px solid ${c.borderBright}` }}
       >
+        <button
+          onClick={onTogglePin}
+          className="w-full text-left px-3 py-2 text-[13px] transition-colors"
+          style={{ color: c.textSecondary }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = c.hoverBg; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = ""; }}
+        >
+          {isPinned ? "Unpin from top" : "Pin to top"}
+        </button>
+        <div style={{ borderTop: `1px solid ${c.border}`, margin: "4px 0" }} />
         <div className="px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: c.textDim }}>
           Move to
         </div>

--- a/windows/src/components/SettingsView.tsx
+++ b/windows/src/components/SettingsView.tsx
@@ -268,6 +268,59 @@ function GeneralSection({
           style={inputStyle(c)}
         />
       </FieldGroup>
+
+      <SelfCompactBlock settings={settings} onChange={onChange} themeTokens={c} />
+    </div>
+  );
+}
+
+function SelfCompactBlock({
+  settings,
+  onChange,
+  themeTokens: c,
+}: {
+  settings: Settings;
+  onChange: (s: Settings) => void;
+  themeTokens: ThemeTokens;
+}) {
+  // Default the whole struct when the file came from a legacy/macOS build
+  // without the field. The toggle controls `enabled`; the rule defaults
+  // ship from the backend.
+  const sc = settings.selfCompact ?? {
+    enabled: false,
+    pollIntervalSeconds: 30,
+    rules: [],
+  };
+  return (
+    <div className="flex flex-col gap-3">
+      <Toggle
+        checked={sc.enabled}
+        onChange={(v) =>
+          onChange({
+            ...settings,
+            selfCompact: { ...sc, enabled: v },
+          })
+        }
+        label="Auto self-compact guard"
+        description="Drop stale compact nudges from the queue once context usage drops below the threshold (compaction worked). Polling/generation is not yet wired on Windows; thresholds will be honored once it lands."
+        themeTokens={c}
+      />
+      {sc.enabled && sc.rules.length > 0 && (
+        <div
+          className="rounded-lg px-3 py-2 text-[12px]"
+          style={{ background: c.bgInput, border: `1px solid ${c.border}`, color: c.textMuted }}
+        >
+          <div className="font-semibold mb-1" style={{ color: c.textSecondary }}>
+            Configured thresholds
+          </div>
+          {sc.rules.map((r) => (
+            <div key={r.id} className="flex items-baseline gap-2">
+              <span className="font-mono">{(r.thresholdTokens / 1000).toFixed(0)}k</span>
+              <span style={{ color: c.textDim }}>{r.action === "compactNow" ? "compact now" : "queue prompt"}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/windows/src/store/boardStore.ts
+++ b/windows/src/store/boardStore.ts
@@ -51,6 +51,8 @@ interface BoardStore {
   deleteCard: (cardId: string) => Promise<void>;
   archiveCard: (cardId: string) => Promise<void>;
   renameCard: (cardId: string, name: string) => Promise<void>;
+  setCardPinned: (cardId: string, isPinned: boolean) => Promise<void>;
+  reorderPinnedCards: (orderedIds: string[]) => void;
   createCard: (
     prompt: string,
     title: string | null,
@@ -69,6 +71,7 @@ interface BoardStore {
 
   // Computed helpers
   cardsInColumn: (column: KanbanColumn) => CardDto[];
+  pinnedCards: () => CardDto[];
   selectedCard: () => CardDto | null;
 }
 
@@ -181,6 +184,52 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     }
   },
 
+  setCardPinned: async (cardId, isPinned) => {
+    // Optimistic: stamp pinnedAt locally so the card jumps into the pinned
+    // section immediately. Assign a sort order one slot above current min so
+    // it lands at the top — matches the backend's behavior.
+    const minOrder = Math.min(
+      0,
+      ...get().cards
+        .map((c) => c.link.pinnedSortOrder)
+        .filter((v): v is number => v != null)
+    );
+    set((state) => ({
+      cards: state.cards.map((c) =>
+        c.id === cardId
+          ? {
+              ...c,
+              link: {
+                ...c.link,
+                pinnedAt: isPinned ? new Date().toISOString() : undefined,
+                pinnedSortOrder: isPinned ? minOrder - 1 : undefined,
+              },
+            }
+          : c
+      ),
+    }));
+    try {
+      await invoke("set_card_pinned", { cardId, isPinned });
+    } catch (e) {
+      set({ error: String(e) });
+      get().refresh();
+    }
+  },
+
+  reorderPinnedCards: (orderedIds) => {
+    set((state) => ({
+      cards: state.cards.map((c) => {
+        const idx = orderedIds.indexOf(c.id);
+        return idx === -1
+          ? c
+          : { ...c, link: { ...c.link, pinnedSortOrder: idx } };
+      }),
+    }));
+    invoke("reorder_pinned_cards", { orderedIds }).catch((e) =>
+      set({ error: String(e) })
+    );
+  },
+
   createCard: async (prompt, title, project, launch = false, assistantId) => {
     try {
       const link = await invoke<{ id: string }>("create_card", {
@@ -216,6 +265,8 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     const { cards, selectedProjectPath } = get();
     const filtered = cards
       .filter((c) => c.link.column === column)
+      // Pinned cards float into the Pinned section instead of double-rendering.
+      .filter((c) => !c.link.pinnedAt)
       .filter((c) => {
         if (!selectedProjectPath) return true;
         const cardPath = c.link.projectPath ?? c.session?.projectPath;
@@ -245,6 +296,35 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       if (sa != null) return -1;
       if (sb != null) return 1;
       return byTimeDesc(a, b);
+    });
+  },
+
+  pinnedCards: () => {
+    const { cards, selectedProjectPath } = get();
+    const filtered = cards
+      .filter((c) => c.link.pinnedAt != null)
+      .filter((c) => {
+        if (!selectedProjectPath) return true;
+        const cardPath = c.link.projectPath ?? c.session?.projectPath;
+        if (!cardPath) return false;
+        return (
+          cardPath === selectedProjectPath ||
+          cardPath.startsWith(selectedProjectPath + "/") ||
+          cardPath.startsWith(selectedProjectPath + "\\")
+        );
+      });
+
+    return filtered.sort((a, b) => {
+      const sa = a.link.pinnedSortOrder;
+      const sb = b.link.pinnedSortOrder;
+      if (sa != null && sb != null && sa !== sb) return sa - sb;
+      if (sa != null && sb == null) return -1;
+      if (sa == null && sb != null) return 1;
+      // Newest pin first — mirrors macOS BoardStore.pinnedCards.
+      const ta = a.link.pinnedAt ?? "";
+      const tb = b.link.pinnedAt ?? "";
+      if (ta !== tb) return tb.localeCompare(ta);
+      return a.id.localeCompare(b.id);
     });
   },
 

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -79,6 +79,8 @@ export interface QueuedPrompt {
   id: string;
   body: string;
   sendAutomatically: boolean;
+  /** Set only for prompts the self-compact guard enqueued (mirrors macOS). */
+  selfCompactThresholdTokens?: number;
 }
 
 export interface Link {
@@ -103,6 +105,11 @@ export interface Link {
   queuedPrompts?: QueuedPrompt[];
   /** Manual sort position within a column; undefined = time-based ordering. */
   sortOrder?: number;
+  /** When set, the card is shown in the Pinned section above the lanes. */
+  pinnedAt?: string;
+  /** Manual order within the Pinned section. Separate from sortOrder so
+   *  rearranging a pin never disturbs the card's lane position. */
+  pinnedSortOrder?: number;
   /** Coding assistant that owns this card. Drives which CLI runs in the
    *  terminal. Defaults to "claude" for legacy/macOS-written cards. */
   assistantId?: AssistantId;
@@ -224,6 +231,21 @@ export interface RemotePrereqs {
   bashPath?: string;
 }
 
+export type SelfCompactAction = "queuePrompt" | "compactNow";
+
+export interface SelfCompactRule {
+  id: string;
+  thresholdTokens: number;
+  action: SelfCompactAction;
+  message: string;
+}
+
+export interface SelfCompactSettings {
+  enabled: boolean;
+  pollIntervalSeconds: number;
+  rules: SelfCompactRule[];
+}
+
 export interface Settings {
   projects: Project[];
   globalView: GlobalViewSettings;
@@ -238,6 +260,8 @@ export interface Settings {
   /** Shell command for the embedded terminal — space-separated tokens. Default "cmd.exe". */
   terminalShell: string;
   remote?: RemoteSettings;
+  /** Automatic context-limit guard for Claude sessions (mirrors macOS). */
+  selfCompact?: SelfCompactSettings;
 }
 
 export interface DependencyStatus {


### PR DESCRIPTION
## Summary

Two macOS-side features that landed in late May / early June and were
missed by the Phase 7 parity audit (which focused on the chat surface,
not board/orchestrator additions). Targets **PR #115's branch** so it
lands as part of the Part 1 follow-up bundle, not directly on \`main\`.

### Pinned cards
- \`Link\` grows \`pinned_at\` + \`pinned_sort_order\`, byte-compatible with macOS
- New Pinned strip above the columns with horizontal drag-reorder
- Pinned cards hidden from their real lane (mirrors macOS \`unpinnedCards(in:)\`)
- Context menu: Pin to top / Unpin from top; gold pin glyph by the title
- Archive + move-to-all-sessions clear the pin
- \`merge_ops\` inherits the pin from source when target wasn't pinned

### Self-compact (data shapes + stale-nudge drop guard)
- \`SelfCompactSettings\` / \`SelfCompactRule\` / \`SelfCompactAction\` with the same defaults as macOS (500k/600k/700k queue, 750k \`/compact\`)
- \`QueuedPrompt.selfCompactThresholdTokens\` so the guard can tell auto-nudges apart from manual prompts
- New \`context_usage.rs\` reads \`<data_dir>/context/<sessionId>.json\` (same statusline shape as macOS)
- New \`should_drop_self_compact_prompt\` command runs the macOS \`shouldDropStaleSelfCompactPrompt\` logic
- Wired into \`CardDetailView\`'s hook-driven auto-send path so a compact nudge the user already addressed gets dropped instead of sent
- SettingsView gets an enable toggle + read-only threshold summary

## Verify

- \`cd windows && npm run build\` — green
- \`cd windows/src-tauri && cargo build\` — green (only pre-existing warnings)
- \`cargo test\` — 58 passed, 0 failed

## Out of scope (deliberate, follow-up issues recommended)

- **Self-compact polling/generation loop** — actually *enqueueing* compact nudges when context usage crosses a threshold. Requires the Claude Code statusline to be emitting \`<data_dir>/context/<sessionId>.json\` first; that statusline plumbing doesn't exist on Windows yet. Once it lands, this PR's drop guard + data shapes are ready.
- **Channel reorder** — the macOS commit bundled \"channels + pinned reorder\"; only pinned is ported here. Channel reorder is a smaller follow-up.

## Test plan

- [ ] Right-click any card → Pin to top → appears in Pinned strip with gold pin glyph
- [ ] Right-click pinned card → Unpin from top → returns to its real lane
- [ ] Drag-reorder within the Pinned strip → order persists across refresh
- [ ] Pin a card, then archive it → pin clears, card lands in All Sessions
- [ ] Merge an unpinned card into a pinned one → target stays pinned in same slot
- [ ] Merge a pinned card into an unpinned one → target inherits the pin
- [ ] Toggle Self-compact in General Settings → toggle persists
- [ ] (manual) Drop the file \`<APPDATA>\kanban-code\context\<sessionId>.json\` with a sub-threshold reading; queue a prompt with \`selfCompactThresholdTokens\` set; trigger a Stop hook → prompt is dropped, not sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)