### PR TITLE
feat(windows): image-paste pipeline for prompts

### DIFF
--- a/windows/src-tauri/src/card_reconciler.rs
+++ b/windows/src-tauri/src/card_reconciler.rs
@@ -244,6 +244,7 @@ fn new_discovered_link(session: &Session) -> Link {
         manually_archived: false,
         source: "discovered".to_string(),
         prompt_body: session.first_prompt.clone(),
+        prompt_image_paths: None,
         session_link: Some(SessionLink {
             session_id: session.id.clone(),
             session_path: session.jsonl_path.clone(),

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -19,6 +19,10 @@ pub struct QueuedPrompt {
     /// unrelated queue items. Mirrors macOS QueuedPrompt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub self_compact_threshold_tokens: Option<i64>,
+    /// Absolute paths to images attached to this prompt. Referenced from the
+    /// body via `[Image #N]` markers (1-based). Mirrors macOS QueuedPrompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_paths: Option<Vec<String>>,
 }
 
 // ── Sub-structs ──────────────────────────────────────────────────────────────
@@ -113,6 +117,11 @@ pub struct Link {
     #[serde(default = "default_source")]
     pub source: String,
     pub prompt_body: Option<String>,
+    /// Images attached to `prompt_body` for unsent cards. Referenced from
+    /// the body via `[Image #N]` markers (1-based). Mirrors macOS
+    /// Link.promptImagePaths.
+    #[serde(default)]
+    pub prompt_image_paths: Option<Vec<String>>,
     pub session_link: Option<SessionLink>,
     pub worktree_link: Option<WorktreeLink>,
     #[serde(default)]
@@ -194,6 +203,7 @@ impl Link {
         title: Option<String>,
         project: String,
         assistant_id: String,
+        prompt_image_paths: Option<Vec<String>>,
     ) -> Self {
         let now = Utc::now();
         // KSUID matches the macOS format (chronologically sortable across the
@@ -212,6 +222,7 @@ impl Link {
             manually_archived: false,
             source: "manual".to_string(),
             prompt_body: Some(prompt),
+            prompt_image_paths,
             session_link: None,
             worktree_link: None,
             pr_links: vec![],
@@ -233,12 +244,17 @@ impl Link {
 }
 
 impl QueuedPrompt {
-    pub fn new(body: String, send_automatically: bool) -> Self {
+    pub fn new(
+        body: String,
+        send_automatically: bool,
+        image_paths: Option<Vec<String>>,
+    ) -> Self {
         Self {
             id: ksuid::generate(Some("prompt")),
             body,
             send_automatically,
             self_compact_threshold_tokens: None,
+            image_paths,
         }
     }
 }
@@ -363,8 +379,9 @@ impl CoordinationStore {
         title: Option<String>,
         project: String,
         assistant_id: String,
+        prompt_image_paths: Option<Vec<String>>,
     ) -> Result<Link> {
-        let link = Link::new_card(prompt, title, project, assistant_id);
+        let link = Link::new_card(prompt, title, project, assistant_id, prompt_image_paths);
         self.upsert_link(&link).await?;
         Ok(link)
     }
@@ -456,6 +473,7 @@ impl CoordinationStore {
             manually_archived: false,
             source: "github_issue".to_string(),
             prompt_body: Some(prompt_body.to_string()),
+            prompt_image_paths: None,
             session_link: None,
             worktree_link: None,
             pr_links: vec![],

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -435,6 +435,7 @@ impl CoordinationStore {
         prompt_id: &str,
         body: &str,
         send_automatically: bool,
+        image_paths: Option<Option<Vec<String>>>,
     ) -> Result<()> {
         let mut links = self.read_links().await?;
         if let Some(link) = links.iter_mut().find(|l| l.id == card_id) {
@@ -442,6 +443,13 @@ impl CoordinationStore {
                 if let Some(p) = prompts.iter_mut().find(|p| p.id == prompt_id) {
                     p.body = body.to_string();
                     p.send_automatically = send_automatically;
+                    // Three states for image_paths:
+                    //   None         — caller didn't pass; keep what's there
+                    //   Some(None)   — caller wants to clear the attachments
+                    //   Some(Some(v))— caller wants to replace with `v`
+                    if let Some(new_paths) = image_paths {
+                        p.image_paths = new_paths;
+                    }
                 }
             }
             link.updated_at = Utc::now();

--- a/windows/src-tauri/src/images.rs
+++ b/windows/src-tauri/src/images.rs
@@ -1,0 +1,70 @@
+//! Disk-backed storage for images pasted into prompts.
+//!
+//! Layout: `<data_dir>/images/<ksuid>.<ext>`. Paths returned to the frontend
+//! are absolute file paths the frontend can stuff into Link.promptImagePaths
+//! / QueuedPrompt.imagePaths. On send, those paths become markdown
+//! references (`![](path)`) when the marker substitution runs.
+//!
+//! Images live forever in this directory — they're cheap and the user can
+//! prune the folder manually. Mirrors macOS behavior where attachments
+//! live under `~/.kanban-code/images/`.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use tokio::fs;
+
+use crate::coordination_store::kanban_data_dir;
+use crate::ksuid;
+
+fn images_dir() -> PathBuf {
+    kanban_data_dir().join("images")
+}
+
+/// Best-effort extension sniffing from the leading bytes. Falls back to
+/// "png" — the clipboard image path on Windows almost always hands us PNG.
+fn extension_for(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        "png"
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        "jpg"
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        "gif"
+    } else if bytes.starts_with(b"RIFF") && bytes.len() > 11 && &bytes[8..12] == b"WEBP" {
+        "webp"
+    } else {
+        "png"
+    }
+}
+
+/// Save raw image bytes to `<data_dir>/images/<ksuid>.<ext>`, returning the
+/// absolute file path. The KSUID id sorts chronologically so a listing of
+/// the directory shows newest pastes last.
+pub async fn save_bytes(bytes: &[u8]) -> Result<String> {
+    let dir = images_dir();
+    fs::create_dir_all(&dir).await.context("create images dir")?;
+    let id = ksuid::generate(Some("img"));
+    let ext = extension_for(bytes);
+    let path = dir.join(format!("{}.{}", id, ext));
+    fs::write(&path, bytes).await.context("write image bytes")?;
+    Ok(path.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_detects_png() {
+        assert_eq!(extension_for(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]), "png");
+    }
+
+    #[test]
+    fn extension_detects_jpeg() {
+        assert_eq!(extension_for(&[0xFF, 0xD8, 0xFF, 0xE0]), "jpg");
+    }
+
+    #[test]
+    fn extension_falls_back_to_png() {
+        assert_eq!(extension_for(&[0xDE, 0xAD, 0xBE, 0xEF]), "png");
+    }
+}

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod git_remote;
 mod git_worktree;
 mod hook_event_store;
 mod hook_manager;
+mod images;
 mod jsonl_parser;
 mod ksuid;
 mod logging;
@@ -105,6 +106,7 @@ async fn create_card(
     project: String,
     launch: Option<bool>,
     assistant_id: Option<String>,
+    prompt_image_paths: Option<Vec<String>>,
     state: tauri::State<'_, AppState>,
 ) -> Result<coordination_store::Link, String> {
     let assistant = assistant_id
@@ -115,7 +117,13 @@ async fn create_card(
         .to_string();
     let link = state
         .coordination_store
-        .create_card(prompt.clone(), title, project.clone(), assistant)
+        .create_card(
+            prompt.clone(),
+            title,
+            project.clone(),
+            assistant,
+            prompt_image_paths,
+        )
         .await
         .map_err(|e| e.to_string())?;
 
@@ -124,6 +132,14 @@ async fn create_card(
     let _ = launch; // suppress unused warning
 
     Ok(link)
+}
+
+/// Save raw image bytes (e.g. from clipboard paste) to disk under
+/// `<data_dir>/images/`. Returns the absolute path the frontend should
+/// stash into Link.promptImagePaths / QueuedPrompt.imagePaths.
+#[tauri::command]
+async fn save_clipboard_image(bytes: Vec<u8>) -> Result<String, String> {
+    images::save_bytes(&bytes).await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -349,9 +365,10 @@ async fn add_queued_prompt(
     card_id: String,
     body: String,
     send_automatically: bool,
+    image_paths: Option<Vec<String>>,
     state: tauri::State<'_, AppState>,
 ) -> Result<coordination_store::QueuedPrompt, String> {
-    let prompt = coordination_store::QueuedPrompt::new(body, send_automatically);
+    let prompt = coordination_store::QueuedPrompt::new(body, send_automatically, image_paths);
     state
         .coordination_store
         .add_queued_prompt(&card_id, prompt)
@@ -1778,6 +1795,7 @@ pub fn run() {
             update_queued_prompt,
             remove_queued_prompt,
             should_drop_self_compact_prompt,
+            save_clipboard_image,
             search_transcript,
             check_dependencies,
             resolve_github_base_url,

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -382,11 +382,22 @@ async fn update_queued_prompt(
     prompt_id: String,
     body: String,
     send_automatically: bool,
+    image_paths: Option<Vec<String>>,
+    set_image_paths: Option<bool>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    // `set_image_paths` flips the outer wrapper: when false / absent we leave
+    // the stored attachments alone (legacy callers and pure body-edits).
+    // When true we replace with whatever `image_paths` carries — empty list
+    // and null both clear the attachments.
+    let paths_update = if set_image_paths.unwrap_or(false) {
+        Some(image_paths.filter(|v| !v.is_empty()))
+    } else {
+        None
+    };
     state
         .coordination_store
-        .update_queued_prompt(&card_id, &prompt_id, &body, send_automatically)
+        .update_queued_prompt(&card_id, &prompt_id, &body, send_automatically, paths_update)
         .await
         .map_err(|e| e.to_string())
 }

--- a/windows/src-tauri/src/merge_ops.rs
+++ b/windows/src-tauri/src/merge_ops.rs
@@ -74,6 +74,11 @@ pub fn merge_into_target(source: &Link, target: &mut Link) {
     }
     if target.prompt_body.is_none() {
         target.prompt_body = source.prompt_body.clone();
+        // Image attachments travel with the prompt body — if we're inheriting
+        // text, inherit the markers' referenced files too.
+        if target.prompt_image_paths.is_none() {
+            target.prompt_image_paths = source.prompt_image_paths.clone();
+        }
     }
     if target.session_link.is_none() {
         target.session_link = source.session_link.clone();
@@ -154,6 +159,7 @@ mod tests {
             manually_archived: false,
             source: "manual".to_string(),
             prompt_body: None,
+            prompt_image_paths: None,
             session_link: None,
             worktree_link: None,
             pr_links: vec![],

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -22,6 +22,7 @@ import {
 import { ASSISTANT_CLI, type Project, type AssistantId } from "../types";
 import { useTheme, t } from "../theme";
 import type { Turn, TranscriptPage, QueuedPrompt } from "../types";
+import { replaceMarkersWithMarkdown } from "../lib/promptImageLayout";
 import TerminalView from "./Terminal";
 import QueuedPromptDialog from "./QueuedPromptDialog";
 import QueuedPromptsBar from "./QueuedPromptsBar";
@@ -333,7 +334,15 @@ export default function CardDetailView() {
   // the dialog is skipped — launchFlags stays null and the dialog defaults
   // apply (no skip-perm, no env prefix). The same builder also feeds the
   // dialog's live preview so what the user sees is what runs.
-  const effectivePrompt = launchFlags?.prompt ?? promptBody ?? "";
+  //
+  // `[Image #N]` markers are rewritten to markdown image refs at this boundary
+  // — the editor surfaces (NewTaskDialog, LaunchConfirmationDialog) work in
+  // marker form so users can move attachments around, but Claude sees the
+  // resolved markdown paths. Matches macOS PromptImageLayout fallback.
+  const rawPrompt = launchFlags?.prompt ?? promptBody ?? "";
+  const effectivePrompt = card.link.promptImagePaths?.length
+    ? replaceMarkersWithMarkdown(rawPrompt, card.link.promptImagePaths)
+    : rawPrompt;
   const effectiveSkipPerm = launchFlags?.dangerouslySkipPermissions ?? false;
   const effectiveEnv = launchFlags?.envPrefix ?? [];
 
@@ -554,7 +563,10 @@ export default function CardDetailView() {
             .catch(() => {});
           return;
         }
-        terminalWriteRef.current(target.body + "\r");
+        const sendBody = target.imagePaths?.length
+          ? replaceMarkersWithMarkdown(target.body, target.imagePaths)
+          : target.body;
+        terminalWriteRef.current(sendBody + "\r");
         recentlyAutoSent.current.set(target.id, now);
         // Garbage-collect dedup entries older than 5 minutes.
         for (const [id, at] of recentlyAutoSent.current) {
@@ -615,16 +627,21 @@ export default function CardDetailView() {
   }, [card.id]);
 
   // Queued prompt handlers
-  const handleAddPrompt = async (body: string, sendAutomatically: boolean) => {
+  const handleAddPrompt = async (body: string, sendAutomatically: boolean, imagePaths?: string[]) => {
     try {
-      const prompt = await addQueuedPrompt(card.id, body, sendAutomatically);
+      const prompt = await addQueuedPrompt(card.id, body, sendAutomatically, imagePaths);
       setQueuedPrompts((prev) => [...prev, prompt]);
     } catch { /* silent */ }
   };
 
-  const handleUpdatePrompt = async (body: string, sendAutomatically: boolean) => {
+  const handleUpdatePrompt = async (body: string, sendAutomatically: boolean, imagePaths?: string[]) => {
     if (!editingPrompt) return;
     try {
+      // update_queued_prompt doesn't accept imagePaths yet — for edits we
+      // keep the existing attachment set. Image changes during edit are a
+      // follow-up; for now the chip-remove path is the editor's way to
+      // detach an image (the marker stays as literal text on send).
+      void imagePaths;
       await updateQueuedPrompt(card.id, editingPrompt.id, body, sendAutomatically);
       setQueuedPrompts((prev) =>
         prev.map((p) => p.id === editingPrompt.id ? { ...p, body, sendAutomatically } : p)
@@ -642,8 +659,12 @@ export default function CardDetailView() {
   const handleSendNow = async (promptId: string) => {
     const prompt = queuedPrompts.find((p) => p.id === promptId);
     if (!prompt || !terminalWriteRef.current) return;
-    // Write to terminal
-    terminalWriteRef.current(prompt.body + "\r");
+    // Write to terminal — substitute [Image #N] markers with markdown refs
+    // so Claude sees real paths, not the editor placeholders.
+    const sendBody = prompt.imagePaths?.length
+      ? replaceMarkersWithMarkdown(prompt.body, prompt.imagePaths)
+      : prompt.body;
+    terminalWriteRef.current(sendBody + "\r");
     // Remove from queue
     handleRemovePrompt(promptId);
   };
@@ -1075,6 +1096,7 @@ export default function CardDetailView() {
         onSave={editingPrompt ? handleUpdatePrompt : handleAddPrompt}
         editBody={editingPrompt?.body}
         editSendAuto={editingPrompt?.sendAutomatically}
+        editImagePaths={editingPrompt?.imagePaths}
       />
 
       {/* Launch confirmation dialog (fresh launches only) */}

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -637,14 +637,18 @@ export default function CardDetailView() {
   const handleUpdatePrompt = async (body: string, sendAutomatically: boolean, imagePaths?: string[]) => {
     if (!editingPrompt) return;
     try {
-      // update_queued_prompt doesn't accept imagePaths yet — for edits we
-      // keep the existing attachment set. Image changes during edit are a
-      // follow-up; for now the chip-remove path is the editor's way to
-      // detach an image (the marker stays as literal text on send).
-      void imagePaths;
-      await updateQueuedPrompt(card.id, editingPrompt.id, body, sendAutomatically);
+      // Pass imagePaths through so chip-remove in the edit dialog actually
+      // persists. The wrapper treats `undefined` as "don't touch", which is
+      // what legacy callers want — here we always pass an array (possibly
+      // empty) because the dialog tracks both states explicitly.
+      const nextPaths = imagePaths ?? [];
+      await updateQueuedPrompt(card.id, editingPrompt.id, body, sendAutomatically, nextPaths);
       setQueuedPrompts((prev) =>
-        prev.map((p) => p.id === editingPrompt.id ? { ...p, body, sendAutomatically } : p)
+        prev.map((p) =>
+          p.id === editingPrompt.id
+            ? { ...p, body, sendAutomatically, imagePaths: nextPaths.length > 0 ? nextPaths : undefined }
+            : p
+        )
       );
     } catch { /* silent */ }
   };

--- a/windows/src/components/NewTaskDialog.tsx
+++ b/windows/src/components/NewTaskDialog.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { getSettings, useBoardStore } from "../store/boardStore";
+import { getSettings, saveClipboardImage, useBoardStore } from "../store/boardStore";
 import { useTheme, t } from "../theme";
 import { ASSISTANT_DISPLAY, type AssistantId } from "../types";
+import { imageMarker } from "../lib/promptImageLayout";
 
 export default function NewTaskDialog() {
   const { createCard, setNewTaskOpen, selectCard, cards } = useBoardStore();
@@ -14,7 +15,44 @@ export default function NewTaskDialog() {
   const [assistantId, setAssistantId] = useState<AssistantId>("claude");
   const [submitting, setSubmitting] = useState(false);
   const [settingsProjects, setSettingsProjects] = useState<string[]>([]);
+  const [imagePaths, setImagePaths] = useState<string[]>([]);
   const promptRef = useRef<HTMLTextAreaElement>(null);
+
+  const handlePromptPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData.items).filter((it) => it.kind === "file" && it.type.startsWith("image/"));
+    if (items.length === 0) return;
+    e.preventDefault();
+    const textarea = e.currentTarget;
+    const selStart = textarea.selectionStart;
+    const selEnd = textarea.selectionEnd;
+    const newPaths: string[] = [];
+    for (const item of items) {
+      const file = item.getAsFile();
+      if (!file) continue;
+      const buf = new Uint8Array(await file.arrayBuffer());
+      try {
+        const path = await saveClipboardImage(buf);
+        newPaths.push(path);
+      } catch (err) {
+        useBoardStore.setState({ error: String(err) });
+        return;
+      }
+    }
+    const baseCount = imagePaths.length;
+    const markers = newPaths.map((_, i) => imageMarker(baseCount + i + 1)).join(" ");
+    const next = prompt.slice(0, selStart) + markers + prompt.slice(selEnd);
+    setPrompt(next);
+    setImagePaths([...imagePaths, ...newPaths]);
+  };
+
+  const removeImageAt = (idx: number) => {
+    setImagePaths(imagePaths.filter((_, i) => i !== idx));
+    // Strip the corresponding marker text. We don't reindex remaining markers
+    // — `replaceMarkersWithMarkdown` only honors markers <= imagePaths.length,
+    // so stale higher-index markers turn into literal text on send. Users can
+    // edit them out by hand, which matches macOS's behavior.
+    setPrompt(prompt.replace(imageMarker(idx + 1), ""));
+  };
 
   const cardProjects = [
     ...new Set(
@@ -47,7 +85,14 @@ export default function NewTaskDialog() {
     if (!prompt.trim()) return;
     setSubmitting(true);
     try {
-      const cardId = await createCard(prompt.trim(), title.trim() || null, project || ".", launch, assistantId);
+      const cardId = await createCard(
+        prompt.trim(),
+        title.trim() || null,
+        project || ".",
+        launch,
+        assistantId,
+        imagePaths.length > 0 ? imagePaths : undefined,
+      );
       setNewTaskOpen(false);
       if (launch && cardId) {
         selectCard(cardId);
@@ -105,9 +150,37 @@ export default function NewTaskDialog() {
               placeholder="Describe the task for Claude..."
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
+              onPaste={handlePromptPaste}
               className="w-full rounded-lg px-3.5 py-3 text-[14px] outline-none resize-none transition-colors leading-relaxed"
               style={inputStyle}
             />
+            {imagePaths.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-2">
+                {imagePaths.map((p, idx) => (
+                  <span
+                    key={p}
+                    className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px]"
+                    style={{ background: c.bgInput, color: c.textSecondary, border: `1px solid ${c.border}` }}
+                    title={p}
+                  >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+                    </svg>
+                    Image #{idx + 1}
+                    <button
+                      type="button"
+                      onClick={() => removeImageAt(idx)}
+                      className="ml-0.5 hover:text-red-400 transition-colors"
+                      aria-label={`Remove image ${idx + 1}`}
+                    >
+                      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
 
           <div>

--- a/windows/src/components/NewTaskDialog.tsx
+++ b/windows/src/components/NewTaskDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { getSettings, saveClipboardImage, useBoardStore } from "../store/boardStore";
 import { useTheme, t } from "../theme";
 import { ASSISTANT_DISPLAY, type AssistantId } from "../types";
-import { imageMarker } from "../lib/promptImageLayout";
+import { imageMarker, removeImageAtIndex } from "../lib/promptImageLayout";
 
 export default function NewTaskDialog() {
   const { createCard, setNewTaskOpen, selectCard, cards } = useBoardStore();
@@ -46,12 +46,9 @@ export default function NewTaskDialog() {
   };
 
   const removeImageAt = (idx: number) => {
-    setImagePaths(imagePaths.filter((_, i) => i !== idx));
-    // Strip the corresponding marker text. We don't reindex remaining markers
-    // — `replaceMarkersWithMarkdown` only honors markers <= imagePaths.length,
-    // so stale higher-index markers turn into literal text on send. Users can
-    // edit them out by hand, which matches macOS's behavior.
-    setPrompt(prompt.replace(imageMarker(idx + 1), ""));
+    const { body, imagePaths: nextPaths } = removeImageAtIndex(prompt, imagePaths, idx);
+    setPrompt(body);
+    setImagePaths(nextPaths);
   };
 
   const cardProjects = [

--- a/windows/src/components/QueuedPromptDialog.tsx
+++ b/windows/src/components/QueuedPromptDialog.tsx
@@ -1,20 +1,24 @@
 import { useState, useEffect, useRef } from "react";
 import { useTheme, t } from "../theme";
+import { saveClipboardImage, useBoardStore } from "../store/boardStore";
+import { imageMarker } from "../lib/promptImageLayout";
 
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSave: (body: string, sendAutomatically: boolean) => void;
+  onSave: (body: string, sendAutomatically: boolean, imagePaths?: string[]) => void;
   /** If set, we're editing an existing prompt */
   editBody?: string;
   editSendAuto?: boolean;
+  editImagePaths?: string[];
 }
 
-export default function QueuedPromptDialog({ open, onClose, onSave, editBody, editSendAuto }: Props) {
+export default function QueuedPromptDialog({ open, onClose, onSave, editBody, editSendAuto, editImagePaths }: Props) {
   const { theme } = useTheme();
   const c = t(theme);
   const [body, setBody] = useState("");
   const [sendAuto, setSendAuto] = useState(true);
+  const [imagePaths, setImagePaths] = useState<string[]>([]);
   const textRef = useRef<HTMLTextAreaElement>(null);
   const isEdit = editBody !== undefined;
 
@@ -22,6 +26,7 @@ export default function QueuedPromptDialog({ open, onClose, onSave, editBody, ed
     if (open) {
       setBody(editBody ?? "");
       setSendAuto(editSendAuto ?? true);
+      setImagePaths(editImagePaths ?? []);
       setTimeout(() => textRef.current?.focus(), 50);
     }
   }, [open]);
@@ -32,8 +37,38 @@ export default function QueuedPromptDialog({ open, onClose, onSave, editBody, ed
 
   const handleSubmit = () => {
     if (!canSave) return;
-    onSave(body.trim(), sendAuto);
+    onSave(body.trim(), sendAuto, imagePaths.length > 0 ? imagePaths : undefined);
     onClose();
+  };
+
+  const handlePaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData.items).filter((it) => it.kind === "file" && it.type.startsWith("image/"));
+    if (items.length === 0) return;
+    e.preventDefault();
+    const ta = e.currentTarget;
+    const selStart = ta.selectionStart;
+    const selEnd = ta.selectionEnd;
+    const newPaths: string[] = [];
+    for (const item of items) {
+      const file = item.getAsFile();
+      if (!file) continue;
+      const buf = new Uint8Array(await file.arrayBuffer());
+      try {
+        newPaths.push(await saveClipboardImage(buf));
+      } catch (err) {
+        useBoardStore.setState({ error: String(err) });
+        return;
+      }
+    }
+    const baseCount = imagePaths.length;
+    const markers = newPaths.map((_, i) => imageMarker(baseCount + i + 1)).join(" ");
+    setBody(body.slice(0, selStart) + markers + body.slice(selEnd));
+    setImagePaths([...imagePaths, ...newPaths]);
+  };
+
+  const removeImageAt = (idx: number) => {
+    setImagePaths(imagePaths.filter((_, i) => i !== idx));
+    setBody(body.replace(imageMarker(idx + 1), ""));
   };
 
   return (
@@ -70,6 +105,7 @@ export default function QueuedPromptDialog({ open, onClose, onSave, editBody, ed
             ref={textRef}
             value={body}
             onChange={(e) => setBody(e.target.value)}
+            onPaste={handlePaste}
             placeholder="Enter your prompt..."
             className="w-full rounded-xl px-4 py-3 text-[13px] leading-[1.6] resize-none outline-none font-mono"
             style={{
@@ -82,6 +118,30 @@ export default function QueuedPromptDialog({ open, onClose, onSave, editBody, ed
             onFocus={(e) => { e.currentTarget.style.borderColor = "rgba(79,142,247,0.4)"; }}
             onBlur={(e) => { e.currentTarget.style.borderColor = c.border; }}
           />
+          {imagePaths.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {imagePaths.map((p, idx) => (
+                <span
+                  key={p}
+                  className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px]"
+                  style={{ background: c.bgInput, color: c.textSecondary, border: `1px solid ${c.border}` }}
+                  title={p}
+                >
+                  Image #{idx + 1}
+                  <button
+                    type="button"
+                    onClick={() => removeImageAt(idx)}
+                    className="ml-0.5 hover:text-red-400 transition-colors"
+                    aria-label={`Remove image ${idx + 1}`}
+                  >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
 
           <label
             className="flex items-center gap-2.5 cursor-pointer select-none"

--- a/windows/src/components/QueuedPromptDialog.tsx
+++ b/windows/src/components/QueuedPromptDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useTheme, t } from "../theme";
 import { saveClipboardImage, useBoardStore } from "../store/boardStore";
-import { imageMarker } from "../lib/promptImageLayout";
+import { imageMarker, removeImageAtIndex } from "../lib/promptImageLayout";
 
 interface Props {
   open: boolean;
@@ -67,8 +67,9 @@ export default function QueuedPromptDialog({ open, onClose, onSave, editBody, ed
   };
 
   const removeImageAt = (idx: number) => {
-    setImagePaths(imagePaths.filter((_, i) => i !== idx));
-    setBody(body.replace(imageMarker(idx + 1), ""));
+    const next = removeImageAtIndex(body, imagePaths, idx);
+    setBody(next.body);
+    setImagePaths(next.imagePaths);
   };
 
   return (

--- a/windows/src/lib/promptImageLayout.ts
+++ b/windows/src/lib/promptImageLayout.ts
@@ -1,0 +1,88 @@
+// TypeScript port of Sources/KanbanCodeCore/UseCases/PromptImageLayout.swift
+//
+// Image positions in a prompt are stored as plain-text markers like `[Image #1]`.
+// On send we replace those markers with markdown image refs (`![](path)`) — the
+// macOS app uses a tmux clipboard-paste dance for assistants that support it,
+// but the markdown fallback is the simpler universal path and matches what the
+// Mac code already falls back to when no inline markers are present.
+
+export interface PromptPart {
+  text: string;
+  /** Zero-based image index. undefined when this part is plain text. */
+  imageIndex?: number;
+}
+
+export const IMAGE_MARKER_PREFIX = "[Image #";
+
+export function imageMarker(index1Based: number): string {
+  return `[Image #${index1Based}]`;
+}
+
+export function parts(text: string, imageCount: number): PromptPart[] {
+  if (imageCount <= 0 || !text.includes(IMAGE_MARKER_PREFIX)) {
+    return text.length === 0 ? [] : [{ text }];
+  }
+
+  const out: PromptPart[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const markerStart = text.indexOf(IMAGE_MARKER_PREFIX, cursor);
+    if (markerStart === -1) break;
+    const markerEnd = text.indexOf("]", markerStart);
+    if (markerEnd === -1) break;
+
+    const numberText = text.slice(markerStart + IMAGE_MARKER_PREFIX.length, markerEnd);
+    const number = Number.parseInt(numberText, 10);
+    if (!Number.isFinite(number) || number < 1 || number > imageCount) {
+      // Not a valid marker — keep as plain text and advance.
+      out.push({ text: text.slice(cursor, markerEnd + 1) });
+      cursor = markerEnd + 1;
+      continue;
+    }
+
+    if (markerStart > cursor) {
+      out.push({ text: text.slice(cursor, markerStart) });
+    }
+    out.push({ text: "", imageIndex: number - 1 });
+    cursor = markerEnd + 1;
+  }
+  if (cursor < text.length) {
+    out.push({ text: text.slice(cursor) });
+  }
+  return coalesceAdjacentText(out);
+}
+
+export function referencedImageIndices(text: string, imageCount: number): number[] {
+  return parts(text, imageCount)
+    .map((p) => p.imageIndex)
+    .filter((i): i is number => i != null);
+}
+
+/** Rewrite the prompt so markers point at the given image paths as markdown
+ *  refs. When the prompt has no markers and there are images, the refs are
+ *  appended after the text — matches macOS PromptImageLayout. */
+export function replaceMarkersWithMarkdown(text: string, imagePaths: string[]): string {
+  const ps = parts(text, imagePaths.length);
+  const hasInline = ps.some((p) => p.imageIndex != null);
+  if (!hasInline) {
+    if (imagePaths.length === 0) return text;
+    const refs = imagePaths.map((p) => `![](${p})`).join("\n");
+    return text.length === 0 ? refs : `${text}\n${refs}`;
+  }
+  return ps
+    .map((p) => (p.imageIndex != null ? `![](${imagePaths[p.imageIndex]})` : p.text))
+    .join("");
+}
+
+function coalesceAdjacentText(items: PromptPart[]): PromptPart[] {
+  const out: PromptPart[] = [];
+  for (const p of items) {
+    const last = out[out.length - 1];
+    if (p.imageIndex == null && last && last.imageIndex == null) {
+      last.text += p.text;
+    } else {
+      out.push({ ...p });
+    }
+  }
+  return out;
+}

--- a/windows/src/lib/promptImageLayout.ts
+++ b/windows/src/lib/promptImageLayout.ts
@@ -74,6 +74,33 @@ export function replaceMarkersWithMarkdown(text: string, imagePaths: string[]): 
     .join("");
 }
 
+/** Drop image `removedIdx` (0-based) and rewrite the body's markers so the
+ *  remaining attachments stay contiguous 1-based. Used by the chip-remove
+ *  button on both the New Task and Queued Prompt dialogs.
+ *
+ *  Returns the new body + the new paths. Doing this purely so the editor
+ *  state stays in sync with what `replaceMarkersWithMarkdown` would emit at
+ *  send time — without the renumber, a higher-numbered marker silently
+ *  becomes literal text on send and that image gets lost. */
+export function removeImageAtIndex(
+  body: string,
+  imagePaths: string[],
+  removedIdx: number,
+): { body: string; imagePaths: string[] } {
+  if (removedIdx < 0 || removedIdx >= imagePaths.length) {
+    return { body, imagePaths };
+  }
+  const nextPaths = imagePaths.filter((_, i) => i !== removedIdx);
+  let nextBody = body.split(imageMarker(removedIdx + 1)).join("");
+  // Shift every marker > removedIdx down by one. Walk in ascending order so
+  // we never collide with a not-yet-shifted higher number (since the new
+  // values are strictly smaller than the source values).
+  for (let i = removedIdx + 1; i < imagePaths.length; i++) {
+    nextBody = nextBody.split(imageMarker(i + 1)).join(imageMarker(i));
+  }
+  return { body: nextBody, imagePaths: nextPaths };
+}
+
 function coalesceAdjacentText(items: PromptPart[]): PromptPart[] {
   const out: PromptPart[] = [];
   for (const p of items) {

--- a/windows/src/store/boardStore.ts
+++ b/windows/src/store/boardStore.ts
@@ -58,7 +58,8 @@ interface BoardStore {
     title: string | null,
     project: string,
     launch?: boolean,
-    assistantId?: string
+    assistantId?: string,
+    promptImagePaths?: string[]
   ) => Promise<string | null>;
   setSearchOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
@@ -230,7 +231,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     );
   },
 
-  createCard: async (prompt, title, project, launch = false, assistantId) => {
+  createCard: async (prompt, title, project, launch = false, assistantId, promptImagePaths) => {
     try {
       const link = await invoke<{ id: string }>("create_card", {
         prompt,
@@ -238,6 +239,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         project,
         launch,
         assistantId: assistantId ?? null,
+        promptImagePaths: promptImagePaths && promptImagePaths.length > 0 ? promptImagePaths : null,
       });
       await get().refresh();
       return link.id;
@@ -405,9 +407,21 @@ export async function openInEditor(
 export async function addQueuedPrompt(
   cardId: string,
   body: string,
-  sendAutomatically: boolean
+  sendAutomatically: boolean,
+  imagePaths?: string[]
 ): Promise<QueuedPrompt> {
-  return invoke<QueuedPrompt>("add_queued_prompt", { cardId, body, sendAutomatically });
+  return invoke<QueuedPrompt>("add_queued_prompt", {
+    cardId,
+    body,
+    sendAutomatically,
+    imagePaths: imagePaths && imagePaths.length > 0 ? imagePaths : null,
+  });
+}
+
+/** Persist clipboard image bytes to disk under <data_dir>/images/, returning
+ *  the absolute path to stash into Link.promptImagePaths / imagePaths. */
+export async function saveClipboardImage(bytes: Uint8Array): Promise<string> {
+  return invoke<string>("save_clipboard_image", { bytes: Array.from(bytes) });
 }
 
 export async function updateQueuedPrompt(

--- a/windows/src/store/boardStore.ts
+++ b/windows/src/store/boardStore.ts
@@ -428,9 +428,21 @@ export async function updateQueuedPrompt(
   cardId: string,
   promptId: string,
   body: string,
-  sendAutomatically: boolean
+  sendAutomatically: boolean,
+  imagePaths?: string[] | null,
 ): Promise<void> {
-  return invoke("update_queued_prompt", { cardId, promptId, body, sendAutomatically });
+  // `imagePaths === undefined` ⇒ leave attachments alone. `null` or `[]` ⇒
+  // clear them. A populated array replaces. The backend honors a
+  // `setImagePaths: true` flag to distinguish "don't touch" from "clear".
+  const setImagePaths = imagePaths !== undefined;
+  return invoke("update_queued_prompt", {
+    cardId,
+    promptId,
+    body,
+    sendAutomatically,
+    setImagePaths,
+    imagePaths: setImagePaths ? imagePaths ?? null : null,
+  });
 }
 
 export async function removeQueuedPrompt(

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -81,6 +81,9 @@ export interface QueuedPrompt {
   sendAutomatically: boolean;
   /** Set only for prompts the self-compact guard enqueued (mirrors macOS). */
   selfCompactThresholdTokens?: number;
+  /** Absolute paths to images attached to this prompt. Referenced from body
+   *  via `[Image #N]` markers (1-based). Mirrors macOS QueuedPrompt. */
+  imagePaths?: string[];
 }
 
 export interface Link {
@@ -95,6 +98,9 @@ export interface Link {
   manuallyArchived: boolean;
   source: "discovered" | "hook" | "github_issue" | "manual";
   promptBody?: string;
+  /** Absolute paths to images attached to the prompt body. Referenced via
+   *  `[Image #N]` markers (1-based). Mirrors macOS Link.promptImagePaths. */
+  promptImagePaths?: string[];
   sessionLink?: SessionLink;
   worktreeLink?: WorktreeLink;
   prLinks: PrLink[];


### PR DESCRIPTION
## Summary

First of three Phase 8 features — Mac→Windows parity for image-paste in prompts. Closes one of the architectural gaps from the latest parity audit.

Users can now paste images into the **New Task** and **Queued Prompt** textareas. The image is saved under \`<APPDATA>\kanban-code\images\\`, an \`[Image #N]\` marker lands at the cursor, and a removable chip appears under the textarea. On send to the terminal, markers are rewritten to markdown image refs (\`![](<path>)\`) — the same fallback path macOS uses when an assistant doesn't accept inline image paste.

## What's new

**Pure logic** (mirrors \`Sources/KanbanCodeCore/UseCases/PromptImageLayout.swift\`):
- \`windows/src/lib/promptImageLayout.ts\` — \`parts()\`, \`imageMarker()\`, \`referencedImageIndices()\`, \`replaceMarkersWithMarkdown()\`

**Backend**:
- \`images.rs\` saves clipboard bytes to \`<data_dir>/images/<ksuid>.<ext>\` with magic-byte ext sniffing (PNG/JPG/GIF/WEBP fallback PNG)
- New \`save_clipboard_image\` Tauri command
- \`Link.prompt_image_paths\` + \`QueuedPrompt.image_paths\` — byte-compatible with macOS so round-tripping a links.json between platforms keeps attachments
- \`merge_ops\` inherits attachments together with the prompt body

**UI**:
- NewTaskDialog + QueuedPromptDialog: paste handler, image chips, remove buttons
- CardDetailView substitutes markers→markdown at all three send sites (initial launch, queued-prompt auto-send, manual Send Now)

## Verify

- \`cd windows && npm run build\` — green
- \`cd windows/src-tauri && cargo build\` — green (only pre-existing warnings)
- \`cargo test\` — passes

## Test plan

- [ ] Paste a screenshot into the New Task prompt → \`[Image #1]\` appears at cursor + chip below textarea
- [ ] Paste another → \`[Image #2]\`, two chips
- [ ] Click X on chip #1 → chip + marker removed; remaining chip still renders as #2
- [ ] Submit → card created with markers in promptBody; check \`<APPDATA>\kanban-code\links.json\` shows \`promptImagePaths\` populated
- [ ] Launch card → terminal command shows \`![](C:\Users\...\images\img_*.png)\` substituted in
- [ ] Same for queued prompt: paste image, queue, then Send Now → terminal receives the markdown ref
- [ ] Auto-send via Stop hook → same substitution applies

## Deliberate scope

- The macOS tmux clipboard-paste loop (for assistants with native image-paste) is **not** ported. Markdown fallback covers Claude Code already.
- Editing a queued prompt keeps existing attachments; image add/remove during edit is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)