### PR TITLE
feat(windows): standalone parity gaps (#126)

### DIFF
--- a/windows/src-tauri/src/card_reconciler.rs
+++ b/windows/src-tauri/src/card_reconciler.rs
@@ -271,5 +271,6 @@ fn new_discovered_link(session: &Session) -> Link {
         pinned_at: None,
         pinned_sort_order: None,
         assistant_id: "claude".to_string(),
+        last_opened_at: None,
     }
 }

--- a/windows/src-tauri/src/channels_store.rs
+++ b/windows/src-tauri/src/channels_store.rs
@@ -155,6 +155,23 @@ impl ChannelsStore {
 
     pub async fn list_channels(&self) -> Result<Vec<Channel>> { self.load_channels().await }
 
+    /// Persist a manual sidebar ordering by assigning each channel its index in
+    /// `ordered_names` as `sort_order`. Names that aren't present in the input
+    /// keep whatever `sort_order` they had. Mirrors `reorder_cards` semantics.
+    pub async fn reorder_channels(&self, ordered_names: &[String]) -> Result<()> {
+        let mut all = self.load_channels().await?;
+        let normalized: Vec<String> = ordered_names
+            .iter()
+            .map(|n| normalize_channel_name(n))
+            .collect();
+        for (idx, name) in normalized.iter().enumerate() {
+            if let Some(ch) = all.iter_mut().find(|c| &c.name == name) {
+                ch.sort_order = Some(idx as i32);
+            }
+        }
+        self.save_channels(&all).await
+    }
+
     pub async fn delete_channel(&self, name: &str) -> Result<bool> {
         let clean = normalize_channel_name(name);
         let mut all = self.load_channels().await?;
@@ -814,6 +831,47 @@ mod tests {
         let listed = store.list_channels().await.unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].name, "general");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn reorder_assigns_indices_and_persists() {
+        let base = tmp_base();
+        let store = ChannelsStore::new(Some(base.clone()));
+        store.create_channel("alpha", ChannelParticipant::user("user")).await.unwrap();
+        store.create_channel("bravo", ChannelParticipant::user("user")).await.unwrap();
+        store.create_channel("charlie", ChannelParticipant::user("user")).await.unwrap();
+        // Reverse the order. Pass with a leading # to verify normalization.
+        store
+            .reorder_channels(&[
+                "#charlie".into(),
+                "bravo".into(),
+                "alpha".into(),
+            ])
+            .await
+            .unwrap();
+        let listed = store.list_channels().await.unwrap();
+        let by_name: BTreeMap<_, _> = listed.iter().map(|c| (c.name.clone(), c.sort_order)).collect();
+        assert_eq!(by_name["charlie"], Some(0));
+        assert_eq!(by_name["bravo"], Some(1));
+        assert_eq!(by_name["alpha"], Some(2));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn reorder_leaves_unmentioned_channels_alone() {
+        let base = tmp_base();
+        let store = ChannelsStore::new(Some(base.clone()));
+        store.create_channel("a", ChannelParticipant::user("user")).await.unwrap();
+        store.create_channel("b", ChannelParticipant::user("user")).await.unwrap();
+        store.create_channel("c", ChannelParticipant::user("user")).await.unwrap();
+        // Only reorder a and b; c was never given a sort_order so it stays None.
+        store.reorder_channels(&["b".into(), "a".into()]).await.unwrap();
+        let listed = store.list_channels().await.unwrap();
+        let by_name: BTreeMap<_, _> = listed.iter().map(|c| (c.name.clone(), c.sort_order)).collect();
+        assert_eq!(by_name["b"], Some(0));
+        assert_eq!(by_name["a"], Some(1));
+        assert_eq!(by_name["c"], None);
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -152,6 +152,10 @@ pub struct Link {
     /// `assistantId`) keep working.
     #[serde(default = "default_assistant")]
     pub assistant_id: String,
+    /// Last time the user opened this card's drawer. Stamped by
+    /// `mark_card_opened` on selectCard. Mirrors macOS Link.lastOpenedAt.
+    #[serde(default)]
+    pub last_opened_at: Option<DateTime<Utc>>,
 }
 
 fn default_assistant() -> String {
@@ -235,6 +239,7 @@ impl Link {
             pinned_at: None,
             pinned_sort_order: None,
             assistant_id,
+            last_opened_at: None,
         }
     }
 
@@ -499,6 +504,7 @@ impl CoordinationStore {
             pinned_at: None,
             pinned_sort_order: None,
             assistant_id: default_assistant(),
+            last_opened_at: None,
         };
         self.upsert_link(&link).await?;
         Ok(link)
@@ -561,6 +567,17 @@ impl CoordinationStore {
         self.write_links(&links).await
     }
 
+    /// Stamp `last_opened_at = now` on the named card. Mirrors macOS
+    /// `selectCard` side effect. Intentionally does NOT bump `updated_at` so
+    /// merely opening a card doesn't push it to the top of time-based sorts.
+    pub async fn mark_card_opened(&self, card_id: &str) -> Result<()> {
+        let mut links = self.read_links().await?;
+        if let Some(link) = links.iter_mut().find(|l| l.id == card_id) {
+            link.last_opened_at = Some(Utc::now());
+        }
+        self.write_links(&links).await
+    }
+
     /// Persist a manual ordering of pinned cards by assigning each its index
     /// in `ordered_ids` as `pinned_sort_order`. Like reorder_cards, this does
     /// NOT bump `updated_at` so the sort doesn't ripple into time-based
@@ -575,5 +592,58 @@ impl CoordinationStore {
             }
         }
         self.write_links(&links).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_base() -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("kanban-coord-{}", uuid::Uuid::new_v4().simple()))
+    }
+
+    #[tokio::test]
+    async fn mark_card_opened_stamps_last_opened_at_without_bumping_updated() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        let created = store
+            .create_card(
+                "prompt".into(),
+                Some("title".into()),
+                "C:/proj".into(),
+                "claude".into(),
+                None,
+            )
+            .await
+            .unwrap();
+        // Snapshot updated_at before marking opened.
+        let before_updated = created.updated_at;
+        assert!(created.last_opened_at.is_none());
+
+        store.mark_card_opened(&created.id).await.unwrap();
+
+        let after = store.read_links().await.unwrap();
+        let link = after.iter().find(|l| l.id == created.id).unwrap();
+        assert!(
+            link.last_opened_at.is_some(),
+            "mark_card_opened should stamp last_opened_at"
+        );
+        assert_eq!(
+            link.updated_at, before_updated,
+            "mark_card_opened must not bump updated_at — sorting by activity would jitter on plain opens"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn mark_card_opened_unknown_id_is_noop() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        // No cards exist yet; mark_card_opened on a bogus id should not error.
+        store.mark_card_opened("card_does_not_exist").await.unwrap();
+        assert!(store.read_links().await.unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -101,6 +101,18 @@ async fn reorder_cards(
 }
 
 #[tauri::command]
+async fn mark_card_opened(
+    card_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state
+        .coordination_store
+        .mark_card_opened(&card_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 async fn create_card(
     prompt: String,
     title: Option<String>,
@@ -958,6 +970,18 @@ async fn rename_channel(
     state: tauri::State<'_, AppState>,
 ) -> Result<bool, String> {
     state.channels_store.rename_channel(&old, &new).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn reorder_channels(
+    ordered_names: Vec<String>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state
+        .channels_store
+        .reorder_channels(&ordered_names)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1833,6 +1857,7 @@ pub fn run() {
             get_board_state,
             move_card,
             reorder_cards,
+            mark_card_opened,
             set_card_pinned,
             reorder_pinned_cards,
             create_card,
@@ -1887,6 +1912,7 @@ pub fn run() {
             create_channel,
             delete_channel,
             rename_channel,
+            reorder_channels,
             join_channel,
             leave_channel,
             send_channel_message,

--- a/windows/src-tauri/src/merge_ops.rs
+++ b/windows/src-tauri/src/merge_ops.rs
@@ -135,6 +135,14 @@ pub fn merge_into_target(source: &Link, target: &mut Link) {
     // updated_at — bump to now
     target.updated_at = Utc::now();
 
+    // last_opened_at — max-wins so the merged card inherits the more recent
+    // user attention; a stale source shouldn't push the target backwards.
+    match (target.last_opened_at, source.last_opened_at) {
+        (None, Some(s)) => target.last_opened_at = Some(s),
+        (Some(t), Some(s)) if s > t => target.last_opened_at = Some(s),
+        _ => {}
+    }
+
     // Deliberately left alone on the target side:
     //   id, column, created_at, manual_overrides, manually_archived,
     //   source, is_launching, queued_prompts, sort_order, assistant_id
@@ -172,6 +180,7 @@ mod tests {
             pinned_at: None,
             pinned_sort_order: None,
             assistant_id: "claude".to_string(),
+            last_opened_at: None,
         }
     }
 

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -1476,6 +1476,25 @@ function HistoryTab({ turns, transcriptPage, loading, fontSize, onLoadMore, sear
   const matchRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // macOS uses Cmd-held cursor as a power-user shortcut on top of the hover
+  // button. Windows mirrors with Ctrl. Both routes — the hover button and
+  // the Ctrl+click — work; this just adds the crosshair affordance.
+  const [ctrlHeld, setCtrlHeld] = useState(false);
+  useEffect(() => {
+    if (!onCheckpoint) return;
+    const down = (e: KeyboardEvent) => { if (e.key === "Control") setCtrlHeld(true); };
+    const up = (e: KeyboardEvent) => { if (e.key === "Control") setCtrlHeld(false); };
+    const blur = () => setCtrlHeld(false);
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    window.addEventListener("blur", blur);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+      window.removeEventListener("blur", blur);
+    };
+  }, [onCheckpoint]);
+
   // Scroll to current match
   useEffect(() => {
     if (matchRef.current) {
@@ -1608,6 +1627,7 @@ function HistoryTab({ turns, transcriptPage, loading, fontSize, onLoadMore, sear
                   isSearchMatch={isMatch}
                   isCurrentMatch={isCurrent}
                   onCheckpoint={onCheckpoint}
+                  ctrlHeld={ctrlHeld}
                 />
               </div>
             );
@@ -1620,16 +1640,18 @@ function HistoryTab({ turns, transcriptPage, loading, fontSize, onLoadMore, sear
 
 /* ── Turn rendering with search highlighting ────────────────────── */
 
-function TurnItem({ turn, searchQuery, isSearchMatch, isCurrentMatch, onCheckpoint }: {
+function TurnItem({ turn, searchQuery, isSearchMatch, isCurrentMatch, onCheckpoint, ctrlHeld }: {
   turn: Turn;
   searchQuery: string;
   isSearchMatch: boolean;
   isCurrentMatch: boolean;
   onCheckpoint?: (turnIndex: number) => void | Promise<void>;
+  ctrlHeld?: boolean;
 }) {
   const isUser = turn.role === "user";
   const blocks = turn.contentBlocks;
   const [hovered, setHovered] = useState(false);
+  const ctrlClickArmed = !!onCheckpoint && !!ctrlHeld;
 
   let borderStyle: string | undefined;
   if (isCurrentMatch) borderStyle = "rgba(249,115,22,0.5)";
@@ -1647,6 +1669,7 @@ function TurnItem({ turn, searchQuery, isSearchMatch, isCurrentMatch, onCheckpoi
           ? "rgba(255,255,255,0.04)"
           : undefined,
         outline: borderStyle ? `1px solid ${borderStyle}` : undefined,
+        cursor: ctrlClickArmed ? "crosshair" : undefined,
       }}
       onMouseEnter={(e) => {
         setHovered(true);
@@ -1656,6 +1679,15 @@ function TurnItem({ turn, searchQuery, isSearchMatch, isCurrentMatch, onCheckpoi
         setHovered(false);
         if (!isCurrentMatch && !isSearchMatch) {
           e.currentTarget.style.background = isUser && blocks.some(b => b.kind === "text") ? "rgba(255,255,255,0.04)" : "";
+        }
+      }}
+      onClick={(e) => {
+        // Ctrl+click is the power-user route. The hover button still works
+        // independently — match macOS's "both routes valid" semantics.
+        if (ctrlClickArmed && (e.ctrlKey || ctrlHeld)) {
+          e.preventDefault();
+          e.stopPropagation();
+          onCheckpoint!(turn.index);
         }
       }}
     >

--- a/windows/src/components/Channels.tsx
+++ b/windows/src/components/Channels.tsx
@@ -4,6 +4,13 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openPath } from "@tauri-apps/plugin-shell";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import {
+  DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter,
+} from "@dnd-kit/core";
+import {
+  arrayMove, SortableContext, useSortable, verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
   otherPartyOfPair,
   partyDisplayName,
   useChannelsStore,
@@ -86,6 +93,7 @@ export default function Channels() {
     unreadCount,
     unreadDmCount,
     clearError,
+    reorderChannels,
   } = useChannelsStore();
   const { setChatOpen } = useBoardStore();
   const { theme } = useTheme();
@@ -163,16 +171,14 @@ export default function Channels() {
               No channels yet.
             </div>
           ) : (
-            channels.map((ch) => (
-              <ChannelRow
-                key={ch.id}
-                channel={ch}
-                selected={selectedChannel === ch.name}
-                unread={unreadCount(ch.name)}
-                onClick={() => selectChannel(ch.name)}
-                c={c}
-              />
-            ))
+            <SortableChannelList
+              channels={channels}
+              selectedChannel={selectedChannel}
+              unreadCount={unreadCount}
+              onSelect={selectChannel}
+              onReorder={reorderChannels}
+              c={c}
+            />
           )}
 
           <SidebarHeader
@@ -321,6 +327,52 @@ function SidebarHeader({
 
 // ── Sidebar rows ─────────────────────────────────────────────────────────────
 
+function SortableChannelList({
+  channels,
+  selectedChannel,
+  unreadCount,
+  onSelect,
+  onReorder,
+  c,
+}: {
+  channels: Channel[];
+  selectedChannel: string | null;
+  unreadCount: (name: string) => number;
+  onSelect: (name: string) => void;
+  onReorder: (orderedNames: string[]) => void;
+  c: ReturnType<typeof t>;
+}) {
+  // 5px distance prevents drag from intercepting plain clicks on rows.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const oldIdx = channels.findIndex((ch) => ch.name === active.id);
+    const newIdx = channels.findIndex((ch) => ch.name === over.id);
+    if (oldIdx === -1 || newIdx === -1) return;
+    const ordered = arrayMove(channels.map((ch) => ch.name), oldIdx, newIdx);
+    onReorder(ordered);
+  };
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={channels.map((ch) => ch.name)} strategy={verticalListSortingStrategy}>
+        {channels.map((ch) => (
+          <ChannelRow
+            key={ch.id}
+            channel={ch}
+            selected={selectedChannel === ch.name}
+            unread={unreadCount(ch.name)}
+            onClick={() => onSelect(ch.name)}
+            c={c}
+          />
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
 function ChannelRow({
   channel,
   selected,
@@ -334,21 +386,31 @@ function ChannelRow({
   onClick: () => void;
   c: ReturnType<typeof t>;
 }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: channel.name });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    background: selected ? c.bgCardSelected : "transparent",
+    color: selected ? c.textPrimary : unread > 0 ? c.textPrimary : c.textSecondary,
+    fontWeight: unread > 0 ? 600 : 400,
+    opacity: isDragging ? 0.5 : 1,
+    touchAction: "none",
+  };
   return (
     <button
+      ref={setNodeRef}
       onClick={onClick}
       className="w-full flex items-center justify-between px-4 py-1.5 text-[13px] transition-colors text-left"
-      style={{
-        background: selected ? c.bgCardSelected : "transparent",
-        color: selected ? c.textPrimary : unread > 0 ? c.textPrimary : c.textSecondary,
-        fontWeight: unread > 0 ? 600 : 400,
-      }}
+      style={style}
       onMouseEnter={(e) => {
         if (!selected) e.currentTarget.style.background = c.hoverBg;
       }}
       onMouseLeave={(e) => {
-        if (!selected) e.currentTarget.style.background = "transparent";
+        if (!selected) e.currentTarget.style.background = selected ? c.bgCardSelected : "transparent";
       }}
+      {...attributes}
+      {...listeners}
     >
       <span className="truncate"># {channel.name}</span>
       {unread > 0 && <UnreadBadge count={unread} />}

--- a/windows/src/components/ProcessManagerView.tsx
+++ b/windows/src/components/ProcessManagerView.tsx
@@ -92,6 +92,36 @@ export default function ProcessManagerView({ open, onClose }: Props) {
     }
   };
 
+  // "Managed" = sessions whose name matches some card's id. Mirrors macOS
+  // ProcessManagerView's "Kill All Managed (N)" button. Unmanaged tmux
+  // sessions (e.g. the user's own ad-hoc work) are left alone.
+  const managedTmuxSessions = state.tmuxSessions.filter((s) => cardForTmuxSession(s.name));
+
+  const killAllManagedTmux = async () => {
+    if (managedTmuxSessions.length === 0) return;
+    const ok = await ask(
+      `Kill ${managedTmuxSessions.length} managed tmux session${managedTmuxSessions.length === 1 ? "" : "s"}?\n\nThis ends every Claude session owned by a card. The action is irreversible.`,
+      {
+        title: "Kill All Managed",
+        kind: "warning",
+        okLabel: `Kill ${managedTmuxSessions.length}`,
+        cancelLabel: "Cancel",
+      }
+    );
+    if (!ok) return;
+    // Serial so a partial failure leaves the rest standing (and the error
+    // banner reflects which kill failed).
+    for (const s of managedTmuxSessions) {
+      try {
+        await invoke("tmux_kill_session", { name: s.name });
+      } catch (e) {
+        useBoardStore.setState({ error: String(e) });
+        break;
+      }
+    }
+    await refresh();
+  };
+
   const killClaude = async (pid: number) => {
     const ok = await ask(`Kill Claude process ${pid}?`, {
       title: "Kill process",
@@ -186,6 +216,18 @@ export default function ProcessManagerView({ open, onClose }: Props) {
             </button>
           ))}
           <span className="flex-1" />
+          {tab === "tmux" && managedTmuxSessions.length > 0 && (
+            <button
+              onClick={killAllManagedTmux}
+              className="px-3 py-1.5 rounded-lg text-[13px] transition-colors"
+              style={{ color: "#f85149", border: `1px solid #f8514940` }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "#f8514912"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+              title="Kill every tmux session owned by a card"
+            >
+              Kill All Managed ({managedTmuxSessions.length})
+            </button>
+          )}
           <button
             onClick={refresh}
             disabled={loading}

--- a/windows/src/store/boardStore.ts
+++ b/windows/src/store/boardStore.ts
@@ -105,7 +105,17 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     }
   },
 
-  selectCard: (id) => set({ selectedCardId: id }),
+  selectCard: (id) => {
+    set({ selectedCardId: id });
+    // Fire-and-forget stamp so opening a card touches `lastOpenedAt`. No
+    // refresh — the field surfaces naturally on the next board refresh and
+    // shouldn't trigger a re-render just for the click stamp.
+    if (id) {
+      invoke("mark_card_opened", { cardId: id }).catch(() => {
+        // best-effort; the stamp is non-critical
+      });
+    }
+  },
 
   moveCard: async (cardId, column) => {
     // Optimistic update

--- a/windows/src/store/channelsStore.ts
+++ b/windows/src/store/channelsStore.ts
@@ -227,6 +227,7 @@ interface ChannelsStore {
   reactDm: (pairKey: string, targetId: string, emoji: string) => Promise<void>;
   createChannel: (name: string) => Promise<Channel | null>;
   deleteChannel: (name: string) => Promise<void>;
+  reorderChannels: (orderedNames: string[]) => void;
   openDmTo: (target: string) => Promise<string | null>;
   saveDraft: (name: string, body: string) => Promise<void>;
   saveDmDraft: (pairKey: string, body: string) => Promise<void>;
@@ -567,6 +568,26 @@ export const useChannelsStore = create<ChannelsStore>((set, get) => ({
     } catch (e) {
       set({ error: String(e) });
     }
+  },
+
+  reorderChannels: (orderedNames) => {
+    // Optimistic — stamp the local order so the sidebar reflects the drag
+    // before the backend roundtrip completes.
+    set((state) => ({
+      channels: state.channels
+        .map((ch) => {
+          const idx = orderedNames.indexOf(ch.name);
+          return idx === -1 ? ch : { ...ch, sortOrder: idx };
+        })
+        .sort((a, b) => {
+          const so = (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER);
+          if (so !== 0) return so;
+          return a.createdAt.localeCompare(b.createdAt);
+        }),
+    }));
+    invoke("reorder_channels", { orderedNames }).catch((e) =>
+      set({ error: String(e) })
+    );
   },
 
   openDmTo: async (target) => {

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -119,6 +119,9 @@ export interface Link {
   /** Coding assistant that owns this card. Drives which CLI runs in the
    *  terminal. Defaults to "claude" for legacy/macOS-written cards. */
   assistantId?: AssistantId;
+  /** ISO timestamp of the last drawer open. Stamped by `mark_card_opened`
+   *  on selectCard. Mirrors macOS Link.lastOpenedAt. */
+  lastOpenedAt?: string;
 }
 
 export type AssistantId = "claude" | "gemini";

--- a/windows/tsconfig.json
+++ b/windows/tsconfig.json
@@ -18,7 +18,8 @@
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": []
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary

Closes the four standalone macOS-parity gaps from #126 — small, scope-disjoint pieces that aren't worth a PR each.

- **`Link.lastOpenedAt`** — new field with `#[serde(default)]`, added to all four Link literal construction sites (`new_card`, `create_issue_card`, `new_discovered_link`, `empty_link`). New `mark_card_opened` Tauri command stamps it from `boardStore.selectCard`. Deliberately does NOT bump `updated_at` so opening a card doesn't reshuffle time-based sorts. Merge semantics: max-wins, mirroring `last_activity`.
- **Channel reorder** — `reorder_channels(ordered_names)` on `ChannelsStore` + Tauri command + dnd-kit-sortable wrapper around the channels sidebar list. Order persists in `channels.json` via `sort_order`. Channels not in the input keep whatever `sort_order` they had.
- **Bulk "Kill All Managed (N)"** in Process Manager — appears in the tmux tab footer next to Refresh when at least one tmux session matches a card id. Confirms before killing; kills are serial so a failure leaves the rest of the fleet standing and shows which kill blew up.
- **Ctrl-held cursor affordance** in the History tab — when Ctrl is down, every TurnItem gets `cursor: crosshair` and clicks fire `onCheckpoint(turn.index)`. The existing hover button still works; this is the power-user shortcut alongside it. Ctrl-up / window blur clears the held state.

## Out-of-scope but needed for verify

`windows/tsconfig.json` gains `"types": []`. A transitive dep implicitly references `@types/node`, which isn't installed, and `npm run build` was broken on a clean checkout of `main`. Explicit opt-out is the smallest correct fix.

## Test plan

- [x] `cd windows/src-tauri && cargo build` — green
- [x] `cargo test --lib` — 83 passed (4 new: `mark_card_opened_*`, `reorder_*`)
- [x] `cd windows && npm run build` — green (was failing pre-PR; tsconfig fix above)
- [ ] Manual: click a card → `links.json` shows `lastOpenedAt` updated
- [ ] Manual: drag-reorder channels in sidebar → reload app → order persists
- [ ] Manual: Process Manager with N managed tmux sessions → "Kill All Managed (N)" appears → click → confirm → all gone
- [ ] Manual: in History tab, hold Ctrl → cursor becomes crosshair on hover → click → checkpoints same as the hover button

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)