### PR TITLE
feat(windows): Session History parity — transcript font + auto-load

### DIFF
--- a/windows/src-tauri/src/settings_store.rs
+++ b/windows/src-tauri/src/settings_store.rs
@@ -219,6 +219,11 @@ pub struct Settings {
     /// Terminal font size (8-24)
     #[serde(default = "default_terminal_font_size")]
     pub terminal_font_size: u32,
+    /// Font size for the History tab transcript view (8-20). Matches the
+    /// macOS `sessionDetailFontSize` AppStorage so a settings round-trip
+    /// between platforms preserves the preference.
+    #[serde(default = "default_session_detail_font_size")]
+    pub session_detail_font_size: u32,
     /// Shell command used by the embedded terminal — space-separated tokens.
     /// Defaults to `cmd.exe` for a native Windows experience. Set to
     /// `wsl.exe` (or `pwsh.exe -NoLogo`, etc.) to run Claude in a different
@@ -236,6 +241,10 @@ pub struct Settings {
 
 fn default_terminal_font_size() -> u32 {
     15
+}
+
+fn default_session_detail_font_size() -> u32 {
+    12
 }
 
 fn default_terminal_shell() -> String {

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -1653,10 +1653,12 @@ function TurnItem({ turn, searchQuery, isSearchMatch, isCurrentMatch, onCheckpoi
         ))
       ) : (
         <div className="flex gap-1.5 items-start">
-          <span className="text-[12px] leading-[1.6] shrink-0" style={{ color: isUser ? "#3fb950" : "#d4d4d4" }}>
+          {/* No hardcoded text-[Npx] \u2014 font size cascades from the History
+              scroll container so the Settings slider takes effect. */}
+          <span className="leading-[1.6] shrink-0" style={{ color: isUser ? "#3fb950" : "#d4d4d4" }}>
             {isUser ? "\u276F" : "\u25CF"}
           </span>
-          <span className="text-[12px] leading-[1.6] line-clamp-6" style={{ color: isUser ? "#e4e4e7" : "rgba(220,220,220,0.85)" }}>
+          <span className="leading-[1.6] line-clamp-6" style={{ color: isUser ? "#e4e4e7" : "rgba(220,220,220,0.85)" }}>
             <HighlightedText text={turn.textPreview || "(empty)"} query={searchQuery} />
           </span>
         </div>
@@ -1671,16 +1673,19 @@ function BlockLine({ block, isUser, isFirst, searchQuery }: {
   isFirst: boolean;
   searchQuery: string;
 }) {
+  // Every span below drops the hardcoded text-[12px] class so the History
+  // scroll container's inline fontSize cascades \u2014 that's what makes the
+  // Settings "Transcript font size" slider actually do something visible.
   if (block.kind === "text") {
     const trimmed = block.text.trim();
     if (!trimmed) return null;
     return (
       <div className="flex gap-1.5 items-start">
-        <span className="text-[12px] leading-[1.6] shrink-0" style={{ color: isUser ? "#3fb950" : "#d4d4d4" }}>
+        <span className="leading-[1.6] shrink-0" style={{ color: isUser ? "#3fb950" : "#d4d4d4" }}>
           {isFirst ? (isUser ? "\u276F" : "\u25CF") : "\u00A0\u00A0"}
         </span>
         <span
-          className="text-[12px] leading-[1.6]"
+          className="leading-[1.6]"
           style={{
             color: isUser ? "#e4e4e7" : "rgba(220,220,220,0.85)",
             display: "-webkit-box",
@@ -1700,8 +1705,8 @@ function BlockLine({ block, isUser, isFirst, searchQuery }: {
     const args = block.text.includes("(") ? block.text.slice(block.text.indexOf("(")) : "";
     return (
       <div className="flex gap-1.5 items-start">
-        <span className="text-[12px] leading-[1.6] shrink-0 text-[#3fb950]">{"\u00A0\u00A0\u25CF"}</span>
-        <span className="text-[12px] leading-[1.6]">
+        <span className="leading-[1.6] shrink-0 text-[#3fb950]">{"\u00A0\u00A0\u25CF"}</span>
+        <span className="leading-[1.6]">
           <span style={{ color: "rgba(63,185,80,0.8)" }}><HighlightedText text={name} query={searchQuery} /></span>
           {args && <span className="line-clamp-2" style={{ color: "#555" }}>{args}</span>}
         </span>
@@ -1712,8 +1717,8 @@ function BlockLine({ block, isUser, isFirst, searchQuery }: {
   if (block.kind === "tool_result") {
     return (
       <div className="flex gap-1.5 items-start">
-        <span className="text-[12px] leading-[1.6] shrink-0" style={{ color: "#444" }}>{"\u00A0\u00A0\u23BF"}</span>
-        <span className="text-[12px] leading-[1.6] line-clamp-3" style={{ color: "#444" }}>
+        <span className="leading-[1.6] shrink-0" style={{ color: "#444" }}>{"\u00A0\u00A0\u23BF"}</span>
+        <span className="leading-[1.6] line-clamp-3" style={{ color: "#444" }}>
           <HighlightedText text={block.text} query={searchQuery} />
         </span>
       </div>
@@ -1723,8 +1728,8 @@ function BlockLine({ block, isUser, isFirst, searchQuery }: {
   if (block.kind === "thinking") {
     return (
       <div className="flex gap-1.5 items-start">
-        <span className="text-[12px] leading-[1.6] shrink-0" style={{ color: "#444" }}>{"\u00A0\u00A0\u2234"}</span>
-        <span className="text-[12px] leading-[1.6] italic" style={{ color: "#444" }}>Thinking...</span>
+        <span className="leading-[1.6] shrink-0" style={{ color: "#444" }}>{"\u00A0\u00A0\u2234"}</span>
+        <span className="leading-[1.6] italic" style={{ color: "#444" }}>Thinking...</span>
       </div>
     );
   }

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -72,6 +72,7 @@ export default function CardDetailView() {
 
   // Settings
   const [terminalFontSize, setTerminalFontSize] = useState(15);
+  const [sessionDetailFontSize, setSessionDetailFontSize] = useState(12);
   const [terminalShell, setTerminalShell] = useState<string>("cmd.exe");
   // Whether `tmux -V` succeeds in the user's WSL environment. When true AND
   // the chosen shell is a Unix shell, terminals are wrapped in
@@ -142,6 +143,7 @@ export default function CardDetailView() {
     getSettings()
       .then((s) => {
         setTerminalFontSize(s.terminalFontSize || 15);
+        setSessionDetailFontSize(s.sessionDetailFontSize || 12);
         setTerminalShell((s.terminalShell && s.terminalShell.trim()) || "cmd.exe");
         setAvailableProjects(s.projects ?? []);
       })
@@ -995,6 +997,7 @@ export default function CardDetailView() {
               turns={turns}
               transcriptPage={transcriptPage}
               loading={loadingTranscript}
+              fontSize={sessionDetailFontSize}
               onLoadMore={() => {
                 if (sessionId && transcriptPage?.hasMore)
                   loadTranscript(sessionId, transcriptPage.nextOffset, false);
@@ -1426,10 +1429,11 @@ function MetaBadge({ label, color, theme, title }: { label: string; color: strin
 
 /* ── History Tab with Search ────────────────────────────────────── */
 
-function HistoryTab({ turns, transcriptPage, loading, onLoadMore, searchText, searchMatches, currentMatchIdx, isSearching, onSearchChange, onNextMatch, onPrevMatch, onCheckpoint }: {
+function HistoryTab({ turns, transcriptPage, loading, fontSize, onLoadMore, searchText, searchMatches, currentMatchIdx, isSearching, onSearchChange, onNextMatch, onPrevMatch, onCheckpoint }: {
   turns: Turn[];
   transcriptPage: TranscriptPage | null;
   loading: boolean;
+  fontSize: number;
   onLoadMore: () => void;
   searchText: string;
   searchMatches: number[];
@@ -1444,6 +1448,7 @@ function HistoryTab({ turns, transcriptPage, loading, onLoadMore, searchText, se
   const c = t(theme);
   const currentMatchTurnIdx = searchMatches.length > 0 ? searchMatches[currentMatchIdx] : -1;
   const matchRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   // Scroll to current match
   useEffect(() => {
@@ -1451,6 +1456,16 @@ function HistoryTab({ turns, transcriptPage, loading, onLoadMore, searchText, se
       matchRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [currentMatchIdx, searchMatches]);
+
+  // Auto-load earlier turns when the scroll position is near the top, matching
+  // the macOS pattern. We throttle by checking `loading` so a slow backend
+  // doesn't fire a stampede of overlapping requests.
+  const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    if (loading) return;
+    if (!transcriptPage?.hasMore) return;
+    if (el.scrollTop < 120) onLoadMore();
+  };
 
   return (
     <>
@@ -1537,9 +1552,25 @@ function HistoryTab({ turns, transcriptPage, loading, onLoadMore, searchText, se
         </div>
       ) : (
         <div
+          ref={scrollRef}
+          onScroll={onScroll}
           className="flex flex-col px-3 pt-2 pb-3 gap-0.5 font-mono overflow-y-auto flex-1"
-          style={{ background: "#141416" }}
+          style={{ background: "#141416", fontSize: `${fontSize}px` }}
         >
+          {/* Auto-load indicator when scrolled near top — replaces the macOS
+              ProgressView at top of the SessionHistoryView. */}
+          {transcriptPage?.hasMore && (
+            <div className="flex items-center justify-center py-2 text-[10px] font-mono" style={{ color: "#555" }}>
+              {loading ? (
+                <span className="flex items-center gap-2">
+                  <div className="w-3 h-3 border-2 border-[#4f8ef7] border-t-transparent rounded-full animate-spin" />
+                  Loading earlier turns…
+                </span>
+              ) : (
+                <span>{transcriptPage.totalTurns - turns.length} earlier turns — scroll up to load</span>
+              )}
+            </div>
+          )}
           {turns.map((turn) => {
             const isMatch = searchMatches.includes(turn.index);
             const isCurrent = turn.index === currentMatchTurnIdx;
@@ -1555,18 +1586,6 @@ function HistoryTab({ turns, transcriptPage, loading, onLoadMore, searchText, se
               </div>
             );
           })}
-          {transcriptPage?.hasMore && (
-            <button
-              onClick={onLoadMore}
-              disabled={loading}
-              className="mt-2 py-2 rounded-lg text-[11px] font-mono font-medium transition-all duration-150 disabled:opacity-40"
-              style={{ color: "#666", background: "rgba(255,255,255,0.03)" }}
-              onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(255,255,255,0.06)"; }}
-              onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(255,255,255,0.03)"; }}
-            >
-              {loading ? "Loading..." : `Load more (${transcriptPage.totalTurns - turns.length} remaining)`}
-            </button>
-          )}
         </div>
       )}
     </>

--- a/windows/src/components/SettingsView.tsx
+++ b/windows/src/components/SettingsView.tsx
@@ -241,6 +241,28 @@ function GeneralSection({
         </p>
       </FieldGroup>
 
+      <FieldGroup label="Transcript font size" themeTokens={c}>
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={8}
+            max={20}
+            step={1}
+            value={settings.sessionDetailFontSize || 12}
+            onChange={(e) =>
+              onChange({ ...settings, sessionDetailFontSize: parseInt(e.target.value) })
+            }
+            className="flex-1 accent-[#4f8ef7] h-1.5 rounded-full cursor-pointer"
+          />
+          <span className="text-sm font-mono w-8 text-right" style={{ color: c.textSecondary }}>
+            {settings.sessionDetailFontSize || 12}
+          </span>
+        </div>
+        <p className="text-[11px] mt-1" style={{ color: c.textMuted }}>
+          Font size for the History tab transcript view (8–20pt). Mirrors the macOS preference.
+        </p>
+      </FieldGroup>
+
       <FieldGroup label="Terminal shell" themeTokens={c}>
         <input
           type="text"

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -257,6 +257,9 @@ export interface Settings {
   hasCompletedOnboarding: boolean;
   editor: string;
   terminalFontSize: number;
+  /** Font size for the History tab transcript (8-20). Mirrors macOS
+   *  `sessionDetailFontSize` AppStorage; defaults to 12. */
+  sessionDetailFontSize?: number;
   /** Shell command for the embedded terminal — space-separated tokens. Default "cmd.exe". */
   terminalShell: string;
   remote?: RemoteSettings;


### PR DESCRIPTION
## Summary

Phase 8 feature 3 — closes the remaining gaps to macOS \`SessionHistoryView\`. Windows's CardDetailView HistoryTab already had search-with-match-nav, hover-button checkpoint, and turn rendering. The two macOS UX details we hadn't matched yet were transcript font size and auto-load-on-scroll-near-top.

## What's new

**\`sessionDetailFontSize\` setting (8–20pt, default 12)**:
- New \`Settings.session_detail_font_size\` field, byte-compatible with the macOS \`sessionDetailFontSize\` AppStorage so a settings round-trip preserves the preference.
- Slider in Settings → General, next to terminal font size.
- HistoryTab applies it via inline \`fontSize\` style so the whole transcript scales (text + code blocks + tool outputs).

**Auto-load earlier turns**:
- Replaces the manual *"Load more (N remaining)"* button with macOS's pattern: scroll within 120px of the top → \`onLoadMore\` fires.
- Throttled by the existing \`loading\` flag so a slow backend can't trigger overlapping requests.
- Footer now shows the unloaded-turn count + a spinner during the fetch — same affordance the macOS ProgressView gives.

## Verify

- \`cd windows && npm run build\` — green
- \`cd windows/src-tauri && cargo build\` — green
- \`cargo test\` — passes (no new tests; HistoryTab is UI)

## Test plan

- [ ] Settings → General now has a "Transcript font size" slider; the value persists across restart
- [ ] Open a card with a long transcript → History tab renders at the configured font size
- [ ] Scroll near the top of a long history → spinner appears + earlier turns load without clicking
- [ ] settings.json file shows \`sessionDetailFontSize\` next to \`terminalFontSize\`

## Not in scope (Windows already matches macOS)

- Search debounce + match navigation (already in Windows HistoryTab)
- Per-turn highlight of current match (already there)
- Checkpoint affordance — Windows uses a discoverable hover-button; macOS uses a mode-toggle with Cmd-held cursor. Different but functionally equivalent. Kept Windows's UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)