### PR TITLE
fix(windows): wrap pinnedCards Zustand selector in useShallow

### DIFF
--- a/windows/src/components/BoardView.tsx
+++ b/windows/src/components/BoardView.tsx
@@ -5,6 +5,7 @@ import {
 } from "@dnd-kit/core";
 import { arrayMove, SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { canMergeCards, mergeCards, useBoardStore } from "../store/boardStore";
 import { COLUMNS, type CardDto, type KanbanColumn } from "../types";
 import { useTheme, t } from "../theme";
@@ -21,7 +22,11 @@ const dropAnimation: DropAnimation = {
 
 export default function BoardView() {
   const { moveCard, reorderCards, reorderPinnedCards, isLoading, cards, setNewTaskOpen, refresh, setMergeTargetId } = useBoardStore();
-  const pinnedCards = useBoardStore((s) => s.pinnedCards());
+  // useShallow keeps the selector's new-array-per-call shape from triggering
+  // an infinite loop under Zustand v5's stricter useSyncExternalStore snapshot
+  // contract. Array element identity is preserved across renders (cards are
+  // memoized in the store), so a shallow compare is all React needs.
+  const pinnedCards = useBoardStore(useShallow((s) => s.pinnedCards()));
   const [draggingCard, setDraggingCard] = useState<CardDto | null>(null);
   const { theme } = useTheme();
   const c = t(theme);


### PR DESCRIPTION
## Symptom

App starts but the window is blank. DevTools shows:

\`\`\`
Warning: The result of getSnapshot should be cached to avoid an infinite loop
  at BoardView (BoardView.tsx:43:119)
→ Error: Maximum update depth exceeded.
\`\`\`

React unmounts the entire tree → nothing renders.

## Cause

\`\`\`ts
// BoardView.tsx:24 — before
const pinnedCards = useBoardStore((s) => s.pinnedCards());
\`\`\`

\`pinnedCards()\` is a computed helper that returns a freshly \`.filter().sort()\`-ed array on every call. Zustand v5 wraps React's \`useSyncExternalStore\`, which treats a new array reference as a state change → re-render → selector runs again → new array → **infinite loop**.

Latent since the Zustand v5 bump (\`^5.0.4\`). Surfaced consistently in current main; probably required a particular pinned-card state shape to trigger reliably before.

## Fix

\`\`\`ts
// after
import { useShallow } from "zustand/react/shallow";
const pinnedCards = useBoardStore(useShallow((s) => s.pinnedCards()));
\`\`\`

\`useShallow\` does a shallow-equality compare on the returned array, so a new reference with the same card elements doesn't trigger a re-render. Canonical Zustand v5 pattern for selectors returning derived collections.

## Test plan

- [x] \`npm run build\` — green
- [x] Window now renders the board instead of blank — confirmed via WebView2 + browser repro
- [ ] Manual: open card with pinned items, verify Pinned section renders without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)