### PR TITLE
feat(windows): self-compact generation loop + Claude Code statusline (#123)

### DIFF
--- a/windows/src-tauri/src/bin/kanban.rs
+++ b/windows/src-tauri/src/bin/kanban.rs
@@ -35,6 +35,11 @@ enum Command {
     Dm(DmCmd),
     /// Print the resolved caller identity (debug)
     Handle(IdentityOpts),
+    /// Claude Code statusline contract — reads the per-turn JSON from stdin,
+    /// snapshots context usage to <data_dir>/context/<sessionId>.json, and
+    /// prints a short status line to stdout. Wire it into Claude Code via
+    /// `~/.claude/settings.json` `statusLine` (or via the Settings UI).
+    Statusline,
 }
 
 #[derive(Subcommand)]
@@ -295,6 +300,7 @@ fn main() -> ExitCode {
                 println!("{}", serde_json::to_string_pretty(&p)?);
                 Ok(())
             }
+            Command::Statusline => run_statusline().await,
         }
     });
 
@@ -638,4 +644,111 @@ async fn run_dm(cmd: DmCmd, store: &ChannelsStore) -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+// ── statusline ──────────────────────────────────────────────────────────────
+
+/// Claude Code's statusline contract: stdin gets a JSON blob per turn, stdout
+/// gets a one-line status string. We treat the per-turn invocation as a
+/// `context_usage` snapshot point — parse the JSON, extract token counts +
+/// model, and write `<data_dir>/context/<session_id>.json` for the polling
+/// loop and drop-guard to read.
+///
+/// The exact stdin shape from Claude Code is documented at
+/// docs.claude.com/en/docs/claude-code/statusline. We tolerate field
+/// renames by parsing into a `serde_json::Value` and probing both
+/// snake_case (`total_input_tokens`) and camelCase variants.
+async fn run_statusline() -> anyhow::Result<()> {
+    use std::io::Read;
+
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw)?;
+    if raw.trim().is_empty() {
+        // Nothing piped in — silent no-op so manual `kanban statusline`
+        // invocations don't error.
+        return Ok(());
+    }
+    let v: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => {
+            // Don't drag Claude Code's chrome down with a parse error;
+            // just print nothing and exit clean.
+            return Ok(());
+        }
+    };
+
+    let session_id = pick_string(&v, &["session_id", "sessionId"]);
+    let Some(session_id) = session_id else {
+        return Ok(());
+    };
+
+    let used_pct = pick_f64(&v, &["used_percentage", "usedPercentage"]).unwrap_or(0.0);
+    let window = pick_i64(&v, &["context_window_size", "contextWindowSize"]).unwrap_or(0);
+    let input = pick_i64(&v, &["total_input_tokens", "totalInputTokens"]).unwrap_or(0);
+    let output = pick_i64(&v, &["total_output_tokens", "totalOutputTokens"]).unwrap_or(0);
+    let cost = pick_f64(&v, &["total_cost_usd", "totalCostUsd"]);
+    let model = pick_string(&v, &["model"]);
+
+    // Match the ContextUsage serde shape exactly so context_usage::read()
+    // can deserialize what we write here.
+    let mut out = serde_json::Map::new();
+    out.insert("usedPercentage".into(), serde_json::json!(used_pct));
+    out.insert("contextWindowSize".into(), serde_json::json!(window));
+    out.insert("totalInputTokens".into(), serde_json::json!(input));
+    out.insert("totalOutputTokens".into(), serde_json::json!(output));
+    if let Some(c) = cost { out.insert("totalCostUsd".into(), serde_json::json!(c)); }
+    if let Some(ref m) = model { out.insert("model".into(), serde_json::json!(m)); }
+
+    let dir = kanban_code_lib::coordination_store::kanban_data_dir().join("context");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{session_id}.json"));
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(&serde_json::Value::Object(out))?;
+    std::fs::write(&tmp, &bytes)?;
+    std::fs::rename(&tmp, &path)?;
+
+    // Print a short status. Claude Code surfaces this verbatim at the
+    // bottom of the terminal — keep it terse.
+    let used_tokens = if window > 0 && used_pct > 0.0 {
+        ((window as f64) * used_pct / 100.0).round() as i64
+    } else {
+        input + output
+    };
+    let used_k = used_tokens as f64 / 1000.0;
+    let model_tag = model.unwrap_or_else(|| "claude".into());
+    println!("{model_tag} · {used_k:.0}k ctx");
+    Ok(())
+}
+
+fn pick_string(v: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    for k in keys {
+        if let Some(s) = v.get(*k).and_then(|x| x.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn pick_i64(v: &serde_json::Value, keys: &[&str]) -> Option<i64> {
+    for k in keys {
+        if let Some(n) = v.get(*k).and_then(|x| x.as_i64()) {
+            return Some(n);
+        }
+        if let Some(n) = v.get(*k).and_then(|x| x.as_f64()) {
+            return Some(n.round() as i64);
+        }
+    }
+    None
+}
+
+fn pick_f64(v: &serde_json::Value, keys: &[&str]) -> Option<f64> {
+    for k in keys {
+        if let Some(n) = v.get(*k).and_then(|x| x.as_f64()) {
+            return Some(n);
+        }
+        if let Some(n) = v.get(*k).and_then(|x| x.as_i64()) {
+            return Some(n as f64);
+        }
+    }
+    None
 }

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -561,6 +561,45 @@ impl CoordinationStore {
         self.write_links(&links).await
     }
 
+    /// Enqueues a self-compact nudge with dedup. Skips the write when the
+    /// card already has an identical-threshold queued prompt (or, for older
+    /// prompts that don't carry the threshold field, an identical body).
+    /// Returns whether the prompt was actually added.
+    ///
+    /// Mirrors macOS BackgroundOrchestrator's enqueue path: queueing is
+    /// idempotent across poll ticks so a single threshold crossing produces
+    /// exactly one nudge regardless of how long the session lingers above it.
+    pub async fn enqueue_self_compact_prompt(
+        &self,
+        card_id: &str,
+        body: String,
+        threshold_tokens: i64,
+    ) -> Result<bool> {
+        let mut links = self.read_links().await?;
+        let Some(link) = links.iter_mut().find(|l| l.id == card_id) else {
+            return Ok(false);
+        };
+        let body_trim = body.trim().to_string();
+        if let Some(prompts) = &link.queued_prompts {
+            for p in prompts {
+                if p.self_compact_threshold_tokens == Some(threshold_tokens) {
+                    return Ok(false);
+                }
+                if p.self_compact_threshold_tokens.is_none() && p.body.trim() == body_trim {
+                    return Ok(false);
+                }
+            }
+        }
+        let mut prompt = QueuedPrompt::new(body, true, None);
+        prompt.self_compact_threshold_tokens = Some(threshold_tokens);
+        link.queued_prompts
+            .get_or_insert_with(Vec::new)
+            .push(prompt);
+        link.updated_at = Utc::now();
+        self.write_links(&links).await?;
+        Ok(true)
+    }
+
     /// Pin or unpin a card. Pinning stamps `pinned_at = now` and assigns a
     /// pinned_sort_order one slot above the current first-pinned (so the
     /// new pin lands at the top, matching macOS). Unpinning clears both
@@ -628,21 +667,25 @@ mod tests {
             .join(format!("kanban-coord-{}", uuid::Uuid::new_v4().simple()))
     }
 
+    async fn mk_card(store: &CoordinationStore, title: Option<&str>) -> Link {
+        store
+            .create_card(
+                "prompt".into(),
+                title.map(str::to_string),
+                "C:/proj".into(),
+                "claude".into(),
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn mark_card_opened_stamps_last_opened_at_without_bumping_updated() {
         let base = tmp_base();
         let store = CoordinationStore::new(Some(base.clone()));
-        let created = store
-            .create_card(
-                "prompt".into(),
-                Some("title".into()),
-                "C:/proj".into(),
-                "claude".into(),
-                None,
-            )
-            .await
-            .unwrap();
-        // Snapshot updated_at before marking opened.
+        let created = mk_card(&store, Some("title")).await;
         let before_updated = created.updated_at;
         assert!(created.last_opened_at.is_none());
 
@@ -665,9 +708,78 @@ mod tests {
     async fn mark_card_opened_unknown_id_is_noop() {
         let base = tmp_base();
         let store = CoordinationStore::new(Some(base.clone()));
-        // No cards exist yet; mark_card_opened on a bogus id should not error.
         store.mark_card_opened("card_does_not_exist").await.unwrap();
         assert!(store.read_links().await.unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn enqueue_self_compact_prompt_dedupes_by_threshold() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        let card = mk_card(&store, None).await;
+
+        let added1 = store
+            .enqueue_self_compact_prompt(&card.id, "compact pls".into(), 500_000)
+            .await
+            .unwrap();
+        let added2 = store
+            .enqueue_self_compact_prompt(&card.id, "compact pls — variant".into(), 500_000)
+            .await
+            .unwrap();
+        assert!(added1, "first enqueue should add");
+        assert!(!added2, "same-threshold re-enqueue should dedup");
+
+        let after = store.read_links().await.unwrap();
+        let link = after.iter().find(|l| l.id == card.id).unwrap();
+        let queue = link.queued_prompts.as_ref().expect("queue should be set");
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].self_compact_threshold_tokens, Some(500_000));
+        assert!(queue[0].send_automatically);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn enqueue_self_compact_prompt_allows_higher_threshold() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        let card = mk_card(&store, None).await;
+
+        store
+            .enqueue_self_compact_prompt(&card.id, "warn-500k".into(), 500_000)
+            .await
+            .unwrap();
+        let added2 = store
+            .enqueue_self_compact_prompt(&card.id, "warn-600k".into(), 600_000)
+            .await
+            .unwrap();
+        assert!(added2, "a higher-threshold rule must enqueue alongside the lower one");
+
+        let after = store.read_links().await.unwrap();
+        let link = after.iter().find(|l| l.id == card.id).unwrap();
+        let queue = link.queued_prompts.as_ref().unwrap();
+        assert_eq!(queue.len(), 2);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn enqueue_self_compact_prompt_dedupes_legacy_prompts_by_body() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        let card = mk_card(&store, None).await;
+
+        let mut links = store.read_links().await.unwrap();
+        let link = links.iter_mut().find(|l| l.id == card.id).unwrap();
+        let mut p = QueuedPrompt::new("/compact".into(), true, None);
+        p.self_compact_threshold_tokens = None;
+        link.queued_prompts = Some(vec![p]);
+        store.write_links(&links).await.unwrap();
+
+        let added = store
+            .enqueue_self_compact_prompt(&card.id, "/compact".into(), 750_000)
+            .await
+            .unwrap();
+        assert!(!added, "legacy body-only match must still dedup");
         let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ mod chat_bootstrap;
 mod coding_assistant;
 mod context_usage;
 pub mod crash_handler;
-mod coordination_store;
+pub mod coordination_store;
 mod gh_cli;
 mod git_remote;
 mod git_worktree;
@@ -31,6 +31,7 @@ mod session_discovery;
 mod session_mover;
 mod settings_store;
 mod shell_command;
+mod statusline_installer;
 mod tmux;
 mod transcript_reader;
 
@@ -481,6 +482,23 @@ async fn update_queued_prompt(
 /// Returns false on every uncertainty (settings unreadable, prompt not
 /// found, no statusline JSON yet) — better to deliver a benign nudge
 /// than to silently swallow a real one.
+// ── Self-compact statusline + installer ──────────────────────────────────────
+
+#[tauri::command]
+async fn install_self_compact_statusline() -> Result<(), String> {
+    statusline_installer::install().await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn uninstall_self_compact_statusline() -> Result<(), String> {
+    statusline_installer::uninstall().await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn self_compact_statusline_installed() -> Result<bool, String> {
+    Ok(statusline_installer::is_installed().await)
+}
+
 #[tauri::command]
 async fn should_drop_self_compact_prompt(
     card_id: String,
@@ -1820,6 +1838,75 @@ async fn mutagen_flush() -> Result<(), String> {
     mutagen::flush_sync().await.map_err(|e| e.to_string())
 }
 
+/// Background poll loop — sibling to start_remote_polling/start_pr_polling.
+/// Every `settings.self_compact.poll_interval_seconds` (default 30):
+///   1. Walks links.json
+///   2. For each link with a live `sessionLink.sessionId`:
+///      a. Reads `<data_dir>/context/<sessionId>.json` (written by our
+///         `kanban statusline` per-turn).
+///      b. Finds the *highest* threshold rule the session has crossed
+///         (rules are sorted descending so the most-severe one wins).
+///      c. Enqueues a QueuedPrompt with sendAutomatically=true and the
+///         threshold stamped on it. The store dedupes so a session
+///         lingering above the threshold produces exactly one nudge.
+///
+/// When the feature toggle is off, the loop is a no-op poke that just
+/// re-reads the toggle. This keeps the task structure simple — no
+/// spawn/cancel ceremony when the user flips it from Settings.
+fn start_self_compact_polling(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        // Conservative floor — pinging the disk faster than once a second
+        // is wasteful and adds disk IO during heavy session activity.
+        const MIN_INTERVAL_SECS: u64 = 1;
+        loop {
+            let app_state = app.state::<AppState>();
+            let settings = match settings_store::SettingsStore::new(None).read().await {
+                Ok(s) => s,
+                Err(_) => {
+                    tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+                    continue;
+                }
+            };
+            let sleep_secs = settings
+                .self_compact
+                .poll_interval_seconds
+                .max(MIN_INTERVAL_SECS);
+
+            if settings.self_compact.enabled {
+                let _ = run_self_compact_pass(&app_state, &settings).await;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(sleep_secs)).await;
+        }
+    });
+}
+
+async fn run_self_compact_pass(
+    app_state: &tauri::State<'_, AppState>,
+    settings: &settings_store::Settings,
+) -> Result<(), String> {
+    let links = app_state
+        .coordination_store
+        .read_links()
+        .await
+        .map_err(|e| e.to_string())?;
+    // Highest threshold first — that way the most-severe rule wins for a
+    // session that's crossed multiple at once.
+    let mut rules = settings.self_compact.rules.clone();
+    rules.sort_by_key(|r| std::cmp::Reverse(r.threshold_tokens));
+
+    for link in links.iter() {
+        let Some(session) = link.session_link.as_ref() else { continue };
+        let Some(usage) = context_usage::read(&session.session_id) else { continue };
+        let used = usage.current_context_tokens();
+        let Some(rule) = rules.iter().find(|r| used >= r.threshold_tokens) else { continue };
+        let _ = app_state
+            .coordination_store
+            .enqueue_self_compact_prompt(&link.id, rule.message.clone(), rule.threshold_tokens)
+            .await;
+    }
+    Ok(())
+}
+
 fn start_remote_polling(app: tauri::AppHandle) {
     tauri::async_runtime::spawn(async move {
         let watcher = remote_status::RemoteStatusWatcher::new();
@@ -1892,6 +1979,9 @@ pub fn run() {
             update_queued_prompt,
             remove_queued_prompt,
             should_drop_self_compact_prompt,
+            install_self_compact_statusline,
+            uninstall_self_compact_statusline,
+            self_compact_statusline_installed,
             save_clipboard_image,
             search_transcript,
             check_dependencies,
@@ -1972,6 +2062,7 @@ pub fn run() {
             start_issue_polling(app.handle().clone());
             start_hook_polling(app.handle().clone());
             start_remote_polling(app.handle().clone());
+            start_self_compact_polling(app.handle().clone());
 
             // Deploy the remote-shell wrapper at startup (idempotent).
             tauri::async_runtime::spawn(async {

--- a/windows/src-tauri/src/statusline_installer.rs
+++ b/windows/src-tauri/src/statusline_installer.rs
@@ -1,0 +1,219 @@
+//! Wires the `kanban statusline` subcommand into Claude Code's per-user
+//! settings. The producer side of the self-compact pipeline — once Claude
+//! Code is told to run our binary as its statusline, every turn snapshots
+//! context usage to `<data_dir>/context/<sessionId>.json`, which the
+//! polling loop (this module's sibling) and drop guard already consume.
+//!
+//! Claude Code reads `statusLine` from `~/.claude/settings.json`. macOS
+//! does the same. Wire format:
+//!
+//! ```json
+//! { "statusLine": { "type": "command", "command": "<path>", "padding": 0 } }
+//! ```
+//!
+//! We round-trip the rest of the settings file untouched so other fields
+//! the user has set (model, tool perms, …) are preserved.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+const STATUSLINE_KEY: &str = "statusLine";
+
+/// Path to `~/.claude/settings.json`. The home dir is resolved fresh each
+/// call so a user who reconfigures profiles mid-session still hits the
+/// right file.
+fn claude_settings_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("no home dir")?;
+    Ok(home.join(".claude").join("settings.json"))
+}
+
+/// Absolute path to the `kanban` binary we'll wire in. We resolve it from
+/// the running app's directory so dev (`cargo run`) and a packaged install
+/// both produce a runnable command.
+fn statusline_command() -> Result<String> {
+    let exe = std::env::current_exe().context("current_exe")?;
+    let dir = exe.parent().context("exe has no parent dir")?;
+    // Sibling binary in the same install dir. On Windows it's `kanban.exe`.
+    let candidate = dir.join(if cfg!(target_os = "windows") { "kanban.exe" } else { "kanban" });
+    if !candidate.exists() {
+        // Fallback: trust PATH. Better a usable plain-name command than a
+        // broken absolute path that just happens to point at the dev dir.
+        return Ok("kanban statusline".to_string());
+    }
+    let quoted = quote_path_for_shell(&candidate);
+    Ok(format!("{quoted} statusline"))
+}
+
+/// Wraps `path` in double quotes when it contains a space — Claude Code
+/// passes the string straight to its shell, so unquoted spaces split args.
+fn quote_path_for_shell(path: &Path) -> String {
+    let s = path.to_string_lossy().to_string();
+    if s.contains(' ') {
+        format!("\"{}\"", s)
+    } else {
+        s
+    }
+}
+
+/// Reads the existing settings, leaves everything alone, and overwrites the
+/// `statusLine` key with our binding. Creates the file (and parent dir) if
+/// missing. Idempotent — re-install with no change to disk after the first.
+pub async fn install() -> Result<()> {
+    install_at(&claude_settings_path()?, &statusline_command()?).await
+}
+
+/// Removes only the `statusLine` key. Other settings are preserved. No-op
+/// when the file or key doesn't exist.
+pub async fn uninstall() -> Result<()> {
+    uninstall_at(&claude_settings_path()?).await
+}
+
+/// True iff `statusLine.command` currently points at our `kanban statusline`
+/// invocation. A false reading just means the user is on the bare CLI — not
+/// an error.
+pub async fn is_installed() -> bool {
+    let Ok(path) = claude_settings_path() else { return false };
+    let Ok(bytes) = fs::read(&path).await else { return false };
+    let Ok(v) = serde_json::from_slice::<Value>(&bytes) else { return false };
+    matches_our_command(&v)
+}
+
+fn matches_our_command(v: &Value) -> bool {
+    let Some(cmd) = v.get(STATUSLINE_KEY).and_then(|s| s.get("command")).and_then(|c| c.as_str()) else {
+        return false;
+    };
+    cmd.contains("kanban") && cmd.contains("statusline")
+}
+
+async fn install_at(path: &Path, command: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await.context("create ~/.claude dir")?;
+    }
+    let mut root = read_json(path).await?.unwrap_or_else(|| Value::Object(Default::default()));
+    let Some(obj) = root.as_object_mut() else {
+        // settings.json existed but wasn't an object — bail rather than
+        // clobber it, so a hand-edited oddball doesn't get nuked silently.
+        anyhow::bail!("~/.claude/settings.json is not a JSON object");
+    };
+    obj.insert(
+        STATUSLINE_KEY.into(),
+        serde_json::json!({
+            "type": "command",
+            "command": command,
+            "padding": 0,
+        }),
+    );
+    write_atomic(path, &root).await
+}
+
+async fn uninstall_at(path: &Path) -> Result<()> {
+    let Some(mut root) = read_json(path).await? else { return Ok(()) };
+    let Some(obj) = root.as_object_mut() else { return Ok(()) };
+    if obj.remove(STATUSLINE_KEY).is_none() {
+        return Ok(());
+    }
+    write_atomic(path, &root).await
+}
+
+async fn read_json(path: &Path) -> Result<Option<Value>> {
+    match fs::read(path).await {
+        Ok(bytes) => {
+            if bytes.iter().all(u8::is_ascii_whitespace) {
+                return Ok(None);
+            }
+            Ok(Some(serde_json::from_slice(&bytes).context("parse settings.json")?))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).context("read settings.json"),
+    }
+}
+
+async fn write_atomic(path: &Path, v: &Value) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(v).context("serialize settings")?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, &bytes).await.context("write tmp")?;
+    fs::rename(&tmp, path).await.context("rename tmp")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> PathBuf {
+        std::env::temp_dir().join(format!("kanban-statusline-{}", uuid::Uuid::new_v4().simple()))
+    }
+
+    #[tokio::test]
+    async fn install_creates_file_and_writes_command() {
+        let dir = tmp();
+        let path = dir.join("settings.json");
+        install_at(&path, "kanban statusline").await.unwrap();
+        let read: Value = serde_json::from_slice(&fs::read(&path).await.unwrap()).unwrap();
+        assert_eq!(read["statusLine"]["command"], "kanban statusline");
+        assert_eq!(read["statusLine"]["type"], "command");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn install_preserves_unrelated_keys() {
+        let dir = tmp();
+        let path = dir.join("settings.json");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            &path,
+            br#"{"model":"opus-4-7","permissions":{"allow":["Read"]}}"#,
+        )
+        .unwrap();
+        install_at(&path, "kanban statusline").await.unwrap();
+        let read: Value = serde_json::from_slice(&fs::read(&path).await.unwrap()).unwrap();
+        assert_eq!(read["model"], "opus-4-7");
+        assert_eq!(read["permissions"]["allow"][0], "Read");
+        assert_eq!(read["statusLine"]["command"], "kanban statusline");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn uninstall_removes_only_the_status_line_key() {
+        let dir = tmp();
+        let path = dir.join("settings.json");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            &path,
+            br#"{"model":"opus","statusLine":{"type":"command","command":"x"}}"#,
+        )
+        .unwrap();
+        uninstall_at(&path).await.unwrap();
+        let read: Value = serde_json::from_slice(&fs::read(&path).await.unwrap()).unwrap();
+        assert_eq!(read["model"], "opus");
+        assert!(read.get("statusLine").is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn uninstall_missing_file_is_a_no_op() {
+        let dir = tmp();
+        let path = dir.join("settings.json");
+        // No file exists yet.
+        uninstall_at(&path).await.unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn matches_only_when_command_mentions_kanban_and_statusline() {
+        let yes: Value = serde_json::from_str(
+            r#"{"statusLine":{"type":"command","command":"\"C:/x/kanban.exe\" statusline"}}"#,
+        )
+        .unwrap();
+        assert!(matches_our_command(&yes));
+        let no: Value = serde_json::from_str(
+            r#"{"statusLine":{"type":"command","command":"some-other-tool"}}"#,
+        )
+        .unwrap();
+        assert!(!matches_our_command(&no));
+        let missing: Value = serde_json::from_str("{}").unwrap();
+        assert!(!matches_our_command(&missing));
+    }
+}

--- a/windows/src/components/SettingsView.tsx
+++ b/windows/src/components/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import {
   discoverProjects,
@@ -318,6 +319,36 @@ function SelfCompactBlock({
     pollIntervalSeconds: 30,
     rules: [],
   };
+
+  // Statusline-install state. We probe on mount and after every
+  // install/uninstall click so the button label reflects what
+  // Claude Code's settings actually say.
+  const [statuslineInstalled, setStatuslineInstalled] = useState<boolean | null>(null);
+  const [statuslineBusy, setStatuslineBusy] = useState(false);
+
+  useEffect(() => {
+    invoke<boolean>("self_compact_statusline_installed")
+      .then(setStatuslineInstalled)
+      .catch(() => setStatuslineInstalled(null));
+  }, []);
+
+  const flipStatusline = async () => {
+    setStatuslineBusy(true);
+    try {
+      if (statuslineInstalled) {
+        await invoke("uninstall_self_compact_statusline");
+      } else {
+        await invoke("install_self_compact_statusline");
+      }
+      const next = await invoke<boolean>("self_compact_statusline_installed");
+      setStatuslineInstalled(next);
+    } catch (e) {
+      useBoardStore.setState({ error: String(e) });
+    } finally {
+      setStatuslineBusy(false);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-3">
       <Toggle
@@ -329,9 +360,41 @@ function SelfCompactBlock({
           })
         }
         label="Auto self-compact guard"
-        description="Drop stale compact nudges from the queue once context usage drops below the threshold (compaction worked). Polling/generation is not yet wired on Windows; thresholds will be honored once it lands."
+        description="Polls each session's context usage and enqueues a nudge when it crosses a configured threshold. Stale nudges are dropped after the model compacts. Install the statusline below so Claude Code feeds it usage data."
         themeTokens={c}
       />
+      <div
+        className="rounded-lg px-3 py-2.5 text-[12px] flex items-center justify-between gap-3"
+        style={{ background: c.bgInput, border: `1px solid ${c.border}` }}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="font-semibold" style={{ color: c.textSecondary }}>
+            Claude Code statusline
+          </div>
+          <div className="text-[11px] mt-0.5" style={{ color: c.textDim }}>
+            {statuslineInstalled === null
+              ? "Checking installation…"
+              : statuslineInstalled
+              ? "Installed in ~/.claude/settings.json. Each turn snapshots context usage for the poller."
+              : "Not installed. Without this, the guard has no data to act on."}
+          </div>
+        </div>
+        <button
+          onClick={flipStatusline}
+          disabled={statuslineBusy || statuslineInstalled === null}
+          className="px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors shrink-0 disabled:opacity-50"
+          style={{
+            color: statuslineInstalled ? "#f85149" : "#4f8ef7",
+            border: `1px solid ${statuslineInstalled ? "#f8514940" : "#4f8ef740"}`,
+          }}
+        >
+          {statuslineBusy
+            ? "…"
+            : statuslineInstalled
+            ? "Uninstall"
+            : "Install statusline"}
+        </button>
+      </div>
       {sc.enabled && sc.rules.length > 0 && (
         <div
           className="rounded-lg px-3 py-2 text-[12px]"


### PR DESCRIPTION
## Summary

Closes #123 — the producer half of the self-compact pipeline.

Phase 4 (#117) ported the consumer (`SelfCompactSettings`, `QueuedPrompt.selfCompactThresholdTokens`, `should_drop_self_compact_prompt`) but nothing was *writing* the context-usage JSON. This wires in both:

1. **`kanban statusline` subcommand** — reads the per-turn JSON Claude Code pipes on stdin, snapshots context tokens + model to `<data_dir>/context/<sessionId>.json` (matching `ContextUsage`'s serde shape exactly), then prints a short status line.
2. **`start_self_compact_polling` background task** — sibling to the existing remote/pr pollers. Every `self_compact.pollIntervalSeconds` (default 30, floored at 1) it walks `links.json` and for each session with statusline data crossing a threshold, enqueues a `QueuedPrompt` with `sendAutomatically=true` and the threshold stamped on it. The existing auto-send path delivers; the existing drop guard handles staleness after compaction.

The store-level dedup is the key correctness piece: a session lingering above threshold produces exactly one nudge per crossing.

## Installer

`statusline_installer.rs` writes the binding into `~/.claude/settings.json`'s `statusLine` key:

```json
{ "statusLine": { "type": "command", "command": "\"C:/.../kanban.exe\" statusline", "padding": 0 } }
```

Unrelated keys (model, permissions, …) are preserved. Install/uninstall are idempotent.

UI: Settings → General → Self-compact gains an Install/Uninstall Statusline button. State is probed on mount and re-read after each click.

## Test plan

- [x] `cargo test --lib` — **87 passed** (8 new: enqueue_self_compact_*, install_*, uninstall_*, matches_only_when_command_*)
- [x] `cargo build` — green
- [x] `cd windows && npm run build` — green
- [ ] Manual: Settings → Install statusline → check `~/.claude/settings.json` shows `statusLine.command` pointing at `kanban.exe statusline`
- [ ] Manual: run a Claude session → `%APPDATA%\kanban-code\context\<sessionId>.json` populates with each turn
- [ ] Manual: cross the configured 500k threshold → a queued nudge appears in the card's queue panel; verifies again after a compaction lowers usage that the drop guard from Phase 4 removes the stale nudge.

Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)