### PR TITLE
feat(windows): per-card runtime gate + in-terminal history + auto-resume

### DIFF
--- a/windows/src-tauri/src/card_reconciler.rs
+++ b/windows/src-tauri/src/card_reconciler.rs
@@ -274,5 +274,6 @@ fn new_discovered_link(session: &Session) -> Link {
         last_opened_at: None,
         api_service_id: None,
         browser_tabs: None,
+        card_runtime: None,
     }
 }

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use tokio::fs;
 
 use crate::ksuid;
+use crate::settings_store::CardRuntime;
 
 // ── Queued Prompt ────────────────────────────────────────────────────────────
 
@@ -189,6 +190,12 @@ pub struct Link {
     /// files. Mirrors macOS Link.browserTabs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub browser_tabs: Option<Vec<BrowserTabInfo>>,
+    /// Which shell this card's embedded terminal launches into. `None` means
+    /// the user hasn't picked yet — the gate panel shows Windows/WSL buttons
+    /// and persists the choice here on click. No global default; each card
+    /// asks once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub card_runtime: Option<CardRuntime>,
 }
 
 fn default_assistant() -> String {
@@ -275,6 +282,7 @@ impl Link {
             last_opened_at: None,
             api_service_id: None,
             browser_tabs: None,
+            card_runtime: None,
         }
     }
 
@@ -443,6 +451,19 @@ impl CoordinationStore {
         self.write_links(&links).await
     }
 
+    pub async fn set_card_runtime(
+        &self,
+        card_id: &str,
+        runtime: Option<CardRuntime>,
+    ) -> Result<()> {
+        let mut links = self.read_links().await?;
+        if let Some(link) = links.iter_mut().find(|l| l.id == card_id) {
+            link.card_runtime = runtime;
+            link.updated_at = Utc::now();
+        }
+        self.write_links(&links).await
+    }
+
     pub async fn remove_link(&self, card_id: &str) -> Result<()> {
         let mut links = self.read_links().await?;
         links.retain(|l| l.id != card_id);
@@ -559,6 +580,7 @@ impl CoordinationStore {
             last_opened_at: None,
             api_service_id: None,
             browser_tabs: None,
+            card_runtime: None,
         };
         self.upsert_link(&link).await?;
         Ok(link)
@@ -1080,8 +1102,10 @@ mod tests {
             last_opened_at: None,
             api_service_id: None,
             browser_tabs: None,
+            card_runtime: None,
         };
         let json = serde_json::to_string(&link).unwrap();
         assert!(!json.contains("browserTabs"), "absent tab list must not write the key");
+        assert!(!json.contains("cardRuntime"), "unpicked runtime must not write the key");
     }
 }

--- a/windows/src-tauri/src/hook_manager.rs
+++ b/windows/src-tauri/src/hook_manager.rs
@@ -8,10 +8,14 @@
 //! `/mnt/c/...` mount), so the Rust tail can read directly without UNC paths.
 //!
 //! Skip-conditions (idempotent):
-//!   * `terminalShell` doesn't include "wsl" → tracked TODO, no install.
 //!   * `wsl.exe -- bash -lc "true"` fails → WSL not set up, log + skip.
 //!   * `~/.kanban-code/hook.sh` already present AND `settings.json` already
 //!     references it → no-op (re-runs are safe).
+//!
+//! Card runtime is per-card now (`Link.card_runtime`), so we can't gate on a
+//! global setting. We install unconditionally when WSL is reachable: the
+//! script + settings.json edits are idempotent, and any future WSL card will
+//! get hook events without a second app launch.
 
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -19,7 +23,6 @@ use std::io::Write;
 
 use crate::coordination_store::kanban_data_dir;
 use crate::logging;
-use crate::settings_store::SettingsStore;
 use crate::tmux::windows_path_to_wsl;
 
 const HOOK_EVENTS: &[&str] = &[
@@ -31,19 +34,10 @@ const HOOK_EVENTS: &[&str] = &[
 ];
 
 /// Top-level entry: install (or refresh) the WSL-side hook script + settings.
-/// Reads the user's current `terminalShell` to decide whether to install at
-/// all. Returns `Ok(false)` when intentionally skipped (e.g. non-wsl shell).
-pub async fn install_if_needed(settings_store: &SettingsStore) -> Result<bool, String> {
-    let settings = settings_store.read().await.map_err(|e| e.to_string())?;
-    let shell = settings.terminal_shell.to_lowercase();
-    if !shell.contains("wsl") {
-        logging::info(
-            "hooks",
-            "skipping install — Settings.terminalShell is not wsl; native cmd.exe/pwsh hooks tracked as TODO",
-        );
-        return Ok(false);
-    }
-
+/// Idempotent — safe to call on every app launch. Skips silently when WSL
+/// isn't reachable (e.g. the user only has Windows cards). Returns
+/// `Ok(false)` when WSL is missing.
+pub async fn install_if_needed() -> Result<bool, String> {
     if !wsl_ok() {
         logging::warn(
             "hooks",

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -167,6 +167,19 @@ async fn set_card_api_service(
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+async fn set_card_runtime(
+    card_id: String,
+    runtime: Option<settings_store::CardRuntime>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state
+        .coordination_store
+        .set_card_runtime(&card_id, runtime)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Save raw image bytes (e.g. from clipboard paste) to disk under
 /// `<data_dir>/images/`. Returns the absolute path the frontend should
 /// stash into Link.promptImagePaths / QueuedPrompt.imagePaths.
@@ -1896,15 +1909,13 @@ fn build_tray(app: &tauri::App) -> tauri::Result<()> {
 fn start_hook_polling(app: tauri::AppHandle) {
     tauri::async_runtime::spawn(async move {
         // Install asynchronously so a slow WSL boot doesn't block startup.
-        let state = app.state::<AppState>();
-        match hook_manager::install_if_needed(&state.settings_store).await {
+        match hook_manager::install_if_needed().await {
             Ok(true) => {}
             Ok(false) => return, // intentionally skipped — no tail loop
             Err(e) => {
                 logging::warn("hooks", &format!("install failed: {} — tail loop will still run", e));
             }
         }
-        drop(state);
 
         let store = std::sync::Arc::new(hook_event_store::HookEventStore::new());
         store.touch();
@@ -2137,6 +2148,7 @@ pub fn run() {
             update_browser_tab,
             create_card,
             set_card_api_service,
+            set_card_runtime,
             delete_card,
             archive_card,
             rename_card,

--- a/windows/src-tauri/src/merge_ops.rs
+++ b/windows/src-tauri/src/merge_ops.rs
@@ -185,6 +185,7 @@ mod tests {
             last_opened_at: None,
             api_service_id: None,
             browser_tabs: None,
+            card_runtime: None,
         }
     }
 

--- a/windows/src-tauri/src/settings_store.rs
+++ b/windows/src-tauri/src/settings_store.rs
@@ -257,12 +257,6 @@ pub struct Settings {
     /// between platforms preserves the preference.
     #[serde(default = "default_session_detail_font_size")]
     pub session_detail_font_size: u32,
-    /// Shell command used by the embedded terminal — space-separated tokens.
-    /// Defaults to `cmd.exe` for a native Windows experience. Set to
-    /// `wsl.exe` (or `pwsh.exe -NoLogo`, etc.) to run Claude in a different
-    /// shell. The first token is the executable; remaining tokens are args.
-    #[serde(default = "default_terminal_shell")]
-    pub terminal_shell: String,
     #[serde(default)]
     pub remote: Option<RemoteSettings>,
     /// Automatic context-limit guard for Claude sessions. Byte-compatible
@@ -310,15 +304,16 @@ fn default_session_detail_font_size() -> u32 {
     12
 }
 
-fn default_terminal_shell() -> String {
-    #[cfg(target_os = "windows")]
-    {
-        "cmd.exe".to_string()
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        "bash".to_string()
-    }
+/// Which terminal runtime a card launches into. Picked per card on the gate
+/// panel — there is no global default. Lives on `Link.card_runtime`; this
+/// enum is shared so both `Link` and any future Settings code can refer to
+/// the same canonical type. Serialized as the lowercase variant name so the
+/// JSON values match the TS string union (`"windows"` / `"wsl"`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CardRuntime {
+    Windows,
+    Wsl,
 }
 
 fn default_issue_template() -> String {
@@ -327,12 +322,10 @@ fn default_issue_template() -> String {
 
 /// First time the settings file is read on this process, peek at the raw JSON
 /// to see whether it came from the macOS app. macOS doesn't write the
-/// Windows-only keys (`terminalShell`, `terminalFontSize`, `editor`); when
+/// Windows-only keys (`terminalFontSize`, `editor`, `cardRuntime`); when
 /// they're absent serde's `#[serde(default)]` silently backfills the Windows
-/// defaults. We use `terminalShell` alone as the sentinel — adding more keys
-/// to the AND would just create false negatives if a Windows user explicitly
-/// cleared one. A new Windows-only field does NOT need to be added to the
-/// check; just keep this comment up to date.
+/// defaults. We use `terminalFontSize` alone as the sentinel — `cardRuntime`
+/// has no default so its absence isn't macOS-specific.
 ///
 /// No `schema_version` field is added — that would break the macOS byte-compat
 /// invariant (sortedKeys+prettyPrinted JSON shared with the Swift app).
@@ -346,11 +339,11 @@ fn log_cross_platform_backfill_once(raw: &[u8]) {
         Some(o) => o,
         None => return,
     };
-    if !obj.contains_key("terminalShell") {
+    if !obj.contains_key("terminalFontSize") {
         let _ = LOGGED.set(());
         crate::logging::info(
             "settings",
-            "settings.json missing terminalShell/terminalFontSize — backfilling Windows defaults (file appears to originate from macOS)",
+            "settings.json missing terminalFontSize — backfilling Windows defaults (file appears to originate from macOS)",
         );
     }
 }

--- a/windows/src-tauri/src/tmux.rs
+++ b/windows/src-tauri/src/tmux.rs
@@ -11,9 +11,9 @@
 //!   * multi-window per session (one window per drawer tab)
 //!
 //! Gating: the caller is responsible for checking
-//! `Settings.terminal_shell.contains("wsl")` before invoking these commands.
-//! When the user has chosen native `cmd.exe` / `pwsh.exe`, tmux is unavailable
-//! and the legacy one-shot PTY remains in effect (tracked TODO: PTY-pool).
+//! `Settings.card_runtime == Some(CardRuntime::Wsl)` before invoking these
+//! commands. When the user has chosen native Windows, tmux is unavailable and
+//! the legacy one-shot PTY remains in effect (tracked TODO: PTY-pool).
 //!
 //! All commands run synchronously — tmux operations are quick and serializing
 //! them avoids the lock-step ordering problems seen on macOS when paste and

--- a/windows/src/components/CardDetailView.tsx
+++ b/windows/src/components/CardDetailView.tsx
@@ -32,6 +32,7 @@ import {
   apiServiceNeedsSeparator,
   type APIService,
   type AssistantId,
+  type CardRuntime,
   type Project,
 } from "../types";
 import { useTheme, t } from "../theme";
@@ -64,6 +65,42 @@ function slugifyHandle(title: string): string {
   return slug || "card";
 }
 
+// Render the prior session transcript as ANSI-coloured text so it can be
+// pre-written into the xterm scrollback. The live PTY's first prompt lands
+// right under this seed — scrolling up inside the terminal then surfaces
+// real session history, no separate overlay. xterm needs CRLF, not LF.
+function formatTranscriptScrollback(turns: Turn[]): string {
+  if (!turns.length) return "";
+  const RESET = "\x1b[0m";
+  const DIM = "\x1b[2m";
+  const USER = "\x1b[36m";
+  const ASSIST = "\x1b[35m";
+  const out: string[] = [];
+  const normalize = (s: string) => s.replace(/\r\n|\r|\n/g, "\r\n");
+  for (const t of turns) {
+    const ts = t.timestamp ? new Date(t.timestamp).toLocaleString() : "";
+    const tag = t.role === "user" ? `${USER}▶ user${RESET}` : `${ASSIST}◀ assistant${RESET}`;
+    out.push(`${tag}${ts ? ` ${DIM}· ${ts}${RESET}` : ""}`);
+    for (const block of t.contentBlocks) {
+      if (block.kind === "text") {
+        out.push(normalize(block.text));
+      } else if (block.kind === "thinking") {
+        const slice = block.text.length > 240 ? block.text.slice(0, 240) + "…" : block.text;
+        out.push(`${DIM}[thinking] ${normalize(slice)}${RESET}`);
+      } else if (block.kind === "tool_use") {
+        out.push(`${DIM}⚙ ${normalize(block.text)}${RESET}`);
+      } else if (block.kind === "tool_result") {
+        const slice = block.text.length > 400 ? block.text.slice(0, 400) + "…" : block.text;
+        out.push(`${DIM}↳ ${normalize(slice)}${RESET}`);
+      }
+    }
+    out.push("");
+  }
+  out.push(`${DIM}── session resumes below ──${RESET}`);
+  out.push("");
+  return out.join("\r\n");
+}
+
 export default function CardDetailView() {
   const { selectedCard, selectCard, renameCard, deleteCard } = useBoardStore();
   const card = selectedCard();
@@ -89,7 +126,6 @@ export default function CardDetailView() {
   // Settings
   const [terminalFontSize, setTerminalFontSize] = useState(15);
   const [sessionDetailFontSize, setSessionDetailFontSize] = useState(12);
-  const [terminalShell, setTerminalShell] = useState<string>("cmd.exe");
   // APIService bindings — captured once at mount and used to resolve the
   // per-card endpoint at launch time. We don't refresh on every settings
   // change to keep the resolved command stable during a live session.
@@ -165,7 +201,6 @@ export default function CardDetailView() {
       .then((s) => {
         setTerminalFontSize(s.terminalFontSize || 15);
         setSessionDetailFontSize(s.sessionDetailFontSize || 12);
-        setTerminalShell((s.terminalShell && s.terminalShell.trim()) || "cmd.exe");
         setAvailableProjects(s.projects ?? []);
         setApiServices(s.apiServices ?? []);
         setDefaultAPIServiceIds(s.defaultAPIServiceIds ?? {});
@@ -176,10 +211,17 @@ export default function CardDetailView() {
       .catch(() => setTmuxAvailable(false));
   }, []);
 
-  // Reset state when card changes
+  // Reset state when card changes. For cards with both a session AND a
+  // picked runtime, this also auto-resumes the terminal — load all
+  // transcript pages, then flip `terminalActive` true so the drawer drops
+  // straight into the live session. The runtime gate panel handles the
+  // no-runtime case; fresh launches (promptBody only) still go through
+  // LaunchConfirmationDialog.
   useEffect(() => {
     if (!card) return;
-    const hasTerminal = !!card.link.sessionLink?.sessionId || !!card.link.promptBody;
+    const sid = card.link.sessionLink?.sessionId;
+    const runtime = card.link.cardRuntime;
+    const hasTerminal = !!sid || !!card.link.promptBody;
     setActiveTab(hasTerminal ? "terminal" : "history");
     setTurns([]);
     setTranscriptPage(null);
@@ -188,10 +230,50 @@ export default function CardDetailView() {
     setSearchText("");
     setSearchMatches([]);
     setCurrentMatchIdx(0);
-    if (card.link.sessionLink?.sessionId) {
-      loadTranscript(card.link.sessionLink.sessionId, 0, true);
-    }
+
+    if (!sid) return;
+
+    let cancelled = false;
+    (async () => {
+      setLoadingTranscript(true);
+      const collected: Turn[] = [];
+      let lastPage: TranscriptPage | null = null;
+      try {
+        let offset = 0;
+        // Walk the full transcript so the scrollback seed below carries
+        // every prior turn, not just page 1. Local file reads — fast.
+        while (true) {
+          const page = await getTranscript(sid, offset);
+          if (cancelled) return;
+          collected.push(...page.turns);
+          lastPage = page;
+          if (!page.hasMore) break;
+          offset = page.nextOffset;
+        }
+      } catch {
+        // silent — terminal still launches, just without seeded scrollback
+      } finally {
+        if (!cancelled) setLoadingTranscript(false);
+      }
+      if (cancelled) return;
+      setTurns(collected);
+      setTranscriptPage(lastPage);
+      // Auto-resume: with a runtime already picked, jump straight in. No
+      // Resume click required. TerminalView reads the formatted scrollback
+      // from props at mount time, so `turns` must be set first.
+      if (runtime) setTerminalActive(true);
+    })();
+
+    return () => { cancelled = true; };
   }, [card?.id]);
+
+  // If the user picks a runtime from the gate panel after the drawer is
+  // already open, kick the terminal on without making them click Resume.
+  useEffect(() => {
+    if (card?.link.sessionLink?.sessionId && card?.link.cardRuntime && !terminalActive) {
+      setTerminalActive(true);
+    }
+  }, [card?.link.cardRuntime]);
 
   // Sync queued prompts when card data updates
   useEffect(() => {
@@ -250,6 +332,20 @@ export default function CardDetailView() {
   const issue = card.link.issueLink;
   const promptBody = card.link.promptBody;
   const canTerminal = !!sessionId || !!promptBody;
+  const cardRuntime = card.link.cardRuntime ?? null;
+
+  // Persist a runtime pick to the card's Link. The gate panel buttons call
+  // this; the choice survives drawer close / app restart because it lives
+  // in links.json. We trigger a board refresh so the local card data
+  // reflects the new runtime without remount.
+  const pickCardRuntime = async (runtime: CardRuntime) => {
+    try {
+      await invoke("set_card_runtime", { cardId: card.id, runtime });
+      await useBoardStore.getState().refresh();
+    } catch (e) {
+      useBoardStore.setState({ error: String(e) });
+    }
+  };
 
   const handleRename = () => {
     if (editName.trim()) renameCard(card.id, editName.trim());
@@ -336,14 +432,12 @@ export default function CardDetailView() {
     }
   };
 
-  // Split the user-configurable shell string into [exe, ...args]. Default is
-  // cmd.exe so the app is Windows-native out of the box; setting it to
-  // "wsl.exe" launches Claude inside WSL instead.
-  const baseShell = terminalShell.trim().split(/\s+/).filter(Boolean);
-  const shellExe = (baseShell[0] ?? "cmd.exe").toLowerCase();
-  const isUnixShell = /(^|[\\/])(wsl|bash|sh|zsh|fish)(\.exe)?$/.test(shellExe);
-  // tmux requires a Unix shell AND a working `tmux -V` inside it.
-  const useTmux = isUnixShell && tmuxAvailable;
+  // Picked once per install via Settings → Card runtime. While `null`, the
+  // terminal tab below renders a "Pick Windows or WSL in Settings" notice
+  // instead of spawning a shell.
+  const isWsl = cardRuntime === "wsl";
+  // tmux requires WSL AND a working `tmux -V` inside it.
+  const useTmux = isWsl && tmuxAvailable;
 
   const assistantId: AssistantId = (card.link.assistantId ?? "claude") as AssistantId;
   const cli = ASSISTANT_CLI[assistantId] ?? "claude";
@@ -512,13 +606,13 @@ export default function CardDetailView() {
         terminalInput: "",
       };
     }
-    if (isUnixShell) {
-      // bash without tmux — fall back to type-after-spawn so non-tmux WSL
-      // users still get a working terminal (just no reattach).
-      return { shellCommand: baseShell, terminalInput: `${innerBashCmd}\r` };
+    if (isWsl) {
+      // WSL without tmux — type-after-spawn so users still get a working
+      // terminal (just no reattach across drawer close/reopen).
+      return { shellCommand: ["wsl.exe"], terminalInput: `${innerBashCmd}\r` };
     }
-    // Native Windows shell.
-    return { shellCommand: baseShell, terminalInput: `${innerCmdShellCmd}\r` };
+    // Native Windows.
+    return { shellCommand: ["cmd.exe"], terminalInput: `${innerCmdShellCmd}\r` };
   })();
 
   // Pull the current window list whenever the terminal becomes active in
@@ -674,6 +768,12 @@ export default function CardDetailView() {
   };
 
   const handleStartTerminal = () => {
+    // No runtime picked — flip to the terminal tab so the gate panel becomes
+    // visible and asks Windows-or-WSL inline. No bounce to Settings.
+    if (!cardRuntime) {
+      setActiveTab("terminal");
+      return;
+    }
     // Resumes — no choices to make, jump straight in.
     if (sessionId) {
       setTerminalActive(true);
@@ -687,12 +787,14 @@ export default function CardDetailView() {
 
   // Auto-open the launch dialog for freshly created tasks so the user sees
   // the command preview before Claude starts churning. They can cancel out.
+  // Gated on cardRuntime — without a chosen runtime the dialog's preview
+  // would be wrong, so the gate panel below handles the prompt instead.
   useEffect(() => {
-    if (!sessionId && promptBody && !terminalActive && !showLaunchDialog && !launchFlags) {
+    if (!sessionId && promptBody && !terminalActive && !showLaunchDialog && !launchFlags && cardRuntime) {
       setShowLaunchDialog(true);
       setActiveTab("terminal");
     }
-  }, [card.id]);
+  }, [card.id, cardRuntime]);
 
   // Queued prompt handlers
   const handleAddPrompt = async (body: string, sendAutomatically: boolean, imagePaths?: string[]) => {
@@ -998,7 +1100,47 @@ export default function CardDetailView() {
         className="flex-1 overflow-hidden flex flex-col min-h-0"
         style={{ background: activeTab === "terminal" && terminalActive ? "#0a0a0c" : undefined }}
       >
-        {activeTab === "terminal" && canTerminal && (
+        {activeTab === "terminal" && canTerminal && !cardRuntime && (
+          <div className="flex flex-col items-center justify-center flex-1 gap-5 p-8">
+            <div className="text-center max-w-sm">
+              <p className="text-[13px] font-medium" style={{ color: c.textSecondary }}>
+                Pick a runtime for this card
+              </p>
+              <p className="text-[12px] mt-1" style={{ color: c.textDim }}>
+                {projectPath?.startsWith("/")
+                  ? <>This project lives under <span className="font-mono" style={{ color: c.textSecondary }}>/</span> so WSL is the natural pick. Saved per-card.</>
+                  : projectPath
+                  ? <>Choose Windows for projects under <span className="font-mono" style={{ color: c.textSecondary }}>C:\</span>, or WSL for ones under <span className="font-mono" style={{ color: c.textSecondary }}>/home/</span>. Saved per-card.</>
+                  : <>Choose where Claude launches for this card. Saved per-card.</>}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
+              {([
+                { id: "windows", label: "Windows", hint: "cmd.exe" },
+                { id: "wsl", label: "WSL", hint: "wsl.exe + bash" },
+              ] as const).map((opt) => (
+                <button
+                  key={opt.id}
+                  onClick={() => pickCardRuntime(opt.id)}
+                  className="rounded-xl px-4 py-3 text-left transition-colors"
+                  style={{
+                    background: c.bgAccent("0.04"),
+                    border: `1px solid ${c.border}`,
+                    color: c.textPrimary,
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.borderColor = "#4f8ef7"; e.currentTarget.style.background = c.bgAccent("0.08"); }}
+                  onMouseLeave={(e) => { e.currentTarget.style.borderColor = c.border; e.currentTarget.style.background = c.bgAccent("0.04"); }}
+                >
+                  <div className="text-sm font-medium">{opt.label}</div>
+                  <div className="text-[11px] mt-0.5 font-mono" style={{ color: c.textMuted }}>
+                    {opt.hint}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        {activeTab === "terminal" && canTerminal && cardRuntime && (
           terminalActive ? (
             <div className="flex-1 flex flex-col min-h-0">
               <QueuedPromptsBar
@@ -1061,6 +1203,7 @@ export default function CardDetailView() {
                 onExit={() => {}}
                 writeRef={terminalWriteRef}
                 fontSize={terminalFontSize}
+                initialScrollback={sessionId ? formatTranscriptScrollback(turns) : undefined}
               />
             </div>
           ) : (
@@ -1190,7 +1333,7 @@ export default function CardDetailView() {
           canCreateWorktree={false}
           initialSkipPermissions={false}
           buildCommand={(f) =>
-            isUnixShell
+            isWsl
               ? buildInnerBashCmd(projectPath, sessionId ?? null, f.prompt, f.dangerouslySkipPermissions, f.envPrefix)
               : buildInnerCmdShellCmd(projectPath, sessionId ?? null, f.prompt, f.dangerouslySkipPermissions, f.envPrefix)
           }

--- a/windows/src/components/SettingsView.tsx
+++ b/windows/src/components/SettingsView.tsx
@@ -269,21 +269,6 @@ function GeneralSection({
         </p>
       </FieldGroup>
 
-      <FieldGroup label="Terminal shell" themeTokens={c}>
-        <input
-          type="text"
-          value={settings.terminalShell || "cmd.exe"}
-          onChange={(e) => onChange({ ...settings, terminalShell: e.target.value })}
-          placeholder="cmd.exe"
-          spellCheck={false}
-          className="w-full rounded-xl px-3 py-2.5 text-sm font-mono outline-none transition-colors"
-          style={inputStyle(c)}
-        />
-        <p className="text-[11px] mt-1" style={{ color: c.textMuted }}>
-          Command used by the embedded terminal. Default <Code c={c}>cmd.exe</Code> for native Windows. Set to <Code c={c}>wsl.exe</Code> to run Claude inside WSL, or e.g. <Code c={c}>pwsh.exe -NoLogo</Code>. Takes effect on the next terminal launch.
-        </p>
-      </FieldGroup>
-
       <FieldGroup label="Prompt template" themeTokens={c}>
         <textarea
           rows={3}

--- a/windows/src/components/Terminal.tsx
+++ b/windows/src/components/Terminal.tsx
@@ -19,6 +19,11 @@ interface Props {
   writeRef?: React.MutableRefObject<((text: string) => void) | null>;
   /** Terminal font size (default 15) */
   fontSize?: number;
+  /** ANSI-formatted text pre-written into the xterm scrollback *before* the
+   *  PTY spawns. Lets us seed the buffer with the resumed session's prior
+   *  turns so scrolling up inside the terminal shows real history — no
+   *  separate overlay or tab to chase. */
+  initialScrollback?: string;
 }
 
 const DARK_THEME = {
@@ -69,11 +74,14 @@ const LIGHT_THEME = {
   brightWhite: "#8c959f",
 };
 
-export default function TerminalView({ ptyId, command, initialInput, onExit, writeRef, fontSize = 15 }: Props) {
+export default function TerminalView({ ptyId, command, initialInput, onExit, writeRef, fontSize = 15, initialScrollback }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const ptyRef = useRef<IPty | null>(null);
+  // `initialScrollback` is consumed once at mount. Stash in a ref so future
+  // prop changes don't try to re-seed an already-running terminal.
+  const initialScrollbackRef = useRef(initialScrollback);
   const { theme } = useTheme();
 
   const doFit = useCallback(() => {
@@ -101,7 +109,10 @@ export default function TerminalView({ ptyId, command, initialInput, onExit, wri
       cursorStyle: "bar",
       theme: DARK_THEME,
       allowProposedApi: true,
-      scrollback: 5000,
+      // Generous scrollback so a freshly-seeded transcript (potentially
+      // hundreds of turns) survives the live PTY scroll without getting
+      // clipped from the top.
+      scrollback: 20000,
     });
 
     const fitAddon = new FitAddon();
@@ -112,6 +123,13 @@ export default function TerminalView({ ptyId, command, initialInput, onExit, wri
     xterm.open(termRef.current);
     xtermRef.current = xterm;
     fitRef.current = fitAddon;
+
+    // Seed the scrollback with the prior session transcript *before* the
+    // PTY's first prompt arrives, so the live shell shows up directly under
+    // the historical turns instead of interleaving with them.
+    if (initialScrollbackRef.current) {
+      xterm.write(initialScrollbackRef.current);
+    }
 
     // Initial fit + spawn — delay to let flex layout compute dimensions
     setTimeout(() => {

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -130,6 +130,10 @@ export interface Link {
    *  the user never opened a tab on this card. Mirrors macOS
    *  Link.browserTabs. */
   browserTabs?: BrowserTabInfo[];
+  /** Which shell this card's embedded terminal launches into. `null` /
+   *  undefined means the user hasn't picked yet — the gate panel asks
+   *  Windows or WSL before any terminal can launch. No global default. */
+  cardRuntime?: CardRuntime | null;
 }
 
 /** Persisted state for one tab in the card's embedded browser panel.
@@ -289,6 +293,12 @@ export interface APIService {
   baseURL?: string;
 }
 
+/** Which shell a card's embedded terminal launches into. Lives on
+ *  `Link.cardRuntime` — each card asks once via its gate panel; no global
+ *  default. Matches `CardRuntime` in `settings_store.rs` (serialized as the
+ *  lowercase variant name). */
+export type CardRuntime = "windows" | "wsl";
+
 export interface Settings {
   projects: Project[];
   globalView: GlobalViewSettings;
@@ -303,8 +313,6 @@ export interface Settings {
   /** Font size for the History tab transcript (8-20). Mirrors macOS
    *  `sessionDetailFontSize` AppStorage; defaults to 12. */
   sessionDetailFontSize?: number;
-  /** Shell command for the embedded terminal — space-separated tokens. Default "cmd.exe". */
-  terminalShell: string;
   remote?: RemoteSettings;
   /** Automatic context-limit guard for Claude sessions (mirrors macOS). */
   selfCompact?: SelfCompactSettings;


### PR DESCRIPTION
## Summary

- **Per-card runtime gate**: Replace the global `terminalShell` setting with a per-card `cardRuntime` (Windows / WSL) chosen from a gate panel inside the card drawer. Each card stores its own choice in `Link.cardRuntime` via a new `set_card_runtime` Tauri command. The Settings → "Terminal shell" field is gone.
- **History inside the terminal**: Seed the xterm scrollback with the prior session transcript before the PTY spawns. Scrolling up *inside* the live terminal now surfaces real history — no separate overlay, no chevron, no overscroll trick. The standalone History tab keeps the rich/structured view.
- **Auto-resume on drawer open**: When a card has both a session and a picked runtime, the terminal launches automatically — no Resume click. The gate panel still asks Windows-or-WSL inline when runtime is null, and auto-fires the terminal as soon as the user picks.

## Test plan

- [ ] Open a card with an existing Claude session and a previously picked runtime → terminal launches immediately, scrolling up shows prior turns above the live shell.
- [ ] Open a fresh card with no runtime → gate panel asks Windows/WSL; picking it kicks off the terminal without a second click.
- [ ] Confirm Settings no longer shows the "Terminal shell" field.
- [ ] Confirm session JSONLs from macOS still load cleanly (Windows-only key backfill sentinel was switched from `terminalShell` to `terminalFontSize`).
- [ ] Multi-tmux-tab cards still attach correctly and reattach across drawer close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)