### PR TITLE
feat(windows): APIService entity + per-card endpoint binding (#122)

### DIFF
--- a/windows/src-tauri/src/card_reconciler.rs
+++ b/windows/src-tauri/src/card_reconciler.rs
@@ -272,5 +272,6 @@ fn new_discovered_link(session: &Session) -> Link {
         pinned_sort_order: None,
         assistant_id: "claude".to_string(),
         last_opened_at: None,
+        api_service_id: None,
     }
 }

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -156,6 +156,11 @@ pub struct Link {
     /// `mark_card_opened` on selectCard. Mirrors macOS Link.lastOpenedAt.
     #[serde(default)]
     pub last_opened_at: Option<DateTime<Utc>>,
+    /// Per-card override for the resolved APIService (see Settings). `None`
+    /// falls back to `Settings.default_api_service_ids[assistant_id]`, then
+    /// to no service. Mirrors macOS Link.apiServiceId.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_service_id: Option<String>,
 }
 
 fn default_assistant() -> String {
@@ -240,6 +245,7 @@ impl Link {
             pinned_sort_order: None,
             assistant_id,
             last_opened_at: None,
+            api_service_id: None,
         }
     }
 
@@ -385,10 +391,27 @@ impl CoordinationStore {
         project: String,
         assistant_id: String,
         prompt_image_paths: Option<Vec<String>>,
+        api_service_id: Option<String>,
     ) -> Result<Link> {
-        let link = Link::new_card(prompt, title, project, assistant_id, prompt_image_paths);
+        let mut link = Link::new_card(prompt, title, project, assistant_id, prompt_image_paths);
+        link.api_service_id = api_service_id;
         self.upsert_link(&link).await?;
         Ok(link)
+    }
+
+    /// Set or clear the per-card APIService override. Passing `None` clears
+    /// the override (card falls back to the per-assistant default).
+    pub async fn set_card_api_service(
+        &self,
+        card_id: &str,
+        api_service_id: Option<String>,
+    ) -> Result<()> {
+        let mut links = self.read_links().await?;
+        if let Some(link) = links.iter_mut().find(|l| l.id == card_id) {
+            link.api_service_id = api_service_id;
+            link.updated_at = Utc::now();
+        }
+        self.write_links(&links).await
     }
 
     pub async fn remove_link(&self, card_id: &str) -> Result<()> {
@@ -505,6 +528,7 @@ impl CoordinationStore {
             pinned_sort_order: None,
             assistant_id: default_assistant(),
             last_opened_at: None,
+            api_service_id: None,
         };
         self.upsert_link(&link).await?;
         Ok(link)

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -120,6 +120,7 @@ async fn create_card(
     launch: Option<bool>,
     assistant_id: Option<String>,
     prompt_image_paths: Option<Vec<String>>,
+    api_service_id: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<coordination_store::Link, String> {
     let assistant = assistant_id
@@ -136,6 +137,7 @@ async fn create_card(
             project.clone(),
             assistant,
             prompt_image_paths,
+            api_service_id,
         )
         .await
         .map_err(|e| e.to_string())?;
@@ -145,6 +147,19 @@ async fn create_card(
     let _ = launch; // suppress unused warning
 
     Ok(link)
+}
+
+#[tauri::command]
+async fn set_card_api_service(
+    card_id: String,
+    api_service_id: Option<String>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state
+        .coordination_store
+        .set_card_api_service(&card_id, api_service_id)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Save raw image bytes (e.g. from clipboard paste) to disk under
@@ -1861,6 +1876,7 @@ pub fn run() {
             set_card_pinned,
             reorder_pinned_cards,
             create_card,
+            set_card_api_service,
             delete_card,
             archive_card,
             rename_card,

--- a/windows/src-tauri/src/merge_ops.rs
+++ b/windows/src-tauri/src/merge_ops.rs
@@ -181,6 +181,7 @@ mod tests {
             pinned_sort_order: None,
             assistant_id: "claude".to_string(),
             last_opened_at: None,
+            api_service_id: None,
         }
     }
 

--- a/windows/src-tauri/src/settings_store.rs
+++ b/windows/src-tauri/src/settings_store.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use tokio::fs;
@@ -194,6 +195,38 @@ impl Default for SelfCompactSettings {
     }
 }
 
+/// Named API service binding for a coding assistant. Wraps the CLI with an
+/// optional launcher prefix (e.g. `ollama launch`), a `--model` value, and
+/// an optional base URL that becomes `ANTHROPIC_BASE_URL` (or the assistant's
+/// equivalent) at launch time. Byte-compatible with macOS APIService.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct APIService {
+    pub id: String,
+    pub name: String,
+    /// CodingAssistant raw value ("claude", "gemini", …). Stored as a string
+    /// so an unknown id from a future macOS-built settings.json still parses.
+    pub assistant: String,
+    /// Shell command prepended before the assistant CLI. `None` = call the
+    /// CLI directly. Example: `Some("ollama launch")`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launcher_prefix: Option<String>,
+    /// Value passed to `--model`. `None` omits the flag entirely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_flag: Option<String>,
+    /// Base URL injected as an env var at launch (e.g. `ANTHROPIC_BASE_URL`).
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "baseURL")]
+    pub base_url: Option<String>,
+}
+
+impl APIService {
+    /// Whether a `--` separator is required before the assistant's own flags.
+    /// Mirrors macOS APIService.needsSeparator.
+    pub fn needs_separator(&self) -> bool {
+        self.launcher_prefix.is_some() || self.model_flag.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
@@ -237,6 +270,36 @@ pub struct Settings {
     /// and Windows keeps its rule set.
     #[serde(default)]
     pub self_compact: SelfCompactSettings,
+    /// Named API service bindings — see APIService for shape. Byte-compatible
+    /// with macOS Settings.apiServices.
+    #[serde(default)]
+    pub api_services: Vec<APIService>,
+    /// Maps `CodingAssistant.rawValue` → `APIService.id` for the per-assistant
+    /// default service. Matches macOS Settings.defaultAPIServiceIds.
+    #[serde(default)]
+    pub default_api_service_ids: HashMap<String, String>,
+}
+
+impl Settings {
+    /// Resolves the APIService to use for a card launch. Resolution order:
+    /// per-card override → per-assistant default → none. Returns `None` when
+    /// no binding exists or the referenced id no longer points at anything
+    /// (e.g. the service was deleted but a card's override is stale).
+    pub fn resolve_api_service(
+        &self,
+        card_override: Option<&str>,
+        assistant_id: &str,
+    ) -> Option<&APIService> {
+        // Per-card override wins. Stale override → fall through to default
+        // so deleting a service doesn't leave cards unlaunchable.
+        if let Some(id) = card_override {
+            if let Some(svc) = self.api_services.iter().find(|s| s.id == id) {
+                return Some(svc);
+            }
+        }
+        let default_id = self.default_api_service_ids.get(assistant_id)?;
+        self.api_services.iter().find(|s| &s.id == default_id)
+    }
 }
 
 fn default_terminal_font_size() -> u32 {
@@ -326,5 +389,95 @@ impl SettingsStore {
         fs::write(&tmp, &data).await.context("write settings tmp")?;
         fs::rename(&tmp, &self.file_path).await.context("rename settings tmp")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn svc(id: &str, assistant: &str) -> APIService {
+        APIService {
+            id: id.into(),
+            name: format!("svc-{id}"),
+            assistant: assistant.into(),
+            launcher_prefix: None,
+            model_flag: None,
+            base_url: None,
+        }
+    }
+
+    #[test]
+    fn resolve_prefers_card_override() {
+        let mut s = Settings::default();
+        s.api_services = vec![svc("a", "claude"), svc("b", "claude")];
+        s.default_api_service_ids.insert("claude".into(), "a".into());
+        let resolved = s.resolve_api_service(Some("b"), "claude").unwrap();
+        assert_eq!(resolved.id, "b");
+    }
+
+    #[test]
+    fn resolve_falls_back_to_per_assistant_default_when_no_override() {
+        let mut s = Settings::default();
+        s.api_services = vec![svc("a", "claude")];
+        s.default_api_service_ids.insert("claude".into(), "a".into());
+        let resolved = s.resolve_api_service(None, "claude").unwrap();
+        assert_eq!(resolved.id, "a");
+    }
+
+    #[test]
+    fn resolve_stale_override_falls_back_to_default_instead_of_failing() {
+        // A card holds an override pointing at a deleted service. Without the
+        // fallback the card would be unlaunchable; with it the per-assistant
+        // default takes over. Matches macOS resolveAPIService.
+        let mut s = Settings::default();
+        s.api_services = vec![svc("kept", "claude")];
+        s.default_api_service_ids.insert("claude".into(), "kept".into());
+        let resolved = s.resolve_api_service(Some("deleted"), "claude").unwrap();
+        assert_eq!(resolved.id, "kept");
+    }
+
+    #[test]
+    fn resolve_returns_none_when_no_default_and_no_override() {
+        let s = Settings::default();
+        assert!(s.resolve_api_service(None, "claude").is_none());
+    }
+
+    #[test]
+    fn settings_round_trip_preserves_api_services_and_defaults() {
+        let mut s = Settings::default();
+        s.api_services = vec![APIService {
+            id: "ollama-1".into(),
+            name: "Local Ollama".into(),
+            assistant: "claude".into(),
+            launcher_prefix: Some("ollama launch".into()),
+            model_flag: Some("qwen3-coder-next:cloud".into()),
+            base_url: Some("http://localhost:11434/v1".into()),
+        }];
+        s.default_api_service_ids.insert("claude".into(), "ollama-1".into());
+        let json = serde_json::to_string(&s).unwrap();
+        // baseURL key — explicit serde rename, mirrors macOS spelling.
+        assert!(json.contains("\"baseURL\":"));
+        let s2: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(s2.api_services.len(), 1);
+        assert_eq!(s2.api_services[0].id, "ollama-1");
+        assert_eq!(
+            s2.default_api_service_ids.get("claude"),
+            Some(&"ollama-1".to_string())
+        );
+        assert!(s2.api_services[0].needs_separator());
+    }
+
+    #[test]
+    fn needs_separator_only_when_launcher_or_model_flag_set() {
+        let bare = APIService {
+            id: "bare".into(),
+            name: "Bare".into(),
+            assistant: "claude".into(),
+            launcher_prefix: None,
+            model_flag: None,
+            base_url: Some("http://localhost".into()),
+        };
+        assert!(!bare.needs_separator(), "base_url alone never needs --");
     }
 }

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useState, useRef, useCallback } from "react";
+import { forwardRef, useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -19,7 +19,14 @@ import {
   truncateSession,
   moveCardToProject,
 } from "../store/boardStore";
-import { ASSISTANT_CLI, type Project, type AssistantId } from "../types";
+import {
+  ASSISTANT_CLI,
+  resolveAPIService,
+  apiServiceNeedsSeparator,
+  type APIService,
+  type AssistantId,
+  type Project,
+} from "../types";
 import { useTheme, t } from "../theme";
 import type { Turn, TranscriptPage, QueuedPrompt } from "../types";
 import { replaceMarkersWithMarkdown } from "../lib/promptImageLayout";
@@ -75,6 +82,11 @@ export default function CardDetailView() {
   const [terminalFontSize, setTerminalFontSize] = useState(15);
   const [sessionDetailFontSize, setSessionDetailFontSize] = useState(12);
   const [terminalShell, setTerminalShell] = useState<string>("cmd.exe");
+  // APIService bindings — captured once at mount and used to resolve the
+  // per-card endpoint at launch time. We don't refresh on every settings
+  // change to keep the resolved command stable during a live session.
+  const [apiServices, setApiServices] = useState<APIService[]>([]);
+  const [defaultAPIServiceIds, setDefaultAPIServiceIds] = useState<Record<string, string>>({});
   // Whether `tmux -V` succeeds in the user's WSL environment. When true AND
   // the chosen shell is a Unix shell, terminals are wrapped in
   // `tmux new-session -A -s <ksuid>` so closing the drawer detaches (the
@@ -147,6 +159,8 @@ export default function CardDetailView() {
         setSessionDetailFontSize(s.sessionDetailFontSize || 12);
         setTerminalShell((s.terminalShell && s.terminalShell.trim()) || "cmd.exe");
         setAvailableProjects(s.projects ?? []);
+        setApiServices(s.apiServices ?? []);
+        setDefaultAPIServiceIds(s.defaultAPIServiceIds ?? {});
       })
       .catch(() => {});
     invoke<boolean>("tmux_available")
@@ -326,6 +340,44 @@ export default function CardDetailView() {
   const assistantId: AssistantId = (card.link.assistantId ?? "claude") as AssistantId;
   const cli = ASSISTANT_CLI[assistantId] ?? "claude";
 
+  // Resolve the per-card APIService. May be undefined when nothing matches
+  // — that's the "vanilla CLI" path the app shipped with.
+  const resolvedService: APIService | undefined = useMemo(
+    () =>
+      resolveAPIService(
+        { apiServices, defaultAPIServiceIds } as never,
+        card.link.apiServiceId,
+        assistantId,
+      ),
+    [apiServices, defaultAPIServiceIds, card.link.apiServiceId, assistantId],
+  );
+
+  // Env vars + command-token wrap derived from the resolved service.
+  // baseURL → `ANTHROPIC_BASE_URL` for claude/codex (Anthropic-shaped APIs).
+  // Gemini and friends will get their own var when #124 ports them.
+  const serviceEnv: string[] = useMemo(() => {
+    if (!resolvedService?.baseURL) return [];
+    if (assistantId === "claude") return [`ANTHROPIC_BASE_URL=${resolvedService.baseURL}`];
+    // Future-proof: an unknown assistant gets the Anthropic-style var as a
+    // conservative default. Per-assistant overrides land with #124.
+    return [`ANTHROPIC_BASE_URL=${resolvedService.baseURL}`];
+  }, [resolvedService, assistantId]);
+
+  // CLI invocation, optionally wrapped by launcherPrefix and given a --model
+  // flag. The `--` separator is only emitted when the service actually needs
+  // it (see apiServiceNeedsSeparator).
+  const cliInvocation = useMemo(() => {
+    if (!resolvedService) return { exe: cli, modelFlag: "", separator: "" };
+    const exe = resolvedService.launcherPrefix
+      ? `${resolvedService.launcherPrefix} ${cli}`
+      : cli;
+    const modelFlag = resolvedService.modelFlag
+      ? ` --model ${resolvedService.modelFlag}`
+      : "";
+    const separator = apiServiceNeedsSeparator(resolvedService) ? " --" : "";
+    return { exe, modelFlag, separator };
+  }, [resolvedService, cli]);
+
   // Identity env injected into every card-launch shell so the in-card
   // `kanban` CLI can resolve who it is without --as flags. Prepended first
   // so a user-supplied entry in the launch dialog still overrides.
@@ -359,16 +411,20 @@ export default function CardDetailView() {
       const allEnv = [
         `KANBAN_CARD_ID=${cardId}`,
         `KANBAN_HANDLE=${kanbanHandle}`,
+        ...serviceEnv,
         ...env,
       ];
       const envPrefix = allEnv.join(" ") + " ";
       const cdCmd = cwd ? `cd ${cwd.replace(/ /g, "\\ ")} && ` : "";
       const skipFlag = skipPerm ? " --dangerously-skip-permissions" : "";
+      // Assistant-owned flags live after the optional `--` separator so a
+      // launcher prefix (e.g. `ollama launch`) doesn't swallow them.
+      const tail = `${cliInvocation.modelFlag}${cliInvocation.separator}${skipFlag}`;
       return sid
-        ? `${cdCmd}${envPrefix}${cli} --resume ${sid}${skipFlag}`
-        : `${cdCmd}${envPrefix}${cli}${skipFlag} '${prompt.replace(/'/g, "'\\''")}'`;
+        ? `${cdCmd}${envPrefix}${cliInvocation.exe} --resume ${sid}${tail}`
+        : `${cdCmd}${envPrefix}${cliInvocation.exe}${tail} '${prompt.replace(/'/g, "'\\''")}'`;
     },
-    [cli, cardId, kanbanHandle],
+    [cardId, kanbanHandle, serviceEnv, cliInvocation],
   );
 
   const buildInnerCmdShellCmd = useCallback(
@@ -384,16 +440,18 @@ export default function CardDetailView() {
       const allEnv = [
         `KANBAN_CARD_ID=${cardId}`,
         `KANBAN_HANDLE=${kanbanHandle}`,
+        ...serviceEnv,
         ...env,
       ];
       const envPrefix = allEnv.map((kv) => `set ${kv}&& `).join("");
       const cdCmd = cwd ? `cd "${cwd}" && ` : "";
       const skipFlag = skipPerm ? " --dangerously-skip-permissions" : "";
+      const tail = `${cliInvocation.modelFlag}${cliInvocation.separator}${skipFlag}`;
       return sid
-        ? `${cdCmd}${envPrefix}${cli} --resume ${sid}${skipFlag}`
-        : `${cdCmd}${envPrefix}${cli}${skipFlag} "${prompt.replace(/"/g, '""')}"`;
+        ? `${cdCmd}${envPrefix}${cliInvocation.exe} --resume ${sid}${tail}`
+        : `${cdCmd}${envPrefix}${cliInvocation.exe}${tail} "${prompt.replace(/"/g, '""')}"`;
     },
-    [cli, cardId, kanbanHandle],
+    [cardId, kanbanHandle, serviceEnv, cliInvocation],
   );
 
   // The inner bash command (`cd … && claude …`) — same for tmux + legacy

--- a/windows/src/components/NewTaskDialog.tsx
+++ b/windows/src/components/NewTaskDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { getSettings, saveClipboardImage, useBoardStore } from "../store/boardStore";
 import { useTheme, t } from "../theme";
-import { ASSISTANT_DISPLAY, type AssistantId } from "../types";
+import { ASSISTANT_DISPLAY, type APIService, type AssistantId } from "../types";
 import { imageMarker, removeImageAtIndex } from "../lib/promptImageLayout";
 
 export default function NewTaskDialog() {
@@ -16,6 +16,11 @@ export default function NewTaskDialog() {
   const [submitting, setSubmitting] = useState(false);
   const [settingsProjects, setSettingsProjects] = useState<string[]>([]);
   const [imagePaths, setImagePaths] = useState<string[]>([]);
+  const [apiServices, setApiServices] = useState<APIService[]>([]);
+  const [defaultAPIServiceIds, setDefaultAPIServiceIds] = useState<Record<string, string>>({});
+  // null = "use the per-assistant default"; a service id pins this card's
+  // override regardless of the default.
+  const [apiServiceId, setApiServiceId] = useState<string | null>(null);
   const promptRef = useRef<HTMLTextAreaElement>(null);
 
   const handlePromptPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -70,6 +75,8 @@ export default function NewTaskDialog() {
         if (!project && paths.length > 0) {
           setProject(paths[0]);
         }
+        setApiServices(s.apiServices ?? []);
+        setDefaultAPIServiceIds(s.defaultAPIServiceIds ?? {});
       })
       .catch(console.error);
     if (cardProjects.length > 0 && !project) {
@@ -89,6 +96,7 @@ export default function NewTaskDialog() {
         launch,
         assistantId,
         imagePaths.length > 0 ? imagePaths : undefined,
+        apiServiceId,
       );
       setNewTaskOpen(false);
       if (launch && cardId) {
@@ -256,6 +264,36 @@ export default function NewTaskDialog() {
               </p>
             )}
           </div>
+
+          {/* APIService picker — only render when at least one service exists
+              for the chosen assistant. Eligible list excludes services bound
+              to other assistants so launching never crosses streams. */}
+          {apiServices.filter((s) => s.assistant === assistantId).length > 0 && (
+            <div>
+              <label className="block text-[13px] font-medium mb-2" style={{ color: c.textSecondary }}>
+                API service
+              </label>
+              <select
+                value={apiServiceId ?? ""}
+                onChange={(e) => setApiServiceId(e.target.value || null)}
+                className="w-full rounded-lg px-3.5 py-2.5 text-[14px] outline-none transition-colors"
+                style={inputStyle}
+              >
+                <option value="">
+                  {defaultAPIServiceIds[assistantId]
+                    ? `Default — ${
+                        apiServices.find((s) => s.id === defaultAPIServiceIds[assistantId])?.name ?? "configured default"
+                      }`
+                    : "Default — bare CLI"}
+                </option>
+                {apiServices
+                  .filter((s) => s.assistant === assistantId)
+                  .map((s) => (
+                    <option key={s.id} value={s.id}>{s.name}</option>
+                  ))}
+              </select>
+            </div>
+          )}
 
           <label className="flex items-center gap-3 cursor-pointer select-none">
             <input

--- a/windows/src/components/SettingsView.tsx
+++ b/windows/src/components/SettingsView.tsx
@@ -11,7 +11,8 @@ import {
   saveSettings,
   useBoardStore,
 } from "../store/boardStore";
-import type { RemotePrereqs, RemoteSettings } from "../types";
+import type { APIService, AssistantId, RemotePrereqs, RemoteSettings } from "../types";
+import { ASSISTANT_DISPLAY } from "../types";
 import { useTheme, t } from "../theme";
 import type { Settings } from "../types";
 
@@ -32,7 +33,7 @@ export default function SettingsView() {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
-  const [activeSection, setActiveSection] = useState<"projects" | "general" | "github" | "notifications" | "remote">("general");
+  const [activeSection, setActiveSection] = useState<"projects" | "general" | "github" | "notifications" | "remote" | "apis">("general");
 
   useEffect(() => {
     getSettings().then(setSettings).catch(console.error);
@@ -63,13 +64,14 @@ export default function SettingsView() {
     );
   }
 
-  const sections = ["general", "projects", "github", "notifications", "remote"] as const;
+  const sections = ["general", "projects", "github", "notifications", "remote", "apis"] as const;
   const sectionIcons: Record<string, string> = {
     general: "M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894Z M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z",
     projects: "M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z",
     github: "M10 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M14 4h6m0 0v6m0-6L10 14",
     notifications: "M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0",
     remote: "M12 21a9 9 0 1 0-9-9m9 9a9 9 0 0 1-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9h18",
+    apis: "M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z",
   };
 
   return (
@@ -169,6 +171,9 @@ export default function SettingsView() {
           )}
           {activeSection === "remote" && (
             <RemoteSection settings={settings} onChange={setSettings} themeTokens={c} />
+          )}
+          {activeSection === "apis" && (
+            <APIsSection settings={settings} onChange={setSettings} themeTokens={c} />
           )}
         </div>
       </div>
@@ -986,5 +991,199 @@ function Code({ children, c }: { children: ReactNode; c: ThemeTokens }) {
     <code className="font-mono" style={{ color: c.textSecondary }}>
       {children}
     </code>
+  );
+}
+
+// ── APIs section ───────────────────────────────────────────────────────────
+
+function APIsSection({
+  settings,
+  onChange,
+  themeTokens: c,
+}: {
+  settings: Settings;
+  onChange: (s: Settings) => void;
+  themeTokens: ThemeTokens;
+}) {
+  const services = settings.apiServices ?? [];
+  const defaults = settings.defaultAPIServiceIds ?? {};
+  // Both Claude and Gemini are known assistant ids today; #124 adds more.
+  const assistants: AssistantId[] = ["claude", "gemini"];
+
+  const update = (next: APIService[], nextDefaults?: Record<string, string>) => {
+    onChange({
+      ...settings,
+      apiServices: next,
+      defaultAPIServiceIds: nextDefaults ?? defaults,
+    });
+  };
+
+  const addService = () => {
+    const fresh: APIService = {
+      id: `svc_${Date.now().toString(36)}`,
+      name: "New service",
+      assistant: "claude",
+    };
+    update([...services, fresh]);
+  };
+
+  const updateOne = (idx: number, patch: Partial<APIService>) => {
+    const next = services.map((s, i) => (i === idx ? { ...s, ...patch } : s));
+    update(next);
+  };
+
+  const removeOne = (idx: number) => {
+    const removed = services[idx];
+    const next = services.filter((_, i) => i !== idx);
+    // Also clear any per-assistant default that pointed at this service.
+    const cleanedDefaults = { ...defaults };
+    for (const k of Object.keys(cleanedDefaults)) {
+      if (cleanedDefaults[k] === removed.id) delete cleanedDefaults[k];
+    }
+    update(next, cleanedDefaults);
+  };
+
+  return (
+    <div className="flex flex-col gap-5 max-w-3xl">
+      <div className="text-[12px]" style={{ color: c.textMuted }}>
+        Define API services that wrap the assistant CLI with a launcher prefix,
+        model override, or a custom base URL — e.g. routing Claude through Ollama
+        or a self-hosted proxy. Per-assistant defaults are applied when a card
+        doesn't carry its own override.
+        <br />
+        <span style={{ color: c.textSecondary }}>
+          Heads-up:
+        </span>{" "}
+        API keys live in <Code c={c}>settings.json</Code> as plaintext for now —
+        same as macOS. Windows Credential Manager storage is a follow-up.
+      </div>
+
+      {/* Defaults per assistant */}
+      <div className="flex flex-col gap-3">
+        <div className="text-[11px] font-medium uppercase tracking-wider" style={{ color: c.textSecondary }}>
+          Per-assistant default
+        </div>
+        {assistants.map((a) => {
+          const eligible = services.filter((s) => s.assistant === a);
+          const value = defaults[a] ?? "";
+          return (
+            <div key={a} className="flex items-center gap-3">
+              <span className="w-32 text-[12px]" style={{ color: c.textSecondary }}>
+                {ASSISTANT_DISPLAY[a] ?? a}
+              </span>
+              <select
+                value={value}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  const nextDefaults = { ...defaults };
+                  if (v) nextDefaults[a] = v;
+                  else delete nextDefaults[a];
+                  update(services, nextDefaults);
+                }}
+                className="flex-1 rounded-lg px-2 py-1.5 text-[12px] outline-none"
+                style={inputStyle(c)}
+              >
+                <option value="">(none — use bare {a} CLI)</option>
+                {eligible.map((s) => (
+                  <option key={s.id} value={s.id}>{s.name}</option>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Service list */}
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <div className="text-[11px] font-medium uppercase tracking-wider" style={{ color: c.textSecondary }}>
+            Services
+          </div>
+          <button
+            onClick={addService}
+            className="px-2.5 py-1 rounded text-[12px] transition-colors"
+            style={{ color: c.textSecondary, border: `1px solid ${c.border}` }}
+          >
+            + Add service
+          </button>
+        </div>
+        {services.length === 0 ? (
+          <div
+            className="flex items-center justify-center py-8 rounded-lg text-[12px]"
+            style={{ color: c.textDim, border: `1px dashed ${c.border}` }}
+          >
+            No API services defined yet.
+          </div>
+        ) : (
+          services.map((svc, idx) => (
+            <div
+              key={svc.id}
+              className="rounded-xl p-3 flex flex-col gap-2"
+              style={{ background: c.bgAccent("0.02"), border: `1px solid ${c.border}` }}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={svc.name}
+                  onChange={(e) => updateOne(idx, { name: e.target.value })}
+                  placeholder="Service name"
+                  className="flex-1 rounded-lg px-2 py-1.5 text-[12px] outline-none"
+                  style={inputStyle(c)}
+                />
+                <select
+                  value={svc.assistant}
+                  onChange={(e) => updateOne(idx, { assistant: e.target.value })}
+                  className="rounded-lg px-2 py-1.5 text-[12px] outline-none"
+                  style={inputStyle(c)}
+                >
+                  {assistants.map((a) => (
+                    <option key={a} value={a}>{ASSISTANT_DISPLAY[a] ?? a}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => removeOne(idx)}
+                  className="px-2 py-1 rounded text-[12px] transition-colors shrink-0"
+                  style={{ color: "#f85149", border: "1px solid #f8514940" }}
+                >
+                  Remove
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  type="text"
+                  value={svc.launcherPrefix ?? ""}
+                  onChange={(e) =>
+                    updateOne(idx, { launcherPrefix: e.target.value || undefined })
+                  }
+                  placeholder="Launcher prefix (e.g. ollama launch)"
+                  className="rounded-lg px-2 py-1.5 text-[12px] font-mono outline-none"
+                  style={inputStyle(c)}
+                />
+                <input
+                  type="text"
+                  value={svc.modelFlag ?? ""}
+                  onChange={(e) =>
+                    updateOne(idx, { modelFlag: e.target.value || undefined })
+                  }
+                  placeholder="--model value (e.g. qwen3-coder)"
+                  className="rounded-lg px-2 py-1.5 text-[12px] font-mono outline-none"
+                  style={inputStyle(c)}
+                />
+              </div>
+              <input
+                type="text"
+                value={svc.baseURL ?? ""}
+                onChange={(e) =>
+                  updateOne(idx, { baseURL: e.target.value || undefined })
+                }
+                placeholder="Base URL (e.g. http://localhost:11434/v1)"
+                className="rounded-lg px-2 py-1.5 text-[12px] font-mono outline-none"
+                style={inputStyle(c)}
+              />
+            </div>
+          ))
+        )}
+      </div>
+    </div>
   );
 }

--- a/windows/src/store/boardStore.ts
+++ b/windows/src/store/boardStore.ts
@@ -59,7 +59,8 @@ interface BoardStore {
     project: string,
     launch?: boolean,
     assistantId?: string,
-    promptImagePaths?: string[]
+    promptImagePaths?: string[],
+    apiServiceId?: string | null,
   ) => Promise<string | null>;
   setSearchOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
@@ -241,7 +242,15 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     );
   },
 
-  createCard: async (prompt, title, project, launch = false, assistantId, promptImagePaths) => {
+  createCard: async (
+    prompt,
+    title,
+    project,
+    launch = false,
+    assistantId,
+    promptImagePaths,
+    apiServiceId,
+  ) => {
     try {
       const link = await invoke<{ id: string }>("create_card", {
         prompt,
@@ -250,6 +259,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         launch,
         assistantId: assistantId ?? null,
         promptImagePaths: promptImagePaths && promptImagePaths.length > 0 ? promptImagePaths : null,
+        apiServiceId: apiServiceId ?? null,
       });
       await get().refresh();
       return link.id;

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -122,6 +122,10 @@ export interface Link {
   /** ISO timestamp of the last drawer open. Stamped by `mark_card_opened`
    *  on selectCard. Mirrors macOS Link.lastOpenedAt. */
   lastOpenedAt?: string;
+  /** Per-card override for the resolved APIService. Falls back to
+   *  Settings.defaultAPIServiceIds[assistantId]. Mirrors macOS
+   *  Link.apiServiceId. */
+  apiServiceId?: string;
 }
 
 export type AssistantId = "claude" | "gemini";
@@ -255,6 +259,22 @@ export interface SelfCompactSettings {
   rules: SelfCompactRule[];
 }
 
+/** Byte-compatible with macOS APIService. Wraps a coding assistant CLI with
+ *  a launcher prefix, model override, and optional base URL injected as an
+ *  env var at launch time. */
+export interface APIService {
+  id: string;
+  name: string;
+  assistant: AssistantId | string;
+  /** Shell command prepended before the assistant CLI (e.g. "ollama launch"). */
+  launcherPrefix?: string;
+  /** Value passed to `--model`. Omits the flag when undefined. */
+  modelFlag?: string;
+  /** Base URL injected as `ANTHROPIC_BASE_URL` (or the assistant's
+   *  equivalent) at launch time. */
+  baseURL?: string;
+}
+
 export interface Settings {
   projects: Project[];
   globalView: GlobalViewSettings;
@@ -274,6 +294,37 @@ export interface Settings {
   remote?: RemoteSettings;
   /** Automatic context-limit guard for Claude sessions (mirrors macOS). */
   selfCompact?: SelfCompactSettings;
+  /** Named API service bindings — see APIService. */
+  apiServices?: APIService[];
+  /** Per-assistant default APIService id (assistant id → service id). */
+  defaultAPIServiceIds?: Record<string, string>;
+}
+
+/** Mirrors macOS APIService.needsSeparator — a `--` separator before the
+ *  assistant's own flags is required iff a launcher prefix or model flag is
+ *  set. */
+export function apiServiceNeedsSeparator(svc: APIService): boolean {
+  return Boolean(svc.launcherPrefix || svc.modelFlag);
+}
+
+/** Resolves an APIService for a launch. Per-card override → per-assistant
+ *  default → undefined. Mirrors the Rust `Settings::resolve_api_service`
+ *  logic; both must stay in sync. */
+export function resolveAPIService(
+  settings: Settings,
+  cardOverride: string | undefined,
+  assistantId: string,
+): APIService | undefined {
+  const services = settings.apiServices ?? [];
+  if (cardOverride) {
+    const hit = services.find((s) => s.id === cardOverride);
+    if (hit) return hit;
+    // stale override — fall through so a deleted service doesn't brick the card
+  }
+  const defaults = settings.defaultAPIServiceIds ?? {};
+  const defaultId = defaults[assistantId];
+  if (!defaultId) return undefined;
+  return services.find((s) => s.id === defaultId);
 }
 
 export interface DependencyStatus {


### PR DESCRIPTION
## Summary

Ports the macOS APIService entity so a card can target a third-party endpoint that speaks the Claude / Codex / Gemini protocol — Ollama, a self-hosted proxy, or a vendor gateway. Closes #122 and unblocks #124.

### Rust
- `APIService { id, name, assistant, launcherPrefix?, modelFlag?, baseURL? }` in `settings_store.rs`. `baseURL` keeps the macOS spelling via explicit serde rename.
- `Settings.apiServices` + `Settings.defaultAPIServiceIds` (assistant id → service id)
- `Settings::resolve_api_service(card_override, assistant_id)` — per-card override → per-assistant default → `None`. **Stale override falls through** so deleting a referenced service doesn't brick a card.
- `Link.api_service_id` added with `#[serde(default)]` at all 4 Link literal sites
- `create_card` Tauri command grows an `api_service_id` arg
- new `set_card_api_service` Tauri command for flipping the override later

### TS
- `APIService` + `Settings.apiServices` / `defaultAPIServiceIds`
- `resolveAPIService()` and `apiServiceNeedsSeparator()` helpers that mirror the Rust resolver byte-for-byte
- `Link.apiServiceId`

### UI
- **Settings → APIs** section: add/edit/remove services + per-assistant default dropdowns. Calls out the plaintext-key caveat (matches macOS; Credential Manager storage is a follow-up).
- **NewTaskDialog** gains a "Service" dropdown rendered only when at least one service exists for the chosen assistant. "Default" preserves whatever the per-assistant default is.

### CardDetailView command builder
- `baseURL` → `ANTHROPIC_BASE_URL` env var prepended to the launch (both WSL/bash and cmd.exe paths)
- `launcherPrefix` wraps the CLI exe (`ollama launch claude`)
- `modelFlag` → `--model <value>` after the CLI
- `--` separator inserted only when needed (matches macOS `needsSeparator`)

## Test plan

- [x] `cargo test --lib` — **85 passed** (6 new: resolve_*, settings_round_trip, needs_separator)
- [x] `cd windows && npm run build` — green
- [x] `cd windows/src-tauri && cargo build` — green
- [ ] Manual: define a service in Settings → restart → service + default persists
- [ ] Manual: create a card with that service → terminal shows `ANTHROPIC_BASE_URL=...` and the resolved CLI invocation
- [ ] Manual: delete the service → the card's override becomes stale → launch falls back to the per-assistant default (no broken command)

Closes #122. Foundation for #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)