### PR TITLE
feat(app): board auto-selects a room's channel via a focus-channel marker

### DIFF
--- a/Sources/KanbanCode/App.swift
+++ b/Sources/KanbanCode/App.swift
@@ -188,8 +188,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUs
         }
     }
 
-    /// Check for a pending project open request from the CLI.
+    /// On activation, drain any pending CLI/gateway requests left as marker
+    /// files in ~/.kanban-code. Plain files, not deep links, so they never
+    /// relaunch the app (which would trip the quit-protection dialog).
     func applicationDidBecomeActive(_ notification: Notification) {
+        checkPendingOpenProject()
+        checkPendingFocusChannel()
+    }
+
+    /// Check for a pending project open request from the CLI.
+    private func checkPendingOpenProject() {
         let file = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".kanban-code/open-project")
         guard let path = try? String(contentsOf: file, encoding: .utf8)
@@ -199,6 +207,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUs
         NotificationCenter.default.post(
             name: .kanbanCodeOpenProject, object: nil,
             userInfo: ["path": path]
+        )
+    }
+
+    /// Check for a pending channel-focus request: select the channel the
+    /// gateway wrote to ~/.kanban-code/focus-channel when a room spawned, so
+    /// the board snaps to the room's channel without a relaunching deep link.
+    private func checkPendingFocusChannel() {
+        let file = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".kanban-code/focus-channel")
+        guard let raw = try? String(contentsOf: file, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return }
+        try? FileManager.default.removeItem(at: file)
+        let name = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
+        NotificationCenter.default.post(
+            name: .kanbanCodeSelectChannel, object: nil,
+            userInfo: ["channelName": name]
         )
     }
 


### PR DESCRIPTION
## Why

The app already selects a channel in response to a `kanbanCodeSelectChannel` notification, and already drains a `~/.kanban-code/open-project` marker file on activation to honor CLI open-project requests without a relaunching deep link (a deep link can relaunch a stale build and trip the quit-protection dialog).

A CLI/gateway that spins up a room wants the same thing for channels: snap the board to the room's channel when the app comes forward, without a deep link.

## What

`applicationDidBecomeActive` now drains a second marker, `~/.kanban-code/focus-channel`, alongside the existing open-project one. When present it reads the channel name, removes the marker, and posts `kanbanCodeSelectChannel` so the board selects it. Same plain-file, no-deep-link approach as open-project.

The existing inline open-project logic is extracted into `checkPendingOpenProject()` so activation just drains both markers.

## Notes

This is the kanban-code side of a voice-orchestrated room tool that writes the marker when it focuses the board on a freshly spawned room's channel. Harmless when no marker is present.

## Build

`swift build` clean (44s): App.swift compiles, full app links.
