### PR TITLE
feat(windows): Process Manager modal (Ctrl+Shift+M)

### DIFF
--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod ksuid;
 mod logging;
 mod merge_ops;
 mod mutagen;
+mod process_manager;
 mod pushover;
 mod remote_shell;
 mod remote_status;
@@ -148,6 +149,48 @@ async fn archive_card(
         .archive_link(&card_id)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// One-shot snapshot of running tmux sessions, Claude processes, and known
+/// worktrees. Backs the Process Manager modal. Each list is best-effort —
+/// e.g. when tmux/WSL is missing, `tmuxSessions` is empty rather than an
+/// error, so the UI can render the rest.
+#[tauri::command]
+async fn get_process_state(
+    state: tauri::State<'_, AppState>,
+) -> Result<process_manager::ProcessState, String> {
+    let settings = settings_store::SettingsStore::new(None)
+        .read()
+        .await
+        .map_err(|e| e.to_string())?;
+    let repo_roots: Vec<String> = settings
+        .projects
+        .iter()
+        .filter_map(|p| p.repo_root.clone().or(Some(p.path.clone())))
+        .collect();
+
+    let tmux_sessions = tokio::task::spawn_blocking(process_manager::list_tmux_sessions)
+        .await
+        .unwrap_or_default();
+    let claude_processes = tokio::task::spawn_blocking(process_manager::list_claude_processes)
+        .await
+        .unwrap_or_default();
+    let worktrees = process_manager::list_all_worktrees(repo_roots).await;
+    // Silence the unused warning when nothing on this struct needs `state` —
+    // we keep it in the signature so adding card-link annotations later
+    // doesn't require a Tauri command-shape change.
+    let _ = state;
+
+    Ok(process_manager::ProcessState {
+        tmux_sessions,
+        claude_processes,
+        worktrees,
+    })
+}
+
+#[tauri::command]
+async fn kill_claude_process(pid: u32) -> Result<(), String> {
+    process_manager::kill_claude_process(pid).await
 }
 
 #[tauri::command]
@@ -1768,6 +1811,8 @@ pub fn run() {
             delete_card,
             archive_card,
             rename_card,
+            get_process_state,
+            kill_claude_process,
             get_transcript,
             get_settings,
             save_settings,

--- a/windows/src-tauri/src/process_manager.rs
+++ b/windows/src-tauri/src/process_manager.rs
@@ -120,12 +120,19 @@ pub fn list_claude_processes() -> Vec<ClaudeProcessInfo> {
 #[cfg(target_os = "windows")]
 fn windows_list_claude() -> Vec<ClaudeProcessInfo> {
     // PowerShell's CIM gives us PID + CommandLine in one shot and survives
-    // long arg strings WMIC truncates at 80 cols. The filter is loose on
-    // purpose — Claude installs land as `claude.exe`, `claude.cmd`, or
-    // `node.exe …\claude\cli.js`, and we want to surface them all.
+    // long arg strings WMIC truncates at 80 cols. The filter is intentionally
+    // narrow — claude installs land as `claude.exe`, `claude.cmd`, or
+    // `node.exe …\claude\cli.js`. We do NOT match every process whose
+    // CommandLine merely contains "claude" because that pulls in unrelated
+    // shells / editors / file managers whose argv references a `claude`
+    // username or repo name. The earlier loose filter would surface
+    // `notepad C:\Users\claude\todo.txt` and let the user kill it.
     let script = r#"
         Get-CimInstance Win32_Process |
-        Where-Object { $_.CommandLine -match 'claude' -or $_.Name -match '^claude' } |
+        Where-Object {
+            $_.Name -match '^claude(\.exe|\.cmd|\.bat)?$' -or
+            ($_.Name -match '^node(\.exe)?$' -and $_.CommandLine -match '[\\\/]claude[\\\/].*cli\.js')
+        } |
         ForEach-Object { "$($_.ProcessId)`t$($_.CommandLine)" }
     "#;
     let out = Command::new("powershell")
@@ -156,21 +163,25 @@ fn windows_list_claude() -> Vec<ClaudeProcessInfo> {
 
 #[cfg(not(target_os = "windows"))]
 fn unix_list_claude() -> Vec<ClaudeProcessInfo> {
-    let out = Command::new("ps")
-        .args(["-eo", "pid,command"])
-        .output();
+    let out = Command::new("ps").args(["-eo", "pid,command"]).output();
     let bytes = match out {
         Ok(o) if o.status.success() => o.stdout,
         _ => return vec![],
     };
     let text = String::from_utf8_lossy(&bytes);
     text.lines()
-        .filter(|l| l.contains("claude"))
         .filter_map(|line| {
             let trimmed = line.trim_start();
             let mut parts = trimmed.splitn(2, char::is_whitespace);
             let pid = parts.next()?.parse::<u32>().ok()?;
             let command = parts.next().unwrap_or("").trim().to_string();
+            // Narrow filter — the first argv token must be a Claude binary
+            // (or a node wrapper running the Claude CLI). Bare substring
+            // matching catches unrelated processes whose argv references a
+            // `claude` user / repo name.
+            if !is_claude_command_line(&command) {
+                return None;
+            }
             let session_id = extract_session_id(&command);
             Some(ClaudeProcessInfo {
                 pid,
@@ -181,14 +192,45 @@ fn unix_list_claude() -> Vec<ClaudeProcessInfo> {
         .collect()
 }
 
+#[cfg(not(target_os = "windows"))]
+fn is_claude_command_line(command: &str) -> bool {
+    let argv0 = command.split_whitespace().next().unwrap_or("");
+    // Mirror the Windows filter: claude{,.exe,.cmd} binary OR a node wrapper
+    // whose first script arg points into a claude package's cli.js.
+    let exe = std::path::Path::new(argv0)
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let exe_matches = matches!(exe.as_str(), "claude" | "claude.exe" | "claude.cmd" | "claude.bat");
+    if exe_matches {
+        return true;
+    }
+    let is_node = exe == "node" || exe == "node.exe";
+    is_node && command.contains("/claude/") && command.contains("cli.js")
+}
+
 /// Pull a Claude session id out of `--session-id <id>` or `--resume <id>`.
 /// Matches the macOS heuristic so card→process linking lines up.
+///
+/// Only treats the flag as a match when the next char is `=`, whitespace, or
+/// end-of-string. Without that guard `--session-id-2 abc` would extract the
+/// substring after `--session-id` and produce `-2` as a session id, which
+/// would then never match a real card.
 fn extract_session_id(command: &str) -> Option<String> {
     for flag in ["--session-id", "--resume"] {
-        if let Some(idx) = command.find(flag) {
+        let mut search_from = 0;
+        while let Some(rel_idx) = command[search_from..].find(flag) {
+            let idx = search_from + rel_idx;
             let after = &command[idx + flag.len()..];
+            // Require a clean boundary so `--session-id-2` and similar
+            // longer flags don't match.
+            let next_char = after.chars().next();
+            let boundary_ok = matches!(next_char, None | Some('=') | Some(' ') | Some('\t'));
+            if !boundary_ok {
+                search_from = idx + flag.len();
+                continue;
+            }
             let trimmed = after.trim_start();
-            // Accept either `--flag id` or `--flag=id`.
             let candidate: &str = if let Some(eq) = trimmed.strip_prefix('=') {
                 eq
             } else {
@@ -201,6 +243,7 @@ fn extract_session_id(command: &str) -> Option<String> {
             if !token.is_empty() {
                 return Some(token);
             }
+            search_from = idx + flag.len();
         }
     }
     None
@@ -294,5 +337,51 @@ mod tests {
     #[test]
     fn returns_none_for_no_session_flag() {
         assert_eq!(extract_session_id("claude.exe --help"), None);
+    }
+
+    #[test]
+    fn does_not_match_session_id_with_extra_suffix() {
+        // `--session-id-2 abc` must NOT extract "abc" — there's no real flag
+        // named --session-id, the prefix match is incidental.
+        assert_eq!(
+            extract_session_id("claude.exe --session-id-2 abc"),
+            None
+        );
+    }
+
+    #[test]
+    fn finds_session_id_after_a_false_prefix_match() {
+        // Mix of a fake-prefixed flag and the real one. The earlier loose
+        // implementation would have stopped at the first `--session-id`
+        // substring with `-` after it; the new boundary check skips that
+        // and reads on to find the real flag.
+        assert_eq!(
+            extract_session_id("--session-id-foo bar --session-id real-id"),
+            Some("real-id".to_string())
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn claude_command_filter_matches_direct_binaries() {
+        assert!(is_claude_command_line("/usr/local/bin/claude --foo"));
+        assert!(is_claude_command_line("claude.exe --resume abc"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn claude_command_filter_matches_node_wrapper() {
+        assert!(is_claude_command_line(
+            "/usr/bin/node /opt/lib/claude/cli.js --foo"
+        ));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn claude_command_filter_rejects_unrelated_processes() {
+        // The earlier bare-substring filter let these through.
+        assert!(!is_claude_command_line("notepad /home/claude/todo.txt"));
+        assert!(!is_claude_command_line("git log --grep \"fix claude\""));
+        assert!(!is_claude_command_line("/usr/bin/code C:\\Users\\claude"));
     }
 }

--- a/windows/src-tauri/src/process_manager.rs
+++ b/windows/src-tauri/src/process_manager.rs
@@ -1,0 +1,298 @@
+//! Snapshots of running processes the app cares about, for the
+//! Process Manager modal. Mirrors `Sources/KanbanCode/ProcessManagerView.swift`
+//! at the data layer — three lists (tmux sessions, Claude processes,
+//! worktrees) the UI surfaces side by side.
+//!
+//! Reads are best-effort. A missing tmux/WSL or a `tasklist`/`ps` that
+//! can't run returns an empty list, not an error. The caller treats
+//! "no rows" the same as "feature unavailable" — same as macOS does
+//! when `tmux` isn't on the PATH.
+
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{git_worktree, logging, tmux};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TmuxSessionInfo {
+    pub name: String,
+    /// Unix timestamp (seconds) the session was created.
+    pub created_at: i64,
+    pub attached: bool,
+    pub windows: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeProcessInfo {
+    pub pid: u32,
+    pub command: String,
+    /// Best-effort extraction of `--session-id <id>` or `--resume <id>` from
+    /// the command line. Null when we can't tell.
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeRow {
+    pub repo_root: String,
+    pub project_name: String,
+    pub path: String,
+    pub branch: Option<String>,
+    pub is_main: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessState {
+    pub tmux_sessions: Vec<TmuxSessionInfo>,
+    pub claude_processes: Vec<ClaudeProcessInfo>,
+    pub worktrees: Vec<WorktreeRow>,
+}
+
+/// Mirrors `tmux list-sessions -F '#{session_name}\t#{session_created}\t#{session_attached}\t#{session_windows}'`.
+/// Returns an empty vec when tmux isn't available (also when there are no
+/// sessions — both look the same from the UI's perspective).
+pub fn list_tmux_sessions() -> Vec<TmuxSessionInfo> {
+    if !tmux::is_available() {
+        return vec![];
+    }
+    // Build the command through tmux's helper indirectly: we shell out to
+    // `wsl tmux list-sessions …` on Windows and `tmux list-sessions …`
+    // elsewhere. Reuse the path tmux.rs uses for the rest of its commands.
+    #[cfg(target_os = "windows")]
+    let mut c = {
+        let mut x = Command::new("wsl.exe");
+        x.arg("--");
+        x.arg("tmux");
+        x
+    };
+    #[cfg(not(target_os = "windows"))]
+    let mut c = Command::new("tmux");
+
+    c.args([
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_created}\t#{session_attached}\t#{session_windows}",
+    ]);
+    let out = match c.output() {
+        Ok(o) => o,
+        Err(_) => return vec![],
+    };
+    if !out.status.success() {
+        return vec![];
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(4, '\t');
+            let name = parts.next()?.to_string();
+            let created_at = parts.next()?.parse::<i64>().ok()?;
+            let attached_raw = parts.next()?;
+            let windows = parts.next()?.parse::<i64>().unwrap_or(0);
+            Some(TmuxSessionInfo {
+                name,
+                created_at,
+                attached: attached_raw != "0",
+                windows,
+            })
+        })
+        .collect()
+}
+
+/// Find every running Claude process. On Windows uses WMIC to grab the full
+/// command line (the only reliable way to surface `--session-id` / `--resume`
+/// args alongside the PID); falls back to bare `tasklist` if WMIC is gone.
+pub fn list_claude_processes() -> Vec<ClaudeProcessInfo> {
+    #[cfg(target_os = "windows")]
+    {
+        windows_list_claude()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        unix_list_claude()
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_list_claude() -> Vec<ClaudeProcessInfo> {
+    // PowerShell's CIM gives us PID + CommandLine in one shot and survives
+    // long arg strings WMIC truncates at 80 cols. The filter is loose on
+    // purpose — Claude installs land as `claude.exe`, `claude.cmd`, or
+    // `node.exe …\claude\cli.js`, and we want to surface them all.
+    let script = r#"
+        Get-CimInstance Win32_Process |
+        Where-Object { $_.CommandLine -match 'claude' -or $_.Name -match '^claude' } |
+        ForEach-Object { "$($_.ProcessId)`t$($_.CommandLine)" }
+    "#;
+    let out = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .output();
+    let bytes = match out {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return vec![],
+    };
+    let text = String::from_utf8_lossy(&bytes);
+    text.lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let pid = parts.next()?.trim().parse::<u32>().ok()?;
+            let command = parts.next().unwrap_or("").trim().to_string();
+            if command.is_empty() {
+                return None;
+            }
+            let session_id = extract_session_id(&command);
+            Some(ClaudeProcessInfo {
+                pid,
+                command,
+                session_id,
+            })
+        })
+        .collect()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn unix_list_claude() -> Vec<ClaudeProcessInfo> {
+    let out = Command::new("ps")
+        .args(["-eo", "pid,command"])
+        .output();
+    let bytes = match out {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return vec![],
+    };
+    let text = String::from_utf8_lossy(&bytes);
+    text.lines()
+        .filter(|l| l.contains("claude"))
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let mut parts = trimmed.splitn(2, char::is_whitespace);
+            let pid = parts.next()?.parse::<u32>().ok()?;
+            let command = parts.next().unwrap_or("").trim().to_string();
+            let session_id = extract_session_id(&command);
+            Some(ClaudeProcessInfo {
+                pid,
+                command,
+                session_id,
+            })
+        })
+        .collect()
+}
+
+/// Pull a Claude session id out of `--session-id <id>` or `--resume <id>`.
+/// Matches the macOS heuristic so card→process linking lines up.
+fn extract_session_id(command: &str) -> Option<String> {
+    for flag in ["--session-id", "--resume"] {
+        if let Some(idx) = command.find(flag) {
+            let after = &command[idx + flag.len()..];
+            let trimmed = after.trim_start();
+            // Accept either `--flag id` or `--flag=id`.
+            let candidate: &str = if let Some(eq) = trimmed.strip_prefix('=') {
+                eq
+            } else {
+                trimmed
+            };
+            let token: String = candidate
+                .chars()
+                .take_while(|c| !c.is_whitespace())
+                .collect();
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Kill a Claude process by PID. `/F` so it doesn't sit on the wait list.
+pub async fn kill_claude_process(pid: u32) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        #[cfg(target_os = "windows")]
+        {
+            let out = Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/F"])
+                .output()
+                .map_err(|e| e.to_string())?;
+            if !out.status.success() {
+                return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+            }
+            logging::info("process_manager", &format!("killed claude pid={}", pid));
+            Ok(())
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let out = Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .output()
+                .map_err(|e| e.to_string())?;
+            if !out.status.success() {
+                return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+            }
+            logging::info("process_manager", &format!("killed claude pid={}", pid));
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Iterate the user's configured project paths and gather all worktrees
+/// known to git for each. `project_name` is the trailing path segment so
+/// the UI can group rows without re-walking the disk.
+pub async fn list_all_worktrees(repo_roots: Vec<String>) -> Vec<WorktreeRow> {
+    let mut rows = vec![];
+    for root in repo_roots {
+        match git_worktree::list_worktrees(&root).await {
+            Ok(wts) => {
+                let project_name = std::path::Path::new(&root)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_else(|| root.clone());
+                for w in wts {
+                    rows.push(WorktreeRow {
+                        repo_root: root.clone(),
+                        project_name: project_name.clone(),
+                        path: w.path,
+                        branch: w.branch,
+                        is_main: w.is_main,
+                    });
+                }
+            }
+            Err(e) => {
+                logging::warn(
+                    "process_manager",
+                    &format!("list_worktrees({}) failed: {}", root, e),
+                );
+            }
+        }
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_session_id_from_resume_flag() {
+        assert_eq!(
+            extract_session_id("node cli.js --resume abc-123 --foo"),
+            Some("abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_session_id_from_session_id_flag_with_equals() {
+        assert_eq!(
+            extract_session_id("claude.exe --session-id=xyz789"),
+            Some("xyz789".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_no_session_flag() {
+        assert_eq!(extract_session_id("claude.exe --help"), None);
+    }
+}

--- a/windows/src/App.tsx
+++ b/windows/src/App.tsx
@@ -5,6 +5,7 @@ import CardDetailView from "./components/CardDetailView";
 import Channels from "./components/Channels";
 import NewTaskDialog from "./components/NewTaskDialog";
 import OnboardingWizard from "./components/OnboardingWizard";
+import ProcessManagerView from "./components/ProcessManagerView";
 import ProjectSwitcher from "./components/ProjectSwitcher";
 import SearchOverlay from "./components/SearchOverlay";
 import SettingsView from "./components/SettingsView";
@@ -36,6 +37,8 @@ export default function App() {
     viewMode,
     setViewMode,
   } = useBoardStore();
+
+  const [processManagerOpen, setProcessManagerOpen] = useState(false);
 
   const channels = useChannelsStore((s) => s.channels);
   const messagesByChannel = useChannelsStore((s) => s.messagesByChannel);
@@ -140,19 +143,26 @@ export default function App() {
         setSettingsOpen(!open);
         return;
       }
+      // Ctrl+Shift+M — Process Manager modal (tmux / Claude / worktrees).
+      if (mod && e.shiftKey && (e.code === "KeyM" || keyLower === "m")) {
+        e.preventDefault();
+        setProcessManagerOpen((v) => !v);
+        return;
+      }
       if (e.key === "Escape" || e.code === "Escape") {
         // Close in stack order: dialog > settings > drawer. Each branch
         // returns so a single Esc only dismisses the topmost layer.
         const s = useBoardStore.getState();
         if (s.newTaskOpen) { setNewTaskOpen(false); return; }
         if (s.searchOpen) { setSearchOpen(false); return; }
+        if (processManagerOpen) { setProcessManagerOpen(false); return; }
         if (s.settingsOpen) { setSettingsOpen(false); return; }
         if (s.selectedCardId) { selectCard(null); return; }
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selectCard, setNewTaskOpen, setSearchOpen, setSettingsOpen]);
+  }, [selectCard, setNewTaskOpen, setSearchOpen, setSettingsOpen, processManagerOpen]);
 
   return (
     <div className="flex flex-col h-full overflow-hidden" style={{ background: c.bg, color: c.text }}>
@@ -327,6 +337,7 @@ export default function App() {
       {/* Overlays */}
       {searchOpen && <SearchOverlay />}
       {newTaskOpen && <NewTaskDialog />}
+      <ProcessManagerView open={processManagerOpen} onClose={() => setProcessManagerOpen(false)} />
 
       {/* Error toast */}
       {error && (

--- a/windows/src/components/ProcessManagerView.tsx
+++ b/windows/src/components/ProcessManagerView.tsx
@@ -1,0 +1,377 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+import { ask } from "@tauri-apps/plugin-dialog";
+import { removeWorktree, useBoardStore } from "../store/boardStore";
+import { useTheme, t } from "../theme";
+
+interface TmuxSessionInfo {
+  name: string;
+  createdAt: number;
+  attached: boolean;
+  windows: number;
+}
+
+interface ClaudeProcessInfo {
+  pid: number;
+  command: string;
+  sessionId?: string;
+}
+
+interface WorktreeRow {
+  repoRoot: string;
+  projectName: string;
+  path: string;
+  branch?: string;
+  isMain: boolean;
+}
+
+interface ProcessState {
+  tmuxSessions: TmuxSessionInfo[];
+  claudeProcesses: ClaudeProcessInfo[];
+  worktrees: WorktreeRow[];
+}
+
+type Tab = "tmux" | "claude" | "worktrees";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function ProcessManagerView({ open, onClose }: Props) {
+  const { theme } = useTheme();
+  const c = t(theme);
+  const cards = useBoardStore((s) => s.cards);
+  const selectCard = useBoardStore((s) => s.selectCard);
+
+  const [tab, setTab] = useState<Tab>("tmux");
+  const [state, setState] = useState<ProcessState>({
+    tmuxSessions: [],
+    claudeProcesses: [],
+    worktrees: [],
+  });
+  const [loading, setLoading] = useState(false);
+  const [removingPaths, setRemovingPaths] = useState<Set<string>>(new Set());
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const s = await invoke<ProcessState>("get_process_state");
+      setState(s);
+    } catch (e) {
+      useBoardStore.setState({ error: String(e) });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open]);
+
+  if (!open) return null;
+
+  // Link a tmux session name to a card when the user owns the session — same
+  // identity rule as macOS: cards stash their tmux session id (a ksuid) and
+  // the session name matches that exactly.
+  const cardForTmuxSession = (sessionName: string) =>
+    cards.find((card) => sessionName === card.id || sessionName.endsWith(card.id));
+
+  // Link a Claude process to a card via session id.
+  const cardForClaudeProcess = (proc: ClaudeProcessInfo) =>
+    proc.sessionId
+      ? cards.find((card) => card.link.sessionLink?.sessionId === proc.sessionId)
+      : undefined;
+
+  const killTmux = async (name: string) => {
+    try {
+      await invoke("tmux_kill_session", { name });
+      await refresh();
+    } catch (e) {
+      useBoardStore.setState({ error: String(e) });
+    }
+  };
+
+  const killClaude = async (pid: number) => {
+    const ok = await ask(`Kill Claude process ${pid}?`, {
+      title: "Kill process",
+      kind: "warning",
+      okLabel: "Kill",
+      cancelLabel: "Cancel",
+    });
+    if (!ok) return;
+    try {
+      await invoke("kill_claude_process", { pid });
+      await refresh();
+    } catch (e) {
+      useBoardStore.setState({ error: String(e) });
+    }
+  };
+
+  const removeWt = async (row: WorktreeRow) => {
+    if (row.isMain) return;
+    const ok = await ask(
+      `Remove worktree at ${row.path}?\n\nThe directory is deleted; the branch stays.`,
+      { title: "Remove worktree", kind: "warning", okLabel: "Remove", cancelLabel: "Cancel" }
+    );
+    if (!ok) return;
+    setRemovingPaths((prev) => new Set(prev).add(row.path));
+    try {
+      await removeWorktree(row.path, row.repoRoot, false);
+      await refresh();
+    } catch (e) {
+      useBoardStore.setState({ error: String(e) });
+    } finally {
+      setRemovingPaths((prev) => {
+        const next = new Set(prev);
+        next.delete(row.path);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: c.bgOverlay }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="rounded-2xl shadow-2xl flex flex-col animate-slide-up"
+        style={{
+          width: 720,
+          height: 540,
+          background: c.bgDialog,
+          border: `1px solid ${c.border}`,
+        }}
+        onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+      >
+        {/* Header */}
+        <div className="px-6 pt-5 pb-3 flex items-center justify-between">
+          <h2 className="text-[16px] font-semibold" style={{ color: c.textPrimary }}>
+            Process Manager
+          </h2>
+          <button
+            onClick={onClose}
+            className="transition-colors"
+            style={{ color: c.textMuted }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = c.textPrimary; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = c.textMuted; }}
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="px-6 pb-3 flex items-center gap-1">
+          {(["tmux", "claude", "worktrees"] as Tab[]).map((id) => (
+            <button
+              key={id}
+              onClick={() => setTab(id)}
+              className="px-3 py-1.5 rounded-lg text-[13px] font-medium transition-colors"
+              style={{
+                background: tab === id ? c.bgInput : "transparent",
+                color: tab === id ? c.textPrimary : c.textMuted,
+                border: `1px solid ${tab === id ? c.borderBright : "transparent"}`,
+              }}
+            >
+              {id === "tmux"
+                ? `Tmux (${state.tmuxSessions.length})`
+                : id === "claude"
+                ? `Claude (${state.claudeProcesses.length})`
+                : `Worktrees (${state.worktrees.length})`}
+            </button>
+          ))}
+          <span className="flex-1" />
+          <button
+            onClick={refresh}
+            disabled={loading}
+            className="px-3 py-1.5 rounded-lg text-[13px] transition-colors disabled:opacity-50"
+            style={{ color: c.textSecondary, border: `1px solid ${c.border}` }}
+            onMouseEnter={(e) => { if (!loading) e.currentTarget.style.background = c.hoverBg; }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = ""; }}
+            title="Refresh"
+          >
+            {loading ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 pb-4">
+          {tab === "tmux" && (
+            <TableEmpty when={state.tmuxSessions.length === 0} c={c} message="No active tmux sessions. Requires WSL + tmux installed." />
+          )}
+          {tab === "tmux" && state.tmuxSessions.map((s) => {
+            const card = cardForTmuxSession(s.name);
+            return (
+              <Row key={s.name} c={c}>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-[13px] truncate" style={{ color: c.textPrimary }}>{s.name}</span>
+                    {s.attached && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wider" style={{ background: "#3fb95018", color: "#3fb950" }}>
+                        attached
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[11px] mt-0.5" style={{ color: c.textDim }}>
+                    {s.windows} window{s.windows === 1 ? "" : "s"} · created {fmtAgo(s.createdAt * 1000)}
+                    {card && <> · <CardLink card={card} onSelect={() => { selectCard(card.id); onClose(); }} c={c} /></>}
+                  </div>
+                </div>
+                <RowAction onClick={() => killTmux(s.name)} c={c} label="Kill" danger />
+              </Row>
+            );
+          })}
+
+          {tab === "claude" && (
+            <TableEmpty when={state.claudeProcesses.length === 0} c={c} message="No Claude processes running." />
+          )}
+          {tab === "claude" && state.claudeProcesses.map((p) => {
+            const card = cardForClaudeProcess(p);
+            return (
+              <Row key={p.pid} c={c}>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-[13px]" style={{ color: c.textPrimary }}>PID {p.pid}</span>
+                    {p.sessionId && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded font-mono" style={{ background: c.bgInput, color: c.textMuted }}>
+                        {p.sessionId.slice(0, 8)}
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[11px] mt-0.5 font-mono truncate" style={{ color: c.textDim }} title={p.command}>
+                    {p.command}
+                  </div>
+                  {card && (
+                    <div className="text-[11px] mt-0.5" style={{ color: c.textDim }}>
+                      <CardLink card={card} onSelect={() => { selectCard(card.id); onClose(); }} c={c} />
+                    </div>
+                  )}
+                </div>
+                <RowAction onClick={() => killClaude(p.pid)} c={c} label="Kill" danger />
+              </Row>
+            );
+          })}
+
+          {tab === "worktrees" && (
+            <TableEmpty when={state.worktrees.length === 0} c={c} message="No worktrees found. Configure a project in Settings → Projects." />
+          )}
+          {tab === "worktrees" && state.worktrees.map((row) => (
+            <Row key={`${row.repoRoot}::${row.path}`} c={c}>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-[13px] truncate" style={{ color: c.textPrimary }}>{row.projectName}</span>
+                  {row.branch && (
+                    <span className="text-[11px] px-1.5 py-0.5 rounded" style={{ background: "#4f8ef718", color: "#4f8ef7" }}>
+                      {row.branch}
+                    </span>
+                  )}
+                  {row.isMain && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wider" style={{ background: c.bgInput, color: c.textMuted }}>
+                      main
+                    </span>
+                  )}
+                </div>
+                <div className="text-[11px] mt-0.5 font-mono truncate" style={{ color: c.textDim }} title={row.path}>
+                  {row.path}
+                </div>
+              </div>
+              {!row.isMain && (
+                <RowAction
+                  onClick={() => removeWt(row)}
+                  c={c}
+                  label={removingPaths.has(row.path) ? "Removing…" : "Remove"}
+                  danger
+                  disabled={removingPaths.has(row.path)}
+                />
+              )}
+            </Row>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ children, c }: { children: React.ReactNode; c: ReturnType<typeof t> }) {
+  return (
+    <div
+      className="flex items-center gap-3 px-3 py-2.5 rounded-lg mb-1.5"
+      style={{ border: `1px solid ${c.border}`, background: c.bgCard }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function RowAction({
+  onClick, c, label, danger, disabled,
+}: {
+  onClick: () => void;
+  c: ReturnType<typeof t>;
+  label: string;
+  danger?: boolean;
+  disabled?: boolean;
+}) {
+  const color = danger ? "#f85149" : c.textSecondary;
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="px-3 py-1.5 rounded text-[12px] font-medium transition-colors shrink-0 disabled:opacity-50"
+      style={{ color, border: `1px solid ${color}40` }}
+      onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = color + "12"; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function CardLink({
+  card,
+  onSelect,
+  c,
+}: {
+  card: { id: string; displayTitle: string };
+  onSelect: () => void;
+  c: ReturnType<typeof t>;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className="underline-offset-2 hover:underline transition-colors"
+      style={{ color: c.textSecondary }}
+      title="Open this card"
+    >
+      → {card.displayTitle}
+    </button>
+  );
+}
+
+function TableEmpty({ when, c, message }: { when: boolean; c: ReturnType<typeof t>; message: string }) {
+  if (!when) return null;
+  return (
+    <div
+      className="flex items-center justify-center py-12 rounded-lg text-[12px]"
+      style={{ color: c.textDim, border: `1px dashed ${c.border}` }}
+    >
+      {message}
+    </div>
+  );
+}
+
+function fmtAgo(ms: number): string {
+  const dt = Date.now() - ms;
+  const sec = Math.floor(dt / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}


### PR DESCRIPTION
## Summary

Phase 8 feature 2 — ports macOS \`ProcessManagerView\`. Ctrl+Shift+M opens a modal with three tabs surfacing live runtime state:

1. **Tmux** — active sessions (name, attached state, window count, created-ago) with Kill
2. **Claude** — running Claude processes (PID, command line, extracted session id) with Kill (taskkill /F)
3. **Worktrees** — every worktree git knows about across configured projects, with Remove

Cards are cross-linked: when a row's session id matches a card on the board, a "→ <card title>" link opens that card and dismisses the modal.

## Backend

- New \`process_manager.rs\`:
  - \`list_tmux_sessions\` — parses \`wsl tmux list-sessions -F …\`
  - \`list_claude_processes\` — PowerShell \`Get-CimInstance Win32_Process\` on Windows (full CommandLine), \`ps\` on Unix; extracts \`--session-id\` / \`--resume\` for card linking
  - \`kill_claude_process\` — \`taskkill /PID /F\` on Windows, \`kill -9\` elsewhere
  - \`list_all_worktrees\` — iterates \`Settings.projects\` and aggregates \`git_worktree::list_worktrees\` per repo
- Tauri commands: \`get_process_state\`, \`kill_claude_process\`. \`tmux_kill_session\` + \`remove_worktree\` reused.

## Frontend

- New \`ProcessManagerView\` modal with three tabs, refresh, per-row confirm-then-kill / confirm-then-remove
- Card→process linking by session id; clicking the card chip navigates + closes the modal
- Esc / overlay click dismisses; honors the existing close-stack

## Verify

- \`cd windows && npm run build\` — green
- \`cd windows/src-tauri && cargo build\` — green (only pre-existing warnings)
- \`cargo test process_manager\` — 3 tests pass (session id parsing)

## Test plan

- [ ] Ctrl+Shift+M opens modal; Esc closes
- [ ] With WSL+tmux: Tmux tab lists current sessions; Kill removes the session
- [ ] Without WSL+tmux: Tmux tab shows the empty-state message
- [ ] Run a Claude session → Claude tab shows PID + command line + 8-char session id badge; Kill terminates
- [ ] Configure a project → Worktrees tab lists all worktrees; main is badged "main" and has no Remove button; Remove on a feature worktree confirms then deletes
- [ ] Cards on the board with matching session id show "→ <title>" links that jump to the card

## Deliberate scope

- No bulk "Kill All Managed" button yet (macOS has one — trial the per-row UX first)
- Card↔session matching is by session id only; macOS also matches by tmux session name

🤖 Generated with [Claude Code](https://claude.com/claude-code)