### PR TITLE
feat: automate Codex sessions as kanban tasks

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -58,7 +58,5 @@ jobs:
         working-directory: windows/src-tauri
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Check Rust formatting
-        run: cargo fmt --check
       - name: Compile and test Rust compatibility layer
         run: cargo test --lib

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,0 +1,64 @@
+name: macOS CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  swift-and-web:
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 10
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: |
+            cli/pnpm-lock.yaml
+            web/pnpm-lock.yaml
+      - run: swift test
+      - run: corepack pnpm install --frozen-lockfile && corepack pnpm run build && corepack pnpm test
+        working-directory: cli
+      - run: corepack pnpm install --frozen-lockfile && corepack pnpm run build
+        working-directory: web
+      - run: make archive
+      - run: plutil -extract LSMinimumSystemVersion raw build/KanbanCode.app/Contents/Info.plist | grep '^26.0$'
+      - name: Verify signed archive contents
+        run: |
+          test -x build/KanbanCode.app/Contents/Helpers/kanban-code-lifecycle
+          EXPECTED="$(tr -d '[:space:]' < build/KanbanCode.app/Contents/Resources/codex-lifecycle.sha256)"
+          ACTUAL="$(shasum -a 256 build/KanbanCode.app/Contents/Helpers/kanban-code-lifecycle | awk '{print $1}')"
+          test "$EXPECTED" = "$ACTUAL"
+          codesign --verify --deep --strict build/KanbanCode.app
+          mkdir build/archive-smoke
+          ditto -x -k build/KanbanCode-0.1.1-macos.zip build/archive-smoke
+          codesign --verify --deep --strict build/archive-smoke/KanbanCode.app
+      - name: Smoke launch archived app
+        run: |
+          open -n build/archive-smoke/KanbanCode.app
+          for attempt in 1 2 3 4 5; do
+            pgrep -f 'archive-smoke/KanbanCode.app/Contents/MacOS/KanbanCode' && exit 0
+            sleep 1
+          done
+          exit 1
+
+  windows-schema:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: windows/src-tauri
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check Rust formatting
+        run: cargo fmt --check
+      - name: Compile and test Rust compatibility layer
+        run: cargo test --lib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ make run-app         # build + launch the app
   - All mutations go through `store.dispatch(action)` → pure `Reducer` → async `Effect`s.
   - `isLaunching` flag on `Link` prevents background reconciliation from overriding cards mid-launch/resume.
   - Never mutate state directly or write to `CoordinationStore` from views — always dispatch an action.
+- Shared project vocabulary lives in [`CONCEPTS.md`](CONCEPTS.md).
+- Durable implementation learnings live under [`docs/solutions/`](docs/solutions/).
 
 ## Critical: DispatchSource + @MainActor Crashes
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,31 @@
+# Project Concepts
+
+## Codex Runtime Backend
+
+Where Codex work actually runs: the Codex App Server, or Codex CLI inside a
+managed tmux session. This is separate from the card's coding-assistant label.
+
+## Managed and Observed Sessions
+
+A managed session was created by the board and has a durable launch lease and
+precise execution binding. An observed session was created elsewhere and is
+imported from App Server or local session discovery; its telemetry may be
+limited until a structured event arrives.
+
+## Execution Binding
+
+The stable identifiers needed to return to the original work: App Server thread
+and turn IDs, Codex session ID, or the owned tmux session name. Bindings carry
+runtime provenance and telemetry quality.
+
+## Canonical Lifecycle
+
+The normalized, persisted state derived from structured App Server and hook
+events. It drives Backlog, In Progress, Waiting, In Review and Done. It is not
+the same as transient filesystem activity or terminal liveness.
+
+## Launch Lease
+
+A per-card, per-generation claim persisted before creating external work. It
+allows restart recovery to reconcile uncertain launches without duplicating a
+thread or killing a session that might belong to someone else.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run app run-app run-release clean cli install-cli web
+.PHONY: build test run app archive run-app run-release clean cli install-cli web
 
 BUNDLE_NAME = KanbanCode.app
 BUNDLE_DIR = build/$(BUNDLE_NAME)
@@ -25,11 +25,16 @@ run:
 app: build cli install-cli web
 	@mkdir -p $(BUNDLE_DIR)/Contents/MacOS
 	@mkdir -p $(BUNDLE_DIR)/Contents/Resources
+	@mkdir -p $(BUNDLE_DIR)/Contents/Helpers
 	@cp $(BUILD_DIR)/KanbanCode $(BUNDLE_DIR)/Contents/MacOS/KanbanCode
+	@cp $(BUILD_DIR)/kanban-code-lifecycle $(BUNDLE_DIR)/Contents/Helpers/kanban-code-lifecycle
+	@chmod 755 $(BUNDLE_DIR)/Contents/Helpers/kanban-code-lifecycle
+	@shasum -a 256 $(BUNDLE_DIR)/Contents/Helpers/kanban-code-lifecycle | awk '{print $$1}' > $(BUNDLE_DIR)/Contents/Resources/codex-lifecycle.sha256
 	@# Active session marker app (detected by Amphetamine etc.)
 	@mkdir -p $(BUNDLE_DIR)/Contents/Helpers/kanban-code-active-session.app/Contents/MacOS
 	@cp $(BUILD_DIR)/kanban-code-active-session $(BUNDLE_DIR)/Contents/Helpers/kanban-code-active-session.app/Contents/MacOS/kanban-code-active-session
 	@/bin/echo '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>CFBundleExecutable</key><string>kanban-code-active-session</string><key>CFBundleIdentifier</key><string>com.kanban-code.active-session</string><key>CFBundleName</key><string>kanban-code-active-session</string><key>CFBundlePackageType</key><string>APPL</string><key>CFBundleVersion</key><string>$(VERSION)</string><key>LSUIElement</key><true/></dict></plist>' > $(BUNDLE_DIR)/Contents/Helpers/kanban-code-active-session.app/Contents/Info.plist
+	@xattr -cr $(BUNDLE_DIR)/Contents/Helpers/kanban-code-active-session.app
 	@codesign --force --sign "$(CODESIGN_IDENTITY)" $(BUNDLE_DIR)/Contents/Helpers/kanban-code-active-session.app
 	@/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f $(BUNDLE_DIR)/Contents/Helpers/kanban-code-active-session.app 2>/dev/null || true
 	@cp Sources/KanbanCode/Resources/AppIcon.icns $(BUNDLE_DIR)/Contents/Resources/AppIcon.icns
@@ -42,7 +47,7 @@ app: build cli install-cli web
 	@echo '<key>CFBundleVersion</key><string>$(VERSION)</string>' >> $(BUNDLE_DIR)/Contents/Info.plist
 	@echo '<key>CFBundleShortVersionString</key><string>$(VERSION)</string>' >> $(BUNDLE_DIR)/Contents/Info.plist
 	@echo '<key>CFBundlePackageType</key><string>APPL</string>' >> $(BUNDLE_DIR)/Contents/Info.plist
-	@echo '<key>LSMinimumSystemVersion</key><string>14.0</string>' >> $(BUNDLE_DIR)/Contents/Info.plist
+	@echo '<key>LSMinimumSystemVersion</key><string>26.0</string>' >> $(BUNDLE_DIR)/Contents/Info.plist
 	@echo '<key>NSHighResolutionCapable</key><true/>' >> $(BUNDLE_DIR)/Contents/Info.plist
 	@echo '<key>LSUIElement</key><false/>' >> $(BUNDLE_DIR)/Contents/Info.plist
 	@echo '<key>CFBundleIconFile</key><string>AppIcon</string>' >> $(BUNDLE_DIR)/Contents/Info.plist
@@ -77,10 +82,17 @@ app: build cli install-cli web
 	@cp -R web/dist $(BUNDLE_DIR)/Contents/Resources/share-web
 	@# Code sign so macOS grants notification permissions and Web Inspector can attach
 	@echo "Code signing with: $(CODESIGN_IDENTITY)"
+	@xattr -cr $(BUNDLE_DIR)
 	@codesign --force --sign "$(CODESIGN_IDENTITY)" --entitlements KanbanCode.entitlements $(BUNDLE_DIR)
+	@xattr -cr $(BUNDLE_DIR)
 	@# Register with Launch Services so macOS picks up the icon
 	@/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f $(BUNDLE_DIR) 2>/dev/null || true
 	@echo "Built $(BUNDLE_DIR)"
+
+archive: app
+	@mkdir -p build
+	@ditto -c -k --sequesterRsrc --keepParent $(BUNDLE_DIR) build/KanbanCode-$(VERSION)-macos.zip
+	@echo "Built build/KanbanCode-$(VERSION)-macos.zip"
 
 run-app: app
 	open $(BUNDLE_DIR)

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .executable(name: "KanbanCode", targets: ["KanbanCode"]),
         .executable(name: "kanban-code-active-session", targets: ["KanbanCodeActiveSession"]),
+        .executable(name: "kanban-code-lifecycle", targets: ["KanbanCodeLifecycle"]),
         .library(name: "KanbanCodeCore", targets: ["KanbanCodeCore"]),
     ],
     dependencies: [
@@ -26,6 +27,11 @@ let package = Package(
         .executableTarget(
             name: "KanbanCodeActiveSession",
             path: "Sources/KanbanCodeActiveSession"
+        ),
+        .executableTarget(
+            name: "KanbanCodeLifecycle",
+            dependencies: ["KanbanCodeCore"],
+            path: "Sources/KanbanCodeLifecycle"
         ),
         .target(
             name: "KanbanCodeCore",

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Productive Mode:
 
 A native macOS app for running multiple Claude Code agents in parallel. Each task is a card on a Kanban board that automatically links your Claude session, git worktree, tmux terminals, and GitHub PR together — cards flow from backlog to done as Claude works, opens PRs, and gets them merged. Push notifications on your phone when agents need attention, remote execution to offload work to a server, and sleep prevention to keep your Mac awake while agents run.
 
+Codex sessions can use either **Codex App** or **Codex CLI + tmux** as a board-level runtime. A global attention strip surfaces sessions waiting for approval or input across both modes, while structured lifecycle events move cards through the five-stage workflow. See [Codex session board](docs/codex-board.md) for capabilities, setup, local files and degraded-operation behavior.
+
 Kanban Code's goal is to ease as much as possible the context switching bottleneck for modern development by centralizing all context needed for each Claude session into their cards.
 
 Kanban Code combines the lessons learned from [claude-resume](https://github.com/langwatch/claude-resume), [claude-remote](https://github.com/langwatch/claude-remote), [git-orchard](https://github.com/drewdrewthis/git-orchard), [claude-pushover](https://github.com/langwatch/claude-pushover), and [cc-amphetamine](https://github.com/rogeriochaves/cc-amphetamine) into one unified experience.

--- a/Sources/KanbanCode/BoardView.swift
+++ b/Sources/KanbanCode/BoardView.swift
@@ -35,6 +35,7 @@ struct BoardView: View {
     var onMergeCards: (String, String) -> Void = { _, _ in }   // (sourceId, targetId)
     var onNewTask: () -> Void = {}
     var onCardClicked: (String) -> Void = { _ in }
+    var onOpenRuntimeSession: (String) -> Void = { _ in }
     var onColumnBackgroundClick: (KanbanCodeColumn) -> Void = { _ in }
 
     var body: some View {
@@ -44,7 +45,7 @@ struct BoardView: View {
     @ViewBuilder
     private var channelsPseudoColumn: some View {
         let channels = store.state.channels
-        let pinnedCards = store.state.pinnedCards
+        let pinnedCards = store.state.codexBoardCards.filter(\.link.isPinned)
         if !channels.isEmpty || !pinnedCards.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
                 if !channels.isEmpty {
@@ -149,7 +150,7 @@ struct BoardView: View {
                     ForEach(store.state.visibleColumns, id: \.self) { column in
                         DroppableColumnView(
                             column: column,
-                            cards: store.state.unpinnedCards(in: column),
+                            cards: store.state.codexBoardCards(in: column).filter { !$0.link.isPinned },
                             selectedCardId: Binding(
                                 get: { store.state.selectedCardId },
                                 set: { store.dispatch(.selectCard(cardId: $0)) }
@@ -189,6 +190,7 @@ struct BoardView: View {
                             onMigrateAssistant: onMigrateAssistant,
                             onRefreshBacklog: column == .backlog ? onRefreshBacklog : nil,
                             onCardClicked: onCardClicked,
+                            onOpenRuntimeSession: onOpenRuntimeSession,
                             onColumnBackgroundClick: onColumnBackgroundClick
                         )
                         .id(column)
@@ -201,14 +203,14 @@ struct BoardView: View {
             .onChange(of: store.state.selectedCardId) {
                 // Scroll to the column containing the selected card
                 guard let selectedId = store.state.selectedCardId else { return }
-                if store.state.pinnedCards.contains(where: { $0.id == selectedId }) {
+                if store.state.codexBoardCards.contains(where: { $0.id == selectedId && $0.link.isPinned }) {
                     withAnimation(.easeInOut(duration: 0.25)) {
                         proxy.scrollTo("channels", anchor: .leading)
                     }
                     return
                 }
                 for col in store.state.visibleColumns {
-                    if store.state.cards(in: col).contains(where: { $0.id == selectedId }) {
+                    if store.state.codexBoardCards(in: col).contains(where: { $0.id == selectedId }) {
                         withAnimation(.easeInOut(duration: 0.25)) {
                             proxy.scrollTo(col, anchor: .center)
                         }
@@ -246,16 +248,16 @@ struct BoardView: View {
         .animation(.easeInOut(duration: 0.25), value: store.state.error != nil)
         // Empty board hint
         .overlay {
-            if store.state.filteredCards.isEmpty && !store.state.isLoading {
+            if store.state.codexBoardCards.isEmpty && !store.state.isLoading {
                 VStack(spacing: 12) {
                     if let projectPath = store.state.selectedProjectPath {
                         let name = store.state.configuredProjects.first(where: { $0.path == projectPath })?.name
                             ?? (projectPath as NSString).lastPathComponent
-                        Text("No sessions yet for \(name)")
+                        Text("No \(store.state.codexBoardRuntime.boardLabel) sessions yet for \(name)")
                             .font(.app(.title3))
                             .foregroundStyle(.secondary)
                     } else {
-                        Text("No sessions found")
+                        Text("No \(store.state.codexBoardRuntime.boardLabel) sessions found")
                             .font(.app(.title3))
                             .foregroundStyle(.secondary)
                     }
@@ -276,7 +278,7 @@ struct BoardView: View {
             set: { if !$0 { renamingPinnedCardId = nil } }
         )) {
             if let cardId = renamingPinnedCardId,
-               let card = store.state.pinnedCards.first(where: { $0.id == cardId }) {
+               let card = store.state.codexBoardCards.first(where: { $0.id == cardId && $0.link.isPinned }) {
                 RenameSessionDialog(
                     currentName: card.link.name ?? card.displayTitle,
                     isPresented: Binding(
@@ -314,7 +316,8 @@ struct BoardView: View {
             onMoveToProject: { projectPath in onMoveToProject(card.id, projectPath) },
             onMoveToFolder: { onMoveToFolder(card.id) },
             enabledAssistants: enabledAssistants,
-            onMigrateAssistant: { target in onMigrateAssistant(card.id, target) }
+            onMigrateAssistant: { target in onMigrateAssistant(card.id, target) },
+            onOpenRuntimeSession: { onOpenRuntimeSession(card.id) }
         )
     }
 }

--- a/Sources/KanbanCode/CardDetailHelpers.swift
+++ b/Sources/KanbanCode/CardDetailHelpers.swift
@@ -30,6 +30,10 @@ struct CardActionsMenuActions {
     let onMoveToProject: (String) -> Void
     let onMoveToFolder: () -> Void
     let onMigrateAssistant: (CodingAssistant) -> Void
+    let onOpenRuntimeSession: (() -> Void)?
+    let onMarkReviewReady: (() -> Void)?
+    let onAcceptReview: (() -> Void)?
+    let onContinueReview: (() -> Void)?
 
     init(
         onStart: @escaping () -> Void,
@@ -49,7 +53,11 @@ struct CardActionsMenuActions {
         onDelete: @escaping () -> Void,
         onMoveToProject: @escaping (String) -> Void,
         onMoveToFolder: @escaping () -> Void,
-        onMigrateAssistant: @escaping (CodingAssistant) -> Void
+        onMigrateAssistant: @escaping (CodingAssistant) -> Void,
+        onOpenRuntimeSession: (() -> Void)? = nil,
+        onMarkReviewReady: (() -> Void)? = nil,
+        onAcceptReview: (() -> Void)? = nil,
+        onContinueReview: (() -> Void)? = nil
     ) {
         self.onStart = onStart
         self.onResume = onResume
@@ -69,6 +77,10 @@ struct CardActionsMenuActions {
         self.onMoveToProject = onMoveToProject
         self.onMoveToFolder = onMoveToFolder
         self.onMigrateAssistant = onMigrateAssistant
+        self.onOpenRuntimeSession = onOpenRuntimeSession
+        self.onMarkReviewReady = onMarkReviewReady
+        self.onAcceptReview = onAcceptReview
+        self.onContinueReview = onContinueReview
     }
 }
 
@@ -89,6 +101,13 @@ struct CardActionsMenu: View {
 
         // Primary actions
         primaryActions
+
+        if let onOpenRuntimeSession = actions.onOpenRuntimeSession,
+           card.link.effectiveAssistant == .codex {
+            Button(action: onOpenRuntimeSession) {
+                Label("Open Original Codex Session", systemImage: "arrow.up.forward.app")
+            }
+        }
 
         Divider()
 
@@ -186,6 +205,24 @@ struct CardActionsMenu: View {
 
     @ViewBuilder
     private var primaryActions: some View {
+        if (card.column == .inProgress || card.column == .waiting),
+           let onMarkReviewReady = actions.onMarkReviewReady {
+            Button(action: onMarkReviewReady) {
+                Label("Mark Ready for Review", systemImage: "checkmark.bubble")
+            }
+        }
+        if card.column == .inReview {
+            if let onAcceptReview = actions.onAcceptReview {
+                Button(action: onAcceptReview) {
+                    Label("Complete Review", systemImage: "checkmark.circle")
+                }
+            }
+            if let onContinueReview = actions.onContinueReview {
+                Button(action: onContinueReview) {
+                    Label("Continue with Feedback", systemImage: "arrow.uturn.backward.circle")
+                }
+            }
+        }
         if card.column == .backlog {
             Button(action: actions.onStart) {
                 Label("Start", systemImage: "play.fill")

--- a/Sources/KanbanCode/CardView.swift
+++ b/Sources/KanbanCode/CardView.swift
@@ -23,6 +23,7 @@ struct CardView: View {
     var onMoveToFolder: () -> Void = {}
     var enabledAssistants: [CodingAssistant] = []
     var onMigrateAssistant: (CodingAssistant) -> Void = { _ in }
+    var onOpenRuntimeSession: () -> Void = {}
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -66,6 +67,15 @@ struct CardView: View {
                 Spacer()
 
                 CardBadgesRow(card: card)
+                if card.link.effectiveAssistant == .codex {
+                    Button(action: onOpenRuntimeSession) {
+                        RuntimeTelemetryBadge(executionBinding: card.link.executionBinding)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open original Codex session")
+                    .accessibilityLabel("Open original Codex session")
+                    .accessibilityValue(card.link.executionBinding?.backend.rawValue ?? "Codex")
+                }
             }
         }
         .padding(10)
@@ -118,7 +128,8 @@ struct CardView: View {
                     onDelete: onDelete,
                     onMoveToProject: onMoveToProject,
                     onMoveToFolder: onMoveToFolder,
-                    onMigrateAssistant: onMigrateAssistant
+                    onMigrateAssistant: onMigrateAssistant,
+                    onOpenRuntimeSession: onOpenRuntimeSession
                 ),
                 availableProjects: availableProjects,
                 enabledAssistants: enabledAssistants

--- a/Sources/KanbanCode/CodexBoardCoordinator.swift
+++ b/Sources/KanbanCode/CodexBoardCoordinator.swift
@@ -1,0 +1,398 @@
+import Foundation
+import KanbanCodeCore
+
+struct CodexPendingAction: Sendable, Equatable, Identifiable {
+    enum Kind: Sendable, Equatable { case approval, input }
+    let cardId: String
+    let kind: Kind
+    let title: String
+    let details: String
+    var id: String { cardId }
+}
+
+/// App-owned bridge that keeps runtime processes alive and applies the durable
+/// scheduler without putting process ownership in SwiftUI views.
+actor CodexBoardCoordinator {
+    private enum LifecycleApplyResult {
+        case acknowledged(CardRuntimeState?)
+        case failed
+    }
+    struct ScheduleResult: Sendable {
+        let outcomes: [CodexLaunchOutcome]
+        let runtimeStates: [String: CardRuntimeState]
+    }
+
+    private let tmux: TmuxAdapter
+    private let stateStore: CodexRuntimeStateStore
+    private let appServerConnection: CodexAppServerConnection
+    private let lifecycleInbox = CodexLifecycleInboxReader()
+    private let onStateChanged: @Sendable (CardRuntimeState) -> Void
+    private var scheduler: CodexLaunchScheduler?
+    private var runtimes: [CodexRuntimeBackend: any CodexRuntimePort] = [:]
+    private var appRuntimeUnavailableReason: String?
+    private var appMonitorTasks: [Task<Void, Never>] = []
+    private var appClient: CodexAppServerClient?
+    private var pendingRequestsByCardId: [String: CodexAppServerRequest] = [:]
+    private var pendingRequestsByThreadId: [String: CodexAppServerRequest] = [:]
+
+    init(
+        tmux: TmuxAdapter,
+        stateStore: CodexRuntimeStateStore = CodexRuntimeStateStore(),
+        appServerConnection: CodexAppServerConnection = .shared,
+        onStateChanged: @escaping @Sendable (CardRuntimeState) -> Void
+    ) {
+        self.tmux = tmux
+        self.stateStore = stateStore
+        self.appServerConnection = appServerConnection
+        self.onStateChanged = onStateChanged
+    }
+
+    func schedule(
+        tasks: [CodexQueuedTask],
+        activeBackend: CodexRuntimeBackend,
+        maxConcurrency: Int
+    ) async throws -> ScheduleResult {
+        // Keep App Server monitoring alive even when CLI + tmux is the active
+        // launch backend so imported Codex App sessions update promptly.
+        if activeBackend != .app {
+            _ = try? await makeSchedulerIfNeeded(activeBackend: .app)
+        }
+        let scheduler = try await makeSchedulerIfNeeded(activeBackend: activeBackend)
+        if activeBackend == .app, let reason = appRuntimeUnavailableReason {
+            throw CodexRuntimeError.unavailable(reason)
+        }
+        let outcomes = try await scheduler.schedule(
+            queuedTasks: tasks,
+            activeBackend: activeBackend,
+            maxConcurrency: maxConcurrency
+        )
+        await bindBufferedRequests()
+        return ScheduleResult(outcomes: outcomes, runtimeStates: try await stateStore.readAll())
+    }
+
+    func pendingAction(for cardId: String) -> CodexPendingAction? {
+        guard let request = pendingRequestsByCardId[cardId] else { return nil }
+        guard request.method == "item/tool/requestUserInput"
+                || request.method == "item/commandExecution/requestApproval"
+                || request.method == "item/fileChange/requestApproval"
+                || request.method == "item/permissions/requestApproval" else { return nil }
+        let isInput = request.method == "item/tool/requestUserInput"
+        return CodexPendingAction(
+            cardId: cardId,
+            kind: isInput ? .input : .approval,
+            title: isInput ? "Codex needs your input" : "Codex requests approval",
+            details: request.params.humanReadableSummary(maxLength: 2_000)
+        )
+    }
+
+    func respond(to cardId: String, approve: Bool? = nil, input: String? = nil) async throws {
+        guard let request = pendingRequestsByCardId[cardId], let client = appClient else {
+            throw CodexRuntimeError.invalidBinding("This Codex request is no longer pending")
+        }
+        let result: CodexJSONValue
+        if request.method == "item/tool/requestUserInput" {
+            let answer = input?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !answer.isEmpty else {
+                throw CodexRuntimeError.invalidBinding("Enter a response before sending")
+            }
+            let questionIDs = request.params.recursiveStrings(for: "id")
+            result = .object([
+                "answers": .object(Dictionary(uniqueKeysWithValues: questionIDs.map { id in
+                    (id, .object(["answers": .array([.string(answer)])]))
+                })),
+            ])
+        } else if request.method == "item/permissions/requestApproval" {
+            let requested = request.params["permissions"] ?? .object([:])
+            result = .object([
+                "permissions": approve == true ? requested : .object([:]),
+                "scope": .string("turn"),
+            ])
+        } else {
+            result = .object(["decision": .string(approve == true ? "accept" : "decline")])
+        }
+        try await client.respond(to: request, result: result)
+        pendingRequestsByCardId.removeValue(forKey: cardId)
+        try await emitLifecycle(kind: .running, cardId: cardId, source: "board:response")
+    }
+
+    func acceptReview(cardId: String) async throws {
+        guard let state = try await stateStore.state(for: cardId), state.lifecycle.phase == .inReview else {
+            throw CodexRuntimeError.invalidBinding("This card is no longer waiting for review")
+        }
+        try await emitLifecycle(kind: .accepted, cardId: cardId, source: "board:accept")
+    }
+
+    func markReviewReady(cardId: String) async throws {
+        guard let state = try await stateStore.state(for: cardId),
+              state.lifecycle.phase == .running || state.lifecycle.phase == .waiting else {
+            throw CodexRuntimeError.invalidBinding("This card is not currently running or waiting")
+        }
+        try await emitLifecycle(kind: .reviewReady, cardId: cardId, source: "board:manual-review")
+    }
+
+    func continueReview(cardId: String, feedback: String) async throws {
+        let body = feedback.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { throw CodexRuntimeError.invalidBinding("Enter revision feedback") }
+        guard let state = try await stateStore.state(for: cardId),
+              state.lifecycle.phase == .inReview,
+              let binding = state.executionBinding else {
+            throw CodexRuntimeError.invalidBinding("This card has no active review binding")
+        }
+        _ = try await makeSchedulerIfNeeded(activeBackend: binding.backend)
+        guard let runtime = runtimes[binding.backend] else {
+            throw CodexRuntimeError.unavailable("The original Codex runtime is unavailable")
+        }
+        try await runtime.sendFeedback(.init(cardId: cardId, binding: binding, body: body))
+        try await emitLifecycle(kind: .running, cardId: cardId, source: "board:continue")
+    }
+
+    func drainLifecycleInbox() async {
+        guard await lifecycleInbox.hasPendingEvents() else { return }
+        guard let states = try? await stateStore.readAll() else { return }
+        let bindings = Dictionary(uniqueKeysWithValues: states.values.compactMap { state -> (String, CodexLifecycleExpectedBinding)? in
+            guard let lease = state.launchLease,
+                  let capability = lease.lifecycleCapability,
+                  let execution = state.executionBinding,
+                  let sessionID = execution.sessionId ?? execution.threadId ?? execution.tmuxSessionName else {
+                return nil
+            }
+            return (state.cardId, CodexLifecycleExpectedBinding(
+                cardId: state.cardId,
+                sessionId: sessionID,
+                attemptId: lease.attemptId,
+                generation: lease.generation,
+                backend: lease.backend,
+                capability: capability
+            ))
+        })
+        guard let batch = try? await lifecycleInbox.drain(bindings: bindings) else { return }
+        var canAcknowledge = true
+        for event in batch.events {
+            switch await apply(event: event) {
+            case .acknowledged:
+                continue
+            case .failed:
+                canAcknowledge = false
+            }
+        }
+        if canAcknowledge {
+            try? await lifecycleInbox.acknowledge(batch)
+        }
+    }
+
+    private func makeSchedulerIfNeeded(activeBackend: CodexRuntimeBackend) async throws -> CodexLaunchScheduler {
+        var addedRuntime = false
+        if runtimes[.cliTmux] == nil {
+            runtimes[.cliTmux] = CodexCLITmuxRuntime(
+                tmux: tmux,
+                metadata: CodexTmuxMetadataAdapter()
+            )
+            addedRuntime = true
+        }
+        if activeBackend == .app {
+            do {
+                let client = try await appServerConnection.client()
+                let clientChanged = appClient.map { $0 !== client } ?? true
+                if runtimes[.app] == nil || clientChanged {
+                    appMonitorTasks.forEach { $0.cancel() }
+                    appMonitorTasks.removeAll()
+                    runtimes[.app] = CodexAppServerRuntime(client: client)
+                    appClient = client
+                    addedRuntime = true
+                    startAppServerMonitors(client: client)
+                }
+                appRuntimeUnavailableReason = nil
+            } catch {
+                appRuntimeUnavailableReason = "Codex App mode is unavailable: \(error.localizedDescription)"
+            }
+        }
+        if let scheduler, !addedRuntime { return scheduler }
+        let created = CodexLaunchScheduler(stateStore: stateStore, runtimes: runtimes)
+        scheduler = created
+        return created
+    }
+
+    private func startAppServerMonitors(client: CodexAppServerClient) {
+        guard appMonitorTasks.isEmpty else { return }
+        appMonitorTasks = [
+            Task { [weak self] in
+                let stream = await client.notifications()
+                for await notification in stream {
+                    await self?.consume(notification: notification)
+                }
+            },
+            Task { [weak self] in
+                let stream = await client.serverRequests()
+                for await request in stream {
+                    await self?.consume(serverRequest: request)
+                }
+            },
+        ]
+    }
+
+    private func consume(notification: CodexAppServerNotification) async {
+        guard let threadID = notification.params.recursiveString(for: "threadId")
+                ?? notification.params.recursiveString(for: "thread_id") else { return }
+
+        let kind: CodexLifecycleEventKind
+        if let changed = try? notification.decodeParams(as: CodexThreadStatusChanged.self) {
+            if changed.status.waitingOnApproval {
+                kind = .waitingForApproval
+            } else if changed.status.waitingOnUserInput {
+                kind = .waitingForInput
+            } else {
+                switch changed.status.type.lowercased() {
+                case "active", "running", "inprogress": kind = .running
+                case "idle", "stopped", "completed": kind = .stopped
+                default: return
+                }
+            }
+        } else if notification.method.contains("turn/completed") {
+            kind = .stopped
+        } else {
+            return
+        }
+        await apply(
+            kind: kind,
+            threadID: threadID,
+            turnID: notification.params.recursiveString(for: "turnId")
+                ?? notification.params.recursiveString(for: "turn_id"),
+            source: notification.method
+        )
+    }
+
+    private func consume(serverRequest: CodexAppServerRequest) async {
+        guard let threadID = serverRequest.params.recursiveString(for: "threadId")
+                ?? serverRequest.params.recursiveString(for: "thread_id") else { return }
+        pendingRequestsByThreadId[threadID] = serverRequest
+        await bindBufferedRequests()
+        let kind: CodexLifecycleEventKind = serverRequest.method.contains("requestUserInput")
+            ? .waitingForInput
+            : .waitingForApproval
+        await apply(
+            kind: kind,
+            threadID: threadID,
+            turnID: serverRequest.params.recursiveString(for: "turnId")
+                ?? serverRequest.params.recursiveString(for: "turn_id"),
+            source: serverRequest.method
+        )
+    }
+
+    private func bindBufferedRequests() async {
+        guard !pendingRequestsByThreadId.isEmpty,
+              let states = try? await stateStore.readAll() else { return }
+        for state in states.values {
+            guard let threadID = state.executionBinding?.threadId,
+                  let request = pendingRequestsByThreadId.removeValue(forKey: threadID) else { continue }
+            pendingRequestsByCardId[state.cardId] = request
+        }
+    }
+
+    private func emitLifecycle(kind: CodexLifecycleEventKind, cardId: String, source: String) async throws {
+        guard let state = try await stateStore.state(for: cardId) else {
+            throw CodexRuntimeError.invalidBinding("The card no longer has runtime state")
+        }
+        let eventID = UUID().uuidString
+        let event = CodexLifecycleEvent(
+            id: eventID,
+            cardId: cardId,
+            kind: kind,
+            watermark: LifecycleEventWatermark(
+                eventId: eventID,
+                source: source,
+                generation: state.launchLease?.generation,
+                turnId: state.executionBinding?.turnId,
+                occurredAt: .now
+            ),
+            telemetryQuality: .precise
+        )
+        if case .failed = await apply(event: event) {
+            throw CodexRuntimeError.unavailable("Could not persist the Codex lifecycle response")
+        }
+    }
+
+    private func apply(
+        kind: CodexLifecycleEventKind,
+        threadID: String,
+        turnID: String? = nil,
+        source: String
+    ) async {
+        guard let states = try? await stateStore.readAll(),
+              let state = states.values.first(where: { $0.executionBinding?.threadId == threadID }) else {
+            return
+        }
+        let eventID = UUID().uuidString
+        let event = CodexLifecycleEvent(
+            id: eventID,
+            cardId: state.cardId,
+            kind: kind,
+            watermark: LifecycleEventWatermark(
+                eventId: eventID,
+                source: "codex-app-server:\(source)",
+                generation: state.launchLease?.generation,
+                turnId: turnID ?? state.executionBinding?.turnId,
+                occurredAt: .now
+            ),
+            telemetryQuality: .precise
+        )
+        _ = await apply(event: event)
+    }
+
+    private func apply(event: CodexLifecycleEvent) async -> LifecycleApplyResult {
+        let reduction: CodexLifecycleReduction
+        do {
+            reduction = try await stateStore.applyLifecycleEvent(event)
+        } catch {
+            return .failed
+        }
+        let state: CardRuntimeState
+        switch reduction {
+        case .applied(let reduced), .conflicted(let reduced):
+            state = reduced
+        case .duplicate, .ignoredStale:
+            return .acknowledged(nil)
+        }
+        onStateChanged(state)
+        return .acknowledged(state)
+    }
+}
+
+private extension CodexJSONValue {
+    func recursiveString(for key: String) -> String? {
+        switch self {
+        case .object(let object):
+            if case .string(let value)? = object[key] { return value }
+            for value in object.values {
+                if let found = value.recursiveString(for: key) { return found }
+            }
+            return nil
+        case .array(let values):
+            for value in values {
+                if let found = value.recursiveString(for: key) { return found }
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    func recursiveStrings(for key: String) -> [String] {
+        switch self {
+        case .object(let object):
+            var values: [String] = []
+            if case .string(let value)? = object[key] { values.append(value) }
+            for value in object.values { values.append(contentsOf: value.recursiveStrings(for: key)) }
+            return Array(Set(values))
+        case .array(let values):
+            return Array(Set(values.flatMap { $0.recursiveStrings(for: key) }))
+        default:
+            return []
+        }
+    }
+
+    func humanReadableSummary(maxLength: Int) -> String {
+        guard let data = try? JSONEncoder().encode(self),
+              let text = String(data: data, encoding: .utf8) else { return "Review the request details in Codex." }
+        return text.count > maxLength ? String(text.prefix(maxLength)) + "…" : text
+    }
+}

--- a/Sources/KanbanCode/CodexBoardUI.swift
+++ b/Sources/KanbanCode/CodexBoardUI.swift
@@ -1,0 +1,486 @@
+import AppKit
+import SwiftUI
+import KanbanCodeCore
+
+enum CodexSessionDestination: Equatable {
+    case codexThread(URL)
+    case tmux(String)
+    case details
+}
+
+enum CodexSessionNavigation {
+    static func destination(
+        executionBinding: CodexExecutionBinding?,
+        legacyTmuxSessionName: String?
+    ) -> CodexSessionDestination {
+        if let threadId = executionBinding?.threadId,
+           let url = codexThreadURL(threadId: threadId) {
+            return .codexThread(url)
+        }
+
+        if let tmuxName = executionBinding?.tmuxSessionName ?? legacyTmuxSessionName {
+            return .tmux(tmuxName)
+        }
+
+        return .details
+    }
+
+    static func codexThreadURL(threadId: String) -> URL? {
+        guard !threadId.isEmpty else { return nil }
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        guard let encodedThreadId = threadId.addingPercentEncoding(withAllowedCharacters: allowed) else {
+            return nil
+        }
+        var components = URLComponents()
+        components.scheme = "codex"
+        components.host = "threads"
+        components.percentEncodedPath = "/\(encodedThreadId)"
+        return components.url
+    }
+}
+
+extension CodexRuntimeBackend {
+    var boardLabel: String {
+        switch self {
+        case .app: "Codex App"
+        case .cliTmux: "CLI + tmux"
+        case .unknown: "Unknown runtime"
+        }
+    }
+
+    var shortBoardLabel: String {
+        switch self {
+        case .app: "App"
+        case .cliTmux: "CLI"
+        case .unknown: "Unknown"
+        }
+    }
+
+    var boardSymbol: String {
+        switch self {
+        case .app: "macwindow"
+        case .cliTmux: "terminal"
+        case .unknown: "questionmark.circle"
+        }
+    }
+}
+
+extension TelemetryQuality {
+    var boardLabel: String {
+        switch self {
+        case .precise: "Precise telemetry"
+        case .limited: "Limited telemetry"
+        case .unknown: "Unknown telemetry"
+        }
+    }
+
+    var boardSymbol: String {
+        switch self {
+        case .precise: "waveform.path.ecg"
+        case .limited: "exclamationmark.triangle"
+        case .unknown: "questionmark.circle"
+        }
+    }
+
+    var boardColor: Color {
+        switch self {
+        case .precise: .green
+        case .limited: .orange
+        case .unknown: .secondary
+        }
+    }
+}
+
+extension LifecycleWaitReason {
+    var attentionLabel: String {
+        switch self {
+        case .input: "Needs input"
+        case .approval: "Needs approval"
+        case .ordinaryStop: "Stopped"
+        case .fault: "Failed"
+        case .disconnected: "Disconnected"
+        case .launchUncertain: "Launch uncertain"
+        case .unknown: "Needs attention"
+        }
+    }
+
+    var attentionSymbol: String {
+        switch self {
+        case .input: "text.bubble"
+        case .approval: "hand.raised"
+        case .ordinaryStop: "pause.circle"
+        case .fault: "exclamationmark.octagon"
+        case .disconnected: "wifi.slash"
+        case .launchUncertain: "arrow.clockwise.circle"
+        case .unknown: "exclamationmark.circle"
+        }
+    }
+}
+
+extension AttentionPrimaryAction {
+    var buttonLabel: String {
+        switch self {
+        case .respond: "Respond"
+        case .approve: "Review"
+        case .retry: "Inspect"
+        case .inspect: "Inspect"
+        }
+    }
+}
+
+struct RuntimeTelemetryBadge: View {
+    let executionBinding: CodexExecutionBinding?
+
+    private var runtime: CodexRuntimeBackend {
+        executionBinding?.backend ?? .unknown
+    }
+
+    private var telemetry: TelemetryQuality {
+        executionBinding?.telemetryQuality ?? .unknown
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: runtime.boardSymbol)
+            Text(runtime.shortBoardLabel)
+            Image(systemName: telemetry.boardSymbol)
+                .foregroundStyle(telemetry.boardColor)
+        }
+        .font(.app(.caption2, weight: .medium))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(.quaternary, in: Capsule())
+        .help("\(runtime.boardLabel) · \(telemetry.boardLabel)")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Runtime")
+        .accessibilityValue("\(runtime.boardLabel), \(telemetry.boardLabel)")
+    }
+}
+
+struct CodexBoardHeader: View {
+    let runtime: CodexRuntimeBackend
+    let boardCount: Int
+    let allSessionsCount: Int
+    let onSelectRuntime: (CodexRuntimeBackend) -> Void
+    let onShowAllSessions: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Picker("Codex runtime", selection: Binding(
+                get: { runtime },
+                set: { runtime in onSelectRuntime(runtime) }
+            )) {
+                Label("Codex App", systemImage: CodexRuntimeBackend.app.boardSymbol)
+                    .tag(CodexRuntimeBackend.app)
+                Label("CLI + tmux", systemImage: CodexRuntimeBackend.cliTmux.boardSymbol)
+                    .tag(CodexRuntimeBackend.cliTmux)
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 250)
+            .accessibilityLabel("Board runtime")
+            .accessibilityValue(runtime.boardLabel)
+            .help("Switching changes the five visible lanes; queued work in the other runtime stays paused")
+
+            Text("\(boardCount) in this runtime")
+                .font(.app(.caption))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button(action: onShowAllSessions) {
+                Label("All Sessions", systemImage: "tray.full")
+                Text("\(allSessionsCount)")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.bordered)
+            .help("Search sessions from every runtime, including legacy sessions")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial)
+    }
+}
+
+struct AttentionStrip: View {
+    let items: [AttentionItem]
+    let onPrimaryAction: (AttentionItem) -> Void
+    let onOpenSession: (AttentionItem) -> Void
+
+    var body: some View {
+        if !items.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Image(systemName: "bell.badge")
+                        .foregroundStyle(.orange)
+                    Text("Needs your attention")
+                        .font(.app(.headline))
+                    Text("\(items.count)")
+                        .font(.app(.caption, weight: .semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.orange.opacity(0.16), in: Capsule())
+                    Spacer()
+                }
+
+                ScrollView(.horizontal, showsIndicators: items.count > 3) {
+                    LazyHStack(spacing: 8) {
+                        ForEach(items) { item in
+                            AttentionItemView(
+                                item: item,
+                                onPrimaryAction: { onPrimaryAction(item) },
+                                onOpenSession: { onOpenSession(item) }
+                            )
+                        }
+                    }
+                }
+                .frame(height: 70)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Color.orange.opacity(0.055))
+            .overlay(alignment: .bottom) { Divider() }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("\(items.count) sessions need attention")
+        }
+    }
+}
+
+private struct AttentionItemView: View {
+    let item: AttentionItem
+    let onPrimaryAction: () -> Void
+    let onOpenSession: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: item.reason.attentionSymbol)
+                .foregroundStyle(item.reason == .fault ? .red : .orange)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.app(.subheadline, weight: .semibold))
+                    .lineLimit(1)
+                HStack(spacing: 5) {
+                    Text(item.reason.attentionLabel)
+                    Text("·")
+                    Text(item.runtime.shortBoardLabel)
+                    if let project = item.project {
+                        Text("·")
+                        Text(project)
+                    }
+                    Text("·")
+                    Text(item.age.formattedAttentionAge)
+                }
+                .font(.app(.caption2))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+
+            Button(item.primaryAction.buttonLabel, action: onPrimaryAction)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            Button(action: onOpenSession) {
+                Image(systemName: "arrow.up.forward.app")
+            }
+            .buttonStyle(.borderless)
+            .help("Open original session")
+            .disabled(!item.canOpenSession)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(width: 360, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(.orange.opacity(0.18)))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(item.title), \(item.reason.attentionLabel), \(item.runtime.boardLabel)")
+        .accessibilityAction(named: item.primaryAction.buttonLabel, onPrimaryAction)
+        .accessibilityAction(named: "Open original session", onOpenSession)
+    }
+}
+
+private extension TimeInterval {
+    var formattedAttentionAge: String {
+        if self < 60 { return "now" }
+        if self < 3_600 { return "\(Int(self / 60))m" }
+        if self < 86_400 { return "\(Int(self / 3_600))h" }
+        return "\(Int(self / 86_400))d"
+    }
+}
+
+struct CodexReviewFeedbackDialog: View {
+    let title: String
+    let onCancel: () -> Void
+    let onSubmit: (String) -> Void
+    @State private var feedback = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Continue (title)")
+                .font(.title2.bold())
+            Text("Feedback is sent to the original Codex session. The card returns to In Progress only after Codex acknowledges it.")
+                .foregroundStyle(.secondary)
+            TextEditor(text: $feedback)
+                .font(.body)
+                .frame(minHeight: 120)
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Send Feedback") { onSubmit(feedback) }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(feedback.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+    }
+}
+
+struct CodexPendingActionDialog: View {
+    let action: CodexPendingAction
+    let onCancel: () -> Void
+    let onRespond: (Bool?, String?) -> Void
+    @State private var input = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(action.title)
+                .font(.title2.bold())
+            ScrollView {
+                Text(action.details)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 180)
+
+            if action.kind == .input {
+                TextEditor(text: $input)
+                    .frame(minHeight: 90)
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                if action.kind == .approval {
+                    Button("Deny") { onRespond(false, nil) }
+                    Button("Approve") { onRespond(true, nil) }
+                        .buttonStyle(.borderedProminent)
+                } else {
+                    Button("Send") { onRespond(nil, input) }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 560)
+    }
+}
+
+struct AllSessionsView: View {
+    let cards: [KanbanCodeCard]
+    let onOpen: (String) -> Void
+    let onDismiss: () -> Void
+    @State private var query = ""
+
+    private var filteredCards: [KanbanCodeCard] {
+        let sorted = cards.sorted {
+            ($0.link.lastActivity ?? $0.link.updatedAt) > ($1.link.lastActivity ?? $1.link.updatedAt)
+        }
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return sorted }
+        return sorted.filter { card in
+            card.displayTitle.localizedCaseInsensitiveContains(normalized)
+                || (card.projectName?.localizedCaseInsensitiveContains(normalized) ?? false)
+                || (card.link.sessionLink?.sessionId.localizedCaseInsensitiveContains(normalized) ?? false)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("All Sessions")
+                    .font(.app(.title2, weight: .semibold))
+                Text("\(cards.count)")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Done", action: onDismiss)
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding()
+
+            TextField("Search title, project, or session ID", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+                .padding(.bottom, 10)
+
+            Divider()
+
+            if cards.isEmpty {
+                ContentUnavailableView(
+                    "No sessions yet",
+                    systemImage: "tray",
+                    description: Text("Created and discovered sessions will appear here across both runtimes.")
+                )
+            } else if filteredCards.isEmpty {
+                ContentUnavailableView.search(text: query)
+            } else {
+                List {
+                    ForEach(filteredCards, id: \.id) { card in
+                        Button {
+                            onOpen(card.id)
+                        } label: {
+                            HStack(spacing: 10) {
+                                AssistantIcon(assistant: card.link.effectiveAssistant)
+                                    .frame(width: 16, height: 16)
+                                    .foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(card.displayTitle)
+                                        .foregroundStyle(.primary)
+                                        .lineLimit(1)
+                                    HStack(spacing: 6) {
+                                        Text(card.column.displayName)
+                                        if let projectName = card.projectName {
+                                            Text("·")
+                                            Text(projectName)
+                                        }
+                                        Text("·")
+                                        Text(card.relativeTime)
+                                    }
+                                    .font(.app(.caption))
+                                    .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                if card.link.effectiveAssistant == .codex {
+                                    RuntimeTelemetryBadge(executionBinding: card.link.executionBinding)
+                                } else {
+                                    Text("Legacy")
+                                        .font(.app(.caption2, weight: .medium))
+                                        .foregroundStyle(.secondary)
+                                        .padding(.horizontal, 5)
+                                        .padding(.vertical, 2)
+                                        .background(.quaternary, in: Capsule())
+                                }
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button("Open Original Session") { onOpen(card.id) }
+                        }
+                        .accessibilityLabel("\(card.displayTitle), \(card.column.displayName)")
+                        .accessibilityHint("Opens the original runtime session or card details")
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .frame(minWidth: 680, minHeight: 520)
+    }
+}

--- a/Sources/KanbanCode/ContentView.swift
+++ b/Sources/KanbanCode/ContentView.swift
@@ -59,6 +59,12 @@ private struct RenameTarget: Identifiable, Equatable {
     var id: String { name }
 }
 
+struct CodexReviewTarget: Identifiable {
+    let cardId: String
+    let title: String
+    var id: String { cardId }
+}
+
 private enum DrawerNavigationTarget: Equatable {
     case card(String)
     case channel(String)
@@ -96,6 +102,7 @@ struct ContentView: View {
     @AppStorage("appearanceMode") var appearanceMode: AppearanceMode = .auto
     @AppStorage("boardViewMode") var boardViewModeRaw = BoardViewMode.kanban.rawValue
     @State var showProcessManager = false
+    @State var showAllSessions = false
     @AppStorage("killTmuxOnQuit") var killTmuxOnQuit = true
     @AppStorage("uiTextSize") var uiTextSize: Int = 1
     @AppStorage("detailExpanded") var detailExpandedPersisted = false
@@ -108,6 +115,8 @@ struct ContentView: View {
     @State var pendingTerminalSession: String?
     @State var showAddLinkCardId: String?
     @State var launchConfig: LaunchConfig?
+    @State var codexReviewTarget: CodexReviewTarget?
+    @State var codexPendingAction: CodexPendingAction?
     @State var syncStatuses: [String: SyncStatus] = [:]
     @State var isSyncRefreshing = false
     @State var showSyncPopover = false
@@ -143,6 +152,7 @@ struct ContentView: View {
     let assistantRegistry: CodingAssistantRegistry
     let launcher: LaunchSession
     let tmuxAdapter: TmuxAdapter
+    let codexBoardCoordinator: CodexBoardCoordinator
     let systemTray = SystemTray()
     let mutagenAdapter = MutagenAdapter()
     let hookEventsPath: String
@@ -200,7 +210,7 @@ struct ContentView: View {
         let geminiDiscovery = GeminiSessionDiscovery()
         let geminiDetector = GeminiActivityDetector()
         let geminiStore = GeminiSessionStore()
-        let codexDiscovery = CodexSessionDiscovery()
+        let codexDiscovery = CodexHybridSessionDiscovery()
         let codexDetector = CodexActivityDetector()
         let codexStore = CodexSessionStore()
 
@@ -222,6 +232,7 @@ struct ContentView: View {
         let coordination = CoordinationStore()
         let settings = SettingsStore()
         let tmux = TmuxAdapter()
+        let codexRuntimeStateStore = CodexRuntimeStateStore()
 
         let effectHandler = EffectHandler(
             coordinationStore: coordination,
@@ -230,7 +241,8 @@ struct ContentView: View {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setData(data, forType: .png)
             },
-            notifier: MacOSNotificationClient()
+            notifier: MacOSNotificationClient(),
+            codexRuntimeStateStore: codexRuntimeStateStore
         )
 
         let boardStore = BoardStore(
@@ -241,7 +253,8 @@ struct ContentView: View {
             settingsStore: settings,
             ghAdapter: GhCliAdapter(),
             worktreeAdapter: GitWorktreeAdapter(),
-            tmuxAdapter: tmux
+            tmuxAdapter: tmux,
+            codexRuntimeStateStore: codexRuntimeStateStore
         )
 
         // Load Pushover from settings.json, wrap in CompositeNotifier with macOS fallback
@@ -281,6 +294,14 @@ struct ContentView: View {
         self.assistantRegistry = registry
         self.launcher = launch
         self.tmuxAdapter = tmux
+        self.codexBoardCoordinator = CodexBoardCoordinator(
+            tmux: tmux,
+            stateStore: codexRuntimeStateStore
+        ) { [weak boardStore] state in
+            Task { @MainActor in
+                boardStore?.dispatch(.codexRuntimeStateChanged(state))
+            }
+        }
         self.hookEventsPath = (NSHomeDirectory() as NSString)
             .appendingPathComponent(".kanban-code/hook-events.jsonl")
         self.settingsFilePath = (NSHomeDirectory() as NSString)
@@ -320,6 +341,44 @@ struct ContentView: View {
         return (PushoverClient(token: token, userKey: user), mode)
     }
 
+    private func selectCodexBoardRuntime(_ runtime: CodexRuntimeBackend) {
+        guard runtime != .unknown, runtime != store.state.codexBoardRuntime else { return }
+        store.dispatch(.setCodexBoardRuntime(runtime))
+
+        Task {
+            do {
+                var settings = try await settingsStore.read()
+                settings.codexBoard.runtime = runtime
+                try await settingsStore.write(settings)
+            } catch {
+                store.dispatch(.setError("Could not save Codex runtime preference: \(error.localizedDescription)"))
+            }
+        }
+    }
+
+    private func openRuntimeSession(cardId: String) {
+        guard let card = store.state.cards.first(where: { $0.id == cardId }) else { return }
+        switchToProjectIfNeeded(for: card)
+
+        switch CodexSessionNavigation.destination(
+            executionBinding: card.link.executionBinding,
+            legacyTmuxSessionName: card.link.tmuxLink?.sessionName
+        ) {
+        case .codexThread(let url):
+            if !NSWorkspace.shared.open(url) {
+                store.dispatch(.selectCard(cardId: cardId))
+                store.dispatch(.setError("Codex could not open this thread. The card details remain available here."))
+            }
+        case .tmux(let sessionName):
+            store.dispatch(.selectCard(cardId: cardId))
+            detailTab = .terminal
+            pendingTerminalSession = sessionName
+            shouldFocusTerminal = true
+        case .details:
+            store.dispatch(.selectCard(cardId: cardId))
+        }
+    }
+
     private func updateRegisteredAssistants(_ enabled: [CodingAssistant]) {
         for assistant in CodingAssistant.allCases {
             if enabled.contains(assistant) {
@@ -331,7 +390,7 @@ struct ContentView: View {
                     case .gemini:
                         assistantRegistry.register(.gemini, discovery: GeminiSessionDiscovery(), detector: GeminiActivityDetector(), store: GeminiSessionStore())
                     case .codex:
-                        assistantRegistry.register(.codex, discovery: CodexSessionDiscovery(), detector: CodexActivityDetector(), store: CodexSessionStore())
+                        assistantRegistry.register(.codex, discovery: CodexHybridSessionDiscovery(), detector: CodexActivityDetector(), store: CodexSessionStore())
                     }
                 }
             } else {
@@ -418,6 +477,7 @@ struct ContentView: View {
                     shouldFocusTerminal = true
                 }
             },
+            onOpenRuntimeSession: { cardId in openRuntimeSession(cardId: cardId) },
             onColumnBackgroundClick: { column in
                 handleColumnBackgroundClick(column)
             }
@@ -504,6 +564,7 @@ struct ContentView: View {
                     shouldFocusTerminal = true
                 }
             },
+            onOpenRuntimeSession: { cardId in openRuntimeSession(cardId: cardId) },
             onRenameCard: { cardId, name in
                 store.dispatch(.renameCard(cardId: cardId, name: name))
             },
@@ -768,21 +829,41 @@ struct ContentView: View {
     private var boardWithOverlays: some View {
         Group {
             if isExpandedDetail {
-                if let dm = store.state.selectedDMParticipant {
-                    dmChatContent(other: dm)
-                } else if let name = store.state.selectedChannelName,
-                          let ch = store.state.channels.first(where: { $0.name == name }) {
-                    channelChatContent(channel: ch)
-                } else if let card = store.state.selectedCard {
-                    makeCardDetailView(card: card)
-                } else {
-                    expandedEmptyState
+                VStack(spacing: 0) {
+                    AttentionStrip(
+                        items: store.state.attentionItems,
+                        onPrimaryAction: handleCodexAttention,
+                        onOpenSession: { openRuntimeSession(cardId: $0.cardId) }
+                    )
+                    if let dm = store.state.selectedDMParticipant {
+                        dmChatContent(other: dm)
+                    } else if let name = store.state.selectedChannelName,
+                              let ch = store.state.channels.first(where: { $0.name == name }) {
+                        channelChatContent(channel: ch)
+                    } else if let card = store.state.selectedCard {
+                        makeCardDetailView(card: card)
+                    } else {
+                        expandedEmptyState
+                    }
                 }
             } else {
                 // Normal: kanban board with inspector.
                 // When a channel/DM is selected the inspector shows chat instead of card detail.
-                boardView
-                    .ignoresSafeArea(edges: .top)
+                VStack(spacing: 0) {
+                    CodexBoardHeader(
+                        runtime: store.state.codexBoardRuntime,
+                        boardCount: store.state.codexBoardCards.count,
+                        allSessionsCount: store.state.cards.count,
+                        onSelectRuntime: selectCodexBoardRuntime,
+                        onShowAllSessions: { showAllSessions = true }
+                    )
+                    AttentionStrip(
+                        items: store.state.attentionItems,
+                        onPrimaryAction: handleCodexAttention,
+                        onOpenSession: { openRuntimeSession(cardId: $0.cardId) }
+                    )
+                    boardView
+                }
                     .inspector(isPresented: showInspector) {
                         inspectorContent
                             .inspectorColumnWidth(min: 600, ideal: 800, max: 1000)
@@ -887,11 +968,12 @@ struct ContentView: View {
                     defaultProjectPath: store.state.selectedProjectPath,
                     globalRemoteSettings: store.state.globalRemoteSettings,
                     enabledAssistants: assistantRegistry.available,
+                    codexRuntime: store.state.codexBoardRuntime,
                     onCreate: { prompt, projectPath, title, startImmediately, images in
-                        createManualTask(prompt: prompt, projectPath: projectPath, title: title, startImmediately: startImmediately, images: images)
+                        createCodexBoardTask(prompt: prompt, projectPath: projectPath, title: title, images: images)
                     },
                     onCreateAndLaunch: { prompt, projectPath, title, createWorktree, runRemotely, skipPermissions, commandOverride, images, assistant, apiServiceId in
-                        createManualTaskAndLaunch(prompt: prompt, projectPath: projectPath, title: title, createWorktree: createWorktree, runRemotely: runRemotely, skipPermissions: skipPermissions, commandOverride: commandOverride, images: images, assistant: assistant, apiServiceId: apiServiceId)
+                        createCodexBoardTask(prompt: prompt, projectPath: projectPath, title: title, images: images)
                     }
                 )
             }
@@ -945,6 +1027,20 @@ struct ContentView: View {
                     }
                 }
             }
+            .sheet(item: $codexReviewTarget) { target in
+                CodexReviewFeedbackDialog(
+                    title: target.title,
+                    onCancel: { codexReviewTarget = nil },
+                    onSubmit: { feedback in continueCodexReview(cardId: target.cardId, feedback: feedback) }
+                )
+            }
+            .sheet(item: $codexPendingAction) { action in
+                CodexPendingActionDialog(
+                    action: action,
+                    onCancel: { codexPendingAction = nil },
+                    onRespond: { approve, input in respondToCodex(action: action, approve: approve, input: input) }
+                )
+            }
             .sheet(isPresented: $showOnboarding) {
                 OnboardingWizard(
                     settingsStore: settingsStore,
@@ -977,6 +1073,16 @@ struct ContentView: View {
                         pendingTerminalSession = terminalSession
                         shouldFocusTerminal = true
                     }
+                )
+            }
+            .sheet(isPresented: $showAllSessions) {
+                AllSessionsView(
+                    cards: store.state.cards,
+                    onOpen: { cardId in
+                        showAllSessions = false
+                        openRuntimeSession(cardId: cardId)
+                    },
+                    onDismiss: { showAllSessions = false }
                 )
             }
             .popover(isPresented: Binding(
@@ -1239,6 +1345,13 @@ struct ContentView: View {
                     guard !Task.isCancelled else { break }
                     await store.reconcile()
                     systemTray.update()
+                }
+            }
+            .task(id: "codex-board-scheduler") {
+                while !Task.isCancelled {
+                    await scheduleQueuedCodexTasks()
+                    await codexBoardCoordinator.drainLifecycleInbox()
+                    try? await Task.sleep(for: .seconds(2))
                 }
             }
             .task(id: "channels-bootstrap") {
@@ -1814,6 +1927,10 @@ struct ContentView: View {
                 showProcessManager = true
             }
 
+            Button("All Sessions...") {
+                showAllSessions = true
+            }
+
             SettingsLink {
                 Text("Settings...")
             }
@@ -2094,6 +2211,58 @@ struct ContentView: View {
         }
     }
 
+    private func handleCodexAttention(_ item: AttentionItem) {
+        Task {
+            if let action = await codexBoardCoordinator.pendingAction(for: item.cardId) {
+                await MainActor.run { codexPendingAction = action }
+            } else {
+                await MainActor.run { openRuntimeSession(cardId: item.cardId) }
+            }
+        }
+    }
+
+    private func respondToCodex(action: CodexPendingAction, approve: Bool?, input: String?) {
+        Task {
+            do {
+                try await codexBoardCoordinator.respond(to: action.cardId, approve: approve, input: input)
+                await MainActor.run { codexPendingAction = nil }
+            } catch {
+                await MainActor.run { store.dispatch(.setError(error.localizedDescription)) }
+            }
+        }
+    }
+
+    private func acceptCodexReview(cardId: String) {
+        Task {
+            do {
+                try await codexBoardCoordinator.acceptReview(cardId: cardId)
+            } catch {
+                await MainActor.run { store.dispatch(.setError(error.localizedDescription)) }
+            }
+        }
+    }
+
+    private func continueCodexReview(cardId: String, feedback: String) {
+        Task {
+            do {
+                try await codexBoardCoordinator.continueReview(cardId: cardId, feedback: feedback)
+                await MainActor.run { codexReviewTarget = nil }
+            } catch {
+                await MainActor.run { store.dispatch(.setError(error.localizedDescription)) }
+            }
+        }
+    }
+
+    private func markCodexReviewReady(cardId: String) {
+        Task {
+            do {
+                try await codexBoardCoordinator.markReviewReady(cardId: cardId)
+            } catch {
+                await MainActor.run { store.dispatch(.setError(error.localizedDescription)) }
+            }
+        }
+    }
+
     // MARK: - Expanded Actions Menu
 
     private func expandedActionsMenu(for card: KanbanCodeCard) -> some View {
@@ -2143,6 +2312,12 @@ struct ContentView: View {
                     onMoveToFolder: { selectFolderForMove(cardId: card.id) },
                     onMigrateAssistant: { target in
                         presentDialog(.confirmMigration(cardId: card.id, targetAssistant: target))
+                    },
+                    onOpenRuntimeSession: { openRuntimeSession(cardId: card.id) },
+                    onMarkReviewReady: { markCodexReviewReady(cardId: card.id) },
+                    onAcceptReview: { acceptCodexReview(cardId: card.id) },
+                    onContinueReview: {
+                        codexReviewTarget = CodexReviewTarget(cardId: card.id, title: card.displayTitle)
                     }
                 ),
                 showBranchInfo: true,
@@ -2497,6 +2672,112 @@ struct ContentView: View {
 
         if startImmediately {
             startCard(cardId: link.id)
+        }
+    }
+
+    private func createCodexBoardTask(
+        prompt: String,
+        projectPath: String?,
+        title: String? = nil,
+        images: [ImageAttachment] = []
+    ) {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let firstLine = trimmed.components(separatedBy: .newlines).first ?? trimmed
+        let name = String((title?.isEmpty == false ? title! : firstLine).prefix(100))
+        let imagePaths: [String]? = images.isEmpty ? nil : images.compactMap { image in
+            var mutable = image
+            return try? mutable.saveToPersistent()
+        }
+        let backend = store.state.codexBoardRuntime
+        var link = Link(
+            name: name,
+            projectPath: projectPath,
+            column: .backlog,
+            source: .manual,
+            promptBody: trimmed,
+            promptImagePaths: imagePaths,
+            assistant: .codex
+        )
+        link.executionBinding = CodexExecutionBinding(
+            backend: backend,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .unknown,
+            boundAt: .now
+        )
+        store.dispatch(.createManualTask(link))
+
+        Task {
+            do {
+                let settings = try await settingsStore.read()
+                let task = CodexQueuedTask(
+                    cardId: link.id,
+                    backend: backend,
+                    enqueuedAt: link.createdAt,
+                    projectPath: projectPath ?? NSHomeDirectory(),
+                    prompt: trimmed
+                )
+                let result = try await codexBoardCoordinator.schedule(
+                    tasks: [task],
+                    activeBackend: backend,
+                    maxConcurrency: settings.codexBoard.maxConcurrency
+                )
+                for state in result.runtimeStates.values {
+                    store.dispatch(.codexRuntimeStateChanged(state))
+                }
+                for outcome in result.outcomes {
+                    switch outcome {
+                    case .launched(let cardId, let binding):
+                        store.dispatch(.bindCodexRuntime(cardId: cardId, binding: binding))
+                    case .failed(_, let message), .uncertain(_, let message):
+                        store.dispatch(.setError(message))
+                    }
+                }
+            } catch {
+                store.dispatch(.setError("Could not start Codex task: \(error.localizedDescription)"))
+            }
+        }
+    }
+
+    private func scheduleQueuedCodexTasks() async {
+        let backend = store.state.codexBoardRuntime
+        let queued = store.state.links.values.compactMap { link -> CodexQueuedTask? in
+            let phase = store.state.codexRuntimeStates[link.id]?.lifecycle.phase
+            guard link.effectiveAssistant == .codex,
+                  link.executionBinding?.backend == backend,
+                  link.executionBinding?.ownership == .managed,
+                  link.executionBinding?.threadId == nil,
+                  link.executionBinding?.tmuxSessionName == nil,
+                  phase == nil || phase == .queued else {
+                return nil
+            }
+            return CodexQueuedTask(
+                cardId: link.id,
+                backend: backend,
+                enqueuedAt: link.createdAt,
+                projectPath: link.projectPath ?? NSHomeDirectory(),
+                prompt: link.promptBody ?? link.name ?? "Codex task"
+            )
+        }
+        guard !queued.isEmpty else { return }
+        do {
+            let settings = try await settingsStore.read()
+            let result = try await codexBoardCoordinator.schedule(
+                tasks: queued,
+                activeBackend: backend,
+                maxConcurrency: settings.codexBoard.maxConcurrency
+            )
+            for state in result.runtimeStates.values {
+                store.dispatch(.codexRuntimeStateChanged(state))
+            }
+            for outcome in result.outcomes {
+                if case .launched(let cardId, let binding) = outcome {
+                    store.dispatch(.bindCodexRuntime(cardId: cardId, binding: binding))
+                }
+            }
+        } catch {
+            // Dependency diagnostics in Settings remain the durable user-facing
+            // explanation. Keep queued work intact for a later scheduling pass.
         }
     }
 

--- a/Sources/KanbanCode/DragAndDrop.swift
+++ b/Sources/KanbanCode/DragAndDrop.swift
@@ -52,6 +52,7 @@ struct DroppableColumnView: View {
     var onMigrateAssistant: (String, CodingAssistant) -> Void = { _, _ in }
     var onRefreshBacklog: (() -> Void)?
     var onCardClicked: (String) -> Void = { _ in }
+    var onOpenRuntimeSession: (String) -> Void = { _ in }
     var onColumnBackgroundClick: (KanbanCodeColumn) -> Void = { _ in }
 
     @State private var isTargeted = false
@@ -286,7 +287,8 @@ struct DroppableColumnView: View {
             onMoveToProject: { projectPath in onMoveToProject(card.id, projectPath) },
             onMoveToFolder: { onMoveToFolder(card.id) },
             enabledAssistants: enabledAssistants,
-            onMigrateAssistant: { target in onMigrateAssistant(card.id, target) }
+            onMigrateAssistant: { target in onMigrateAssistant(card.id, target) },
+            onOpenRuntimeSession: { onOpenRuntimeSession(card.id) }
         )
     }
 }

--- a/Sources/KanbanCode/ListBoardView.swift
+++ b/Sources/KanbanCode/ListBoardView.swift
@@ -35,13 +35,14 @@ struct ListBoardView: View {
     var canDropCard: (KanbanCodeCard, KanbanCodeColumn) -> Bool = { _, _ in true }
     var onNewTask: () -> Void = {}
     var onCardClicked: (String) -> Void = { _ in }
+    var onOpenRuntimeSession: (String) -> Void = { _ in }
     var onRenameCard: (String, String) -> Void = { _, _ in } // (cardId, newName)
     var inSidebar: Bool = false
     @AppStorage("listBoardCollapsedColumns") private var collapsedColumnsRaw = ""
 
     private var sections: [ListBoardSection] {
         ListBoardSection.make(columns: store.state.visibleColumns) { column in
-            store.state.unpinnedCards(in: column)
+            store.state.codexBoardCards(in: column).filter { !$0.link.isPinned }
         }
     }
 
@@ -60,7 +61,7 @@ struct ListBoardView: View {
             set: { if !$0 { renamingPinnedCardId = nil } }
         )) {
             if let cardId = renamingPinnedCardId,
-               let card = store.state.pinnedCards.first(where: { $0.id == cardId }) {
+               let card = store.state.codexBoardCards.first(where: { $0.id == cardId && $0.link.isPinned }) {
                 RenameSessionDialog(
                     currentName: card.link.name ?? card.displayTitle,
                     isPresented: Binding(
@@ -96,7 +97,7 @@ struct ListBoardView: View {
 
     @ViewBuilder
     private var pinnedCardsSection: some View {
-        let cards = store.state.pinnedCards
+        let cards = store.state.codexBoardCards.filter(\.link.isPinned)
         if !cards.isEmpty {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
@@ -158,7 +159,8 @@ struct ListBoardView: View {
             onMoveToFolder: { onMoveToFolder(card.id) },
             enabledAssistants: enabledAssistants,
             onMigrateAssistant: { target in onMigrateAssistant(card.id, target) },
-            onRenameRequest: { renamingPinnedCardId = card.id }
+            onRenameRequest: { renamingPinnedCardId = card.id },
+            onOpenRuntimeSession: { onOpenRuntimeSession(card.id) }
         )
     }
 
@@ -257,6 +259,7 @@ struct ListBoardView: View {
                 store.dispatch(.reorderCard(cardId: cardId, targetCardId: targetCardId, above: above))
             },
             onRenameCard: onRenameCard,
+            onOpenRuntimeSession: onOpenRuntimeSession,
             onToggleCollapse: { toggleCollapse(for: section.column) }
         )
     }
@@ -308,16 +311,16 @@ struct ListBoardView: View {
 
     @ViewBuilder
     private var emptyStateOverlay: some View {
-        if store.state.filteredCards.isEmpty && !store.state.isLoading {
+        if store.state.codexBoardCards.isEmpty && !store.state.isLoading {
             VStack(spacing: 12) {
                 if let projectPath = store.state.selectedProjectPath {
                     let name = store.state.configuredProjects.first(where: { $0.path == projectPath })?.name
                         ?? (projectPath as NSString).lastPathComponent
-                    Text("No sessions yet for \(name)")
+                    Text("No \(store.state.codexBoardRuntime.boardLabel) sessions yet for \(name)")
                         .font(.app(.title3))
                         .foregroundStyle(.secondary)
                 } else {
-                    Text("No sessions found")
+                    Text("No \(store.state.codexBoardRuntime.boardLabel) sessions found")
                         .font(.app(.title3))
                         .foregroundStyle(.secondary)
                 }
@@ -364,6 +367,7 @@ private struct ListBoardSectionView: View {
     let canDropCard: (KanbanCodeCard, KanbanCodeColumn) -> Bool
     let onReorderCard: (String, String, Bool) -> Void
     let onRenameCard: (String, String) -> Void
+    let onOpenRuntimeSession: (String) -> Void
     @State private var renamingCardId: String?
     let onToggleCollapse: () -> Void
 
@@ -485,7 +489,8 @@ private struct ListBoardSectionView: View {
                         onMoveToFolder: { onMoveToFolder(card.id) },
                         enabledAssistants: enabledAssistants,
                         onMigrateAssistant: { target in onMigrateAssistant(card.id, target) },
-                        onRenameRequest: { renamingCardId = card.id }
+                        onRenameRequest: { renamingCardId = card.id },
+                        onOpenRuntimeSession: { onOpenRuntimeSession(card.id) }
                     )
                     .opacity(dragState.draggingCard?.id == card.id ? 0.65 : 1)
                     .overlay(
@@ -750,6 +755,7 @@ private struct ListCardRowView: View {
     var enabledAssistants: [CodingAssistant] = []
     var onMigrateAssistant: (CodingAssistant) -> Void = { _ in }
     var onRenameRequest: () -> Void = {}
+    var onOpenRuntimeSession: () -> Void = {}
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
@@ -776,6 +782,14 @@ private struct ListCardRowView: View {
                 // Row 2: metadata badges
                 HStack(spacing: 6) {
                     CardBadgesRow(card: card)
+
+                    if card.link.effectiveAssistant == .codex {
+                        Button(action: onOpenRuntimeSession) {
+                            RuntimeTelemetryBadge(executionBinding: card.link.executionBinding)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Open original Codex session")
+                    }
 
                     if let projectName = card.projectName {
                         Label(projectName, systemImage: "folder")
@@ -836,7 +850,8 @@ private struct ListCardRowView: View {
                     onDelete: onDelete,
                     onMoveToProject: onMoveToProject,
                     onMoveToFolder: onMoveToFolder,
-                    onMigrateAssistant: onMigrateAssistant
+                    onMigrateAssistant: onMigrateAssistant,
+                    onOpenRuntimeSession: onOpenRuntimeSession
                 ),
                 availableProjects: availableProjects,
                 enabledAssistants: enabledAssistants

--- a/Sources/KanbanCode/NewTaskDialog.swift
+++ b/Sources/KanbanCode/NewTaskDialog.swift
@@ -7,6 +7,7 @@ struct NewTaskDialog: View {
     var defaultProjectPath: String?
     var globalRemoteSettings: RemoteSettings?
     var enabledAssistants: [CodingAssistant] = CodingAssistant.allCases
+    var codexRuntime: CodexRuntimeBackend?
     /// (prompt, projectPath, title, startImmediately, images) — creates task without an assistant set
     var onCreate: (String, String?, String?, Bool, [ImageAttachment]) -> Void = { _, _, _, _, _ in }
     /// (prompt, projectPath, title, createWorktree, runRemotely, skipPermissions, commandOverride, images, assistant, apiServiceId) — creates and launches directly (skips LaunchConfirmation)
@@ -78,8 +79,22 @@ struct NewTaskDialog: View {
                 }
             }
 
+            if let codexRuntime {
+                HStack(spacing: 8) {
+                    Image(systemName: codexRuntime.boardSymbol)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Codex · \(codexRuntime.boardLabel)")
+                            .font(.app(.callout, weight: .semibold))
+                        Text("The task will be queued and claimed automatically.")
+                            .font(.app(.caption))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 8))
             // Assistant picker (when multiple enabled)
-            if startImmediately && enabledAssistants.count > 1 {
+            } else if startImmediately && enabledAssistants.count > 1 {
                 Picker("Assistant", selection: $selectedAssistantRaw) {
                     ForEach(enabledAssistants, id: \.self) { assistant in
                         Text(assistant.displayName).tag(assistant.rawValue)
@@ -105,11 +120,13 @@ struct NewTaskDialog: View {
             }
 
             // Start immediately toggle
-            Toggle("Start immediately", isOn: $startImmediately)
-                .font(.app(.callout))
+            if codexRuntime == nil {
+                Toggle("Start immediately", isOn: $startImmediately)
+                    .font(.app(.callout))
+            }
 
             // Launch options (shown when "Start immediately" is checked)
-            if startImmediately {
+            if startImmediately && codexRuntime == nil {
                 VStack(alignment: .leading, spacing: 6) {
                     Toggle("Create worktree", isOn: (isGitRepo && selectedAssistant.supportsWorktree) ? $createWorktree : .constant(false))
                         .font(.app(.callout))
@@ -182,7 +199,7 @@ struct NewTaskDialog: View {
                 }
                 .keyboardShortcut(.cancelAction)
 
-                Button(startImmediately ? "Create & Start" : "Create", action: submitForm)
+                Button(codexRuntime != nil || startImmediately ? "Create & Start" : "Create", action: submitForm)
                 .keyboardShortcut(.defaultAction)
                 .disabled(prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .buttonStyle(.borderedProminent)
@@ -191,6 +208,10 @@ struct NewTaskDialog: View {
         .padding(20)
         .frame(width: 450)
         .onAppear {
+            if codexRuntime != nil {
+                selectedAssistant = .codex
+                startImmediately = true
+            }
             if let defaultPath = defaultProjectPath,
                projects.contains(where: { $0.path == defaultPath }) {
                 selectedProjectPath = defaultPath
@@ -271,7 +292,7 @@ struct NewTaskDialog: View {
         let proj = resolvedProjectPath
         let titleOrNil = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : title.trimmingCharacters(in: .whitespacesAndNewlines)
         if let proj { lastSelectedProjectPath = proj }
-        if startImmediately {
+        if codexRuntime != nil || startImmediately {
             onCreateAndLaunch(
                 prompt,
                 proj,
@@ -281,7 +302,7 @@ struct NewTaskDialog: View {
                 dangerouslySkipPermissions,
                 commandEdited ? command : nil,
                 images,
-                selectedAssistant,
+                codexRuntime == nil ? selectedAssistant : .codex,
                 selectedServiceId
             )
         } else {

--- a/Sources/KanbanCode/OnboardingWizard.swift
+++ b/Sources/KanbanCode/OnboardingWizard.swift
@@ -25,6 +25,7 @@ struct OnboardingWizard: View {
     @State private var wizardServiceBaseURL: [CodingAssistant: String] = [:]
     @State private var wizardServiceSaved: Set<CodingAssistant> = []
     @State private var existingDefaultServiceIds: [String: String] = [:]
+    @State private var codexBoard = CodexBoardSettings()
 
     /// Steps are built dynamically: Welcome, Assistants, [per-assistant hooks...], Dependencies, Notifications, Complete.
     private var steps: [OnboardingStep] {
@@ -113,6 +114,7 @@ struct OnboardingWizard: View {
                         Task {
                             var settings = (try? await settingsStore.read()) ?? Settings()
                             settings.hasCompletedOnboarding = true
+                            settings.codexBoard = codexBoard
                             try? await settingsStore.write(settings)
                         }
                         onComplete()
@@ -126,6 +128,7 @@ struct OnboardingWizard: View {
         .task {
             await refreshStatus()
             if let settings = try? await settingsStore.read() {
+                codexBoard = settings.codexBoard
                 existingDefaultServiceIds = settings.defaultAPIServiceIds
                 for assistant in CodingAssistant.allCases {
                     guard let serviceId = settings.defaultAPIServiceIds[assistant.rawValue],
@@ -276,6 +279,26 @@ struct OnboardingWizard: View {
                 }
             }
 
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Codex task runtime")
+                    .font(.app(.callout, weight: .semibold))
+                Picker("Codex task runtime", selection: $codexBoard.runtime) {
+                    Text("Codex App")
+                        .tag(CodexRuntimeBackend.app)
+                        .disabled(status?.codexDesktopAvailable != true || status?.codexAppServerAvailable != true)
+                    Text("Codex CLI + tmux")
+                        .tag(CodexRuntimeBackend.cliTmux)
+                        .disabled(status?.codexAvailable != true || status?.tmuxAvailable != true)
+                }
+                .pickerStyle(.segmented)
+
+                Text(codexRuntimeHelp)
+                    .font(.app(.caption))
+                    .foregroundStyle(.secondary)
+            }
+
             let anyMissing = CodingAssistant.allCases.contains { assistant in
                 guard enabledAssistants.contains(assistant) else { return false }
                 switch assistant {
@@ -332,6 +355,23 @@ struct OnboardingWizard: View {
             Spacer()
         }
         .padding(24)
+    }
+
+    private var codexRuntimeHelp: String {
+        switch codexBoard.runtime {
+        case .app:
+            if status?.codexDesktopAvailable != true || status?.codexAppServerAvailable != true {
+                return "Codex App mode needs Codex.app plus a compatible `codex app-server` executable."
+            }
+            return "Tasks open as Codex desktop threads; managed approvals and lifecycle use App Server."
+        case .cliTmux:
+            if status?.codexAvailable != true || status?.tmuxAvailable != true {
+                return "CLI mode needs both `codex` and `tmux`. You can finish setup and install them later."
+            }
+            return "Tasks run in persistent tmux sessions and can be attached from the app or Terminal."
+        case .unknown:
+            return "Choose how newly queued Codex tasks should run."
+        }
     }
 
     // MARK: - Step: Hooks (per-assistant)

--- a/Sources/KanbanCode/SettingsView.swift
+++ b/Sources/KanbanCode/SettingsView.swift
@@ -598,6 +598,11 @@ struct GeneralSettingsView: View {
     @State private var showOnboarding = false
     @State private var mergeCommand: String = GitHubSettings.defaultMergeCommand
     @State private var mergeSaveTask: Task<Void, Never>?
+    @State private var codexBoard = CodexBoardSettings()
+    @State private var codexDependencyStatus: DependencyChecker.Status?
+    @State private var codexSettingsMessage: String?
+    @State private var codexSaveTask: Task<Void, Never>?
+    @State private var codexHooksInstalled = false
 
     private let settingsStore = SettingsStore()
 
@@ -654,6 +659,72 @@ struct GeneralSettingsView: View {
                 statusRow("GitHub CLI (gh)", available: ghAvailable)
             }
 
+            Section("Codex Board") {
+                Picker("Runtime", selection: Binding(
+                    get: { codexBoard.runtime },
+                    set: { selectCodexRuntime($0) }
+                )) {
+                    Text("Codex App").tag(CodexRuntimeBackend.app)
+                    Text("Codex CLI + tmux").tag(CodexRuntimeBackend.cliTmux)
+                }
+
+                HStack {
+                    Text("Managed concurrency")
+                    Spacer()
+                    Text("\(codexBoard.maxConcurrency)")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                    Stepper("", value: Binding(
+                        get: { codexBoard.maxConcurrency },
+                        set: {
+                            codexBoard.maxConcurrency = $0
+                            scheduleCodexSettingsSave()
+                        }
+                    ), in: CodexBoardSettings.concurrencyRange)
+                    .labelsHidden()
+                }
+
+                statusRow("Codex desktop navigation", available: codexDependencyStatus?.codexDesktopAvailable ?? false)
+                statusRow("Codex App Server", available: codexDependencyStatus?.codexAppServerAvailable ?? false)
+                statusRow("Codex CLI", available: codexDependencyStatus?.codexAvailable ?? false)
+                statusRow("tmux runtime", available: tmuxAvailable)
+
+                HStack {
+                    Label(
+                        "Lifecycle Hooks",
+                        systemImage: codexHooksInstalled ? "checkmark.circle.fill" : "minus.circle"
+                    )
+                    .foregroundStyle(codexHooksInstalled ? .green : .secondary)
+                    Spacer()
+                    if codexHooksInstalled {
+                        Button("Uninstall") { uninstallCodexHooks() }
+                            .controlSize(.small)
+                    } else {
+                        Button("Install…") { installCodexHooks() }
+                            .controlSize(.small)
+                    }
+                }
+
+                if let path = codexDependencyStatus?.codexExecutablePath {
+                    LabeledContent("Resolved executable") {
+                        Text(path)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                    }
+                    if let version = codexDependencyStatus?.codexVersion {
+                        LabeledContent("Version", value: version)
+                    }
+                }
+                if let codexSettingsMessage {
+                    Text(codexSettingsMessage)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+                Text("Switching runtime pauses only the hidden queue. Sessions that are already running continue and remain available in All Sessions.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Permissions") {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Agents launched by Kanban Code inherit Kanban Code's macOS privacy permissions. Grant Full Disk Access once to stop repeated prompts when agents read protected app data or new project folders.")
@@ -708,6 +779,13 @@ struct GeneralSettingsView: View {
                 .controlSize(.small)
             }
         }
+        .task {
+            if let settings = try? await settingsStore.read() {
+                codexBoard = settings.codexBoard
+            }
+            codexDependencyStatus = await DependencyChecker.checkAll(settingsStore: settingsStore)
+            codexHooksInstalled = codexHooksAreCurrent()
+        }
         .formStyle(.grouped)
         .padding()
         .onAppear {
@@ -725,6 +803,99 @@ struct GeneralSettingsView: View {
                     showOnboarding = false
                 }
             )
+        }
+    }
+
+    private func selectCodexRuntime(_ runtime: CodexRuntimeBackend) {
+        guard runtime != .unknown else { return }
+        let available: Bool
+        switch runtime {
+        case .app:
+            available = codexDependencyStatus?.codexDesktopAvailable == true
+                && codexDependencyStatus?.codexAppServerAvailable == true
+            if !available {
+                codexSettingsMessage = "Codex App mode requires both Codex.app and a compatible `codex app-server` executable."
+            }
+        case .cliTmux:
+            available = codexDependencyStatus?.codexAvailable == true && tmuxAvailable
+            if !available {
+                codexSettingsMessage = "Codex CLI + tmux mode requires both `codex` and `tmux`."
+            }
+        case .unknown:
+            available = false
+        }
+        guard available else { return }
+        codexSettingsMessage = nil
+        codexBoard.runtime = runtime
+        scheduleCodexSettingsSave()
+    }
+
+    private func scheduleCodexSettingsSave() {
+        codexSaveTask?.cancel()
+        let snapshot = codexBoard
+        codexSaveTask = Task {
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            do {
+                var settings = try await settingsStore.read()
+                settings.codexBoard = snapshot
+                try await settingsStore.write(settings)
+                NotificationCenter.default.post(name: .kanbanCodeSettingsChanged, object: nil)
+            } catch {
+                await MainActor.run { codexSettingsMessage = error.localizedDescription }
+            }
+        }
+    }
+
+    private func installCodexHooks() {
+        do {
+            let executableDirectory = Bundle.main.executableURL?.deletingLastPathComponent()
+            let bundled = Bundle.main.bundleURL
+                .appendingPathComponent("Contents/Helpers/kanban-code-lifecycle").path
+            let development = executableDirectory?
+                .appendingPathComponent("kanban-code-lifecycle").path
+            let source = FileManager.default.isExecutableFile(atPath: bundled) ? bundled : development
+            guard let source else {
+                codexSettingsMessage = "The lifecycle helper is missing. Rebuild the app bundle and try again."
+                return
+            }
+            let expectedHash: String
+            let manifest = Bundle.main.bundleURL
+                .appendingPathComponent("Contents/Resources/codex-lifecycle.sha256").path
+            if let signedHash = try? String(contentsOfFile: manifest, encoding: .utf8), !signedHash.isEmpty {
+                expectedHash = signedHash
+            } else {
+                // SwiftPM development builds have no signed app bundle yet.
+                expectedHash = try CodexHookInstaller.sha256(path: source)
+            }
+            let installedPath = try CodexHookInstaller.deployHelper(
+                from: source,
+                expectedSHA256: expectedHash
+            )
+            try CodexHookInstaller.install(helperPath: installedPath)
+            codexHooksInstalled = true
+            codexSettingsMessage = "Lifecycle Hooks installed. Existing Codex configuration was preserved and backed up."
+        } catch {
+            codexSettingsMessage = "Could not install Lifecycle Hooks: \(error.localizedDescription)"
+        }
+    }
+
+    private func codexHooksAreCurrent() -> Bool {
+        let manifest = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Resources/codex-lifecycle.sha256").path
+        guard let expected = try? String(contentsOfFile: manifest, encoding: .utf8) else {
+            return CodexHookInstaller.isInstalled()
+        }
+        return CodexHookInstaller.isInstalled(expectedHelperSHA256: expected)
+    }
+
+    private func uninstallCodexHooks() {
+        do {
+            try CodexHookInstaller.uninstall()
+            codexHooksInstalled = false
+            codexSettingsMessage = "Kanban Code Lifecycle Hooks were removed; unrelated Codex hooks were preserved."
+        } catch {
+            codexSettingsMessage = "Could not uninstall Lifecycle Hooks: \(error.localizedDescription)"
         }
     }
 

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerClient.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerClient.swift
@@ -1,0 +1,443 @@
+import Foundation
+
+/// Minimal newline-delimited transport boundary for `codex app-server`.
+/// A Process-backed implementation can be added without coupling protocol tests
+/// or the client actor to Foundation.Process lifecycle details.
+public protocol CodexAppServerLineTransport: Sendable {
+    func writeLine(_ line: String) async throws
+    func readLine() async throws -> String?
+}
+
+public enum CodexAppServerClientError: Error, LocalizedError, Sendable, Equatable {
+    case disconnected
+    case requestTimedOut(method: String)
+    case remoteError(code: Int, message: String)
+    case invalidResponse(method: String)
+    case serverRequestNotPending
+
+    public var errorDescription: String? {
+        switch self {
+        case .disconnected:
+            "Codex App Server disconnected"
+        case .requestTimedOut(let method):
+            "Codex App Server request timed out: \(method)"
+        case .remoteError(let code, let message):
+            "Codex App Server error \(code): \(message)"
+        case .invalidResponse(let method):
+            "Codex App Server returned an invalid response for \(method)"
+        case .serverRequestNotPending:
+            "Codex App Server request is no longer pending"
+        }
+    }
+}
+
+/// Actor-isolated JSON-RPC client for the Codex App Server protocol.
+///
+/// The actor owns request correlation and connection generation. A response or
+/// server request from an older generation can never complete current work.
+public actor CodexAppServerClient {
+    public static let defaultServerRequestMethods: Set<String> = [
+        "item/commandExecution/requestApproval",
+        "item/fileChange/requestApproval",
+        "item/permissions/requestApproval",
+        "item/tool/requestUserInput",
+    ]
+
+    public private(set) var generation: UInt64 = 0
+
+    public var isConnected: Bool { readerTask != nil }
+
+    private let transport: any CodexAppServerLineTransport
+    private let requestTimeout: Duration
+    private let allowedServerRequestMethods: Set<String>
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private var nextRequestID = 0
+    private var readerTask: Task<Void, Never>?
+    private var pendingRequests: [Int: PendingRequest] = [:]
+    private var initializeResult: CodexInitializeResult?
+    private var pendingServerRequests: [CodexRPCIdentifier: UInt64] = [:]
+    private var notificationContinuations: [UUID: AsyncStream<CodexAppServerNotification>.Continuation] = [:]
+    private var serverRequestContinuations: [UUID: AsyncStream<CodexAppServerRequest>.Continuation] = [:]
+
+    public init(
+        transport: any CodexAppServerLineTransport,
+        requestTimeout: Duration = .seconds(10),
+        allowedServerRequestMethods: Set<String> = CodexAppServerClient.defaultServerRequestMethods
+    ) {
+        self.transport = transport
+        self.requestTimeout = requestTimeout
+        self.allowedServerRequestMethods = allowedServerRequestMethods
+    }
+
+    deinit {
+        readerTask?.cancel()
+        for pending in pendingRequests.values {
+            pending.timeoutTask.cancel()
+            pending.continuation.resume(throwing: CodexAppServerClientError.disconnected)
+        }
+        for continuation in notificationContinuations.values { continuation.finish() }
+        for continuation in serverRequestContinuations.values { continuation.finish() }
+    }
+
+    /// Begin consuming inbound lines. Calling this repeatedly is idempotent.
+    public func start() {
+        guard readerTask == nil else { return }
+        if generation == 0 { generation = 1 }
+        startReader(for: generation)
+    }
+
+    /// End the current generation and fail every outstanding request.
+    public func disconnect() {
+        advanceGeneration()
+    }
+
+    /// Start a fresh protocol generation on the same reconnectable transport.
+    /// Future Process-backed transports can swap their underlying pipes before
+    /// invoking this method.
+    public func beginNewGeneration() {
+        advanceGeneration()
+        startReader(for: generation)
+    }
+
+    public func notifications() -> AsyncStream<CodexAppServerNotification> {
+        let token = UUID()
+        return AsyncStream(bufferingPolicy: .bufferingNewest(256)) { continuation in
+            notificationContinuations[token] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeNotificationContinuation(token) }
+            }
+        }
+    }
+
+    public func serverRequests() -> AsyncStream<CodexAppServerRequest> {
+        let token = UUID()
+        return AsyncStream { continuation in
+            serverRequestContinuations[token] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeServerRequestContinuation(token) }
+            }
+        }
+    }
+
+    @discardableResult
+    public func initialize(clientName: String, clientVersion: String) async throws -> CodexInitializeResult {
+        if let initializeResult { return initializeResult }
+        let params: CodexJSONValue = .object([
+            "clientInfo": .object([
+                "name": .string(clientName),
+                "version": .string(clientVersion),
+            ]),
+            "capabilities": .object([:]),
+        ])
+        let result: CodexInitializeResult = try await request(method: "initialize", params: params)
+        try await sendNotification(method: "initialized", params: .object([:]))
+        initializeResult = result
+        return result
+    }
+
+    public func listThreads(
+        cursor: String? = nil,
+        limit: Int? = nil,
+        sourceKinds: [String]? = nil,
+        archived: Bool? = nil
+    ) async throws -> CodexThreadListResponse {
+        var params: [String: CodexJSONValue] = [:]
+        if let cursor { params["cursor"] = .string(cursor) }
+        if let limit { params["limit"] = .number(Double(limit)) }
+        if let sourceKinds { params["sourceKinds"] = .array(sourceKinds.map(CodexJSONValue.string)) }
+        if let archived { params["archived"] = .bool(archived) }
+        return try await request(method: "thread/list", params: .object(params))
+    }
+
+    public func startThread(
+        cwd: String? = nil,
+        approvalPolicy: String? = nil,
+        sandbox: CodexJSONValue? = nil
+    ) async throws -> CodexThread {
+        var params: [String: CodexJSONValue] = [:]
+        if let cwd { params["cwd"] = .string(cwd) }
+        if let approvalPolicy { params["approvalPolicy"] = .string(approvalPolicy) }
+        if let sandbox { params["sandbox"] = sandbox }
+        let value = try await requestValue(method: "thread/start", params: .object(params))
+        return try decodeEnvelopeOrValue(CodexThreadEnvelope.self, CodexThread.self, from: value, method: "thread/start") { $0.thread }
+    }
+
+    public func resumeThread(id: String) async throws -> CodexThread {
+        let value = try await requestValue(
+            method: "thread/resume",
+            params: .object(["threadId": .string(id)])
+        )
+        return try decodeEnvelopeOrValue(CodexThreadEnvelope.self, CodexThread.self, from: value, method: "thread/resume") { $0.thread }
+    }
+
+    public func startTurn(threadID: String, text: String) async throws -> CodexTurn {
+        let value = try await requestValue(
+            method: "turn/start",
+            params: .object([
+                "threadId": .string(threadID),
+                "input": textInput(text),
+            ])
+        )
+        return try decodeEnvelopeOrValue(CodexTurnEnvelope.self, CodexTurn.self, from: value, method: "turn/start") { $0.turn }
+    }
+
+    public func steerTurn(threadID: String, turnID: String, text: String) async throws -> String {
+        struct Response: Decodable { let turnId: String }
+        let response: Response = try await request(
+            method: "turn/steer",
+            params: .object([
+                "threadId": .string(threadID),
+                "expectedTurnId": .string(turnID),
+                "input": textInput(text),
+            ])
+        )
+        return response.turnId
+    }
+
+    public func respond(to request: CodexAppServerRequest, result: CodexJSONValue) async throws {
+        guard request.generation == generation,
+              request.method.isEmpty == false,
+              allowedServerRequestMethods.contains(request.method),
+              pendingServerRequests[request.id] == generation
+        else {
+            throw CodexAppServerClientError.serverRequestNotPending
+        }
+
+        pendingServerRequests.removeValue(forKey: request.id)
+        try await write(.object([
+            "jsonrpc": .string("2.0"),
+            "id": request.id.jsonValue,
+            "result": result,
+        ]))
+    }
+
+    private func textInput(_ text: String) -> CodexJSONValue {
+        .array([.object(["type": .string("text"), "text": .string(text)])])
+    }
+
+    private func request<Response: Decodable>(method: String, params: CodexJSONValue) async throws -> Response {
+        let value = try await requestValue(method: method, params: params)
+        do {
+            return try decode(Response.self, from: value)
+        } catch {
+            throw CodexAppServerClientError.invalidResponse(method: method)
+        }
+    }
+
+    private func requestValue(method: String, params: CodexJSONValue) async throws -> CodexJSONValue {
+        start()
+        nextRequestID += 1
+        let id = nextRequestID
+        let requestGeneration = generation
+        let message: CodexJSONValue = .object([
+            "jsonrpc": .string("2.0"),
+            "id": .number(Double(id)),
+            "method": .string(method),
+            "params": params,
+        ])
+        let line: String
+        do {
+            line = try encodeLine(message)
+        } catch {
+            throw CodexAppServerClientError.invalidResponse(method: method)
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let timeoutTask = Task { [weak self, requestTimeout] in
+                    do {
+                        try await Task.sleep(for: requestTimeout)
+                    } catch {
+                        return
+                    }
+                    await self?.expireRequest(id: id, generation: requestGeneration)
+                }
+                pendingRequests[id] = PendingRequest(
+                    method: method,
+                    generation: requestGeneration,
+                    continuation: continuation,
+                    timeoutTask: timeoutTask
+                )
+                Task { [weak self, transport] in
+                    do {
+                        try await transport.writeLine(line)
+                    } catch {
+                        await self?.transportEnded(generation: requestGeneration)
+                    }
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.failRequest(id: id, generation: requestGeneration, error: CancellationError())
+            }
+        }
+    }
+
+    private func sendNotification(method: String, params: CodexJSONValue) async throws {
+        start()
+        try await write(.object([
+            "jsonrpc": .string("2.0"),
+            "method": .string(method),
+            "params": params,
+        ]))
+    }
+
+    private func startReader(for readerGeneration: UInt64) {
+        let transport = self.transport
+        readerTask = Task { [weak self] in
+            do {
+                while !Task.isCancelled {
+                    guard let line = try await transport.readLine() else {
+                        await self?.transportEnded(generation: readerGeneration)
+                        return
+                    }
+                    await self?.handle(line: line, generation: readerGeneration)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                await self?.transportEnded(generation: readerGeneration)
+            }
+        }
+    }
+
+    private func handle(line: String, generation messageGeneration: UInt64) async {
+        guard messageGeneration == generation,
+              let data = line.data(using: .utf8),
+              let message = try? decoder.decode(CodexRPCMessage.self, from: data)
+        else { return }
+
+        if let method = message.method {
+            if let id = message.id {
+                if allowedServerRequestMethods.contains(method) {
+                    pendingServerRequests[id] = messageGeneration
+                    let request = CodexAppServerRequest(
+                        id: id,
+                        method: method,
+                        params: message.params ?? .object([:]),
+                        generation: messageGeneration
+                    )
+                    for continuation in serverRequestContinuations.values {
+                        continuation.yield(request)
+                    }
+                } else {
+                    try? await sendRPCError(id: id, code: -32601, message: "Method not found")
+                }
+            } else {
+                let notification = CodexAppServerNotification(
+                    method: method,
+                    params: message.params ?? .object([:]),
+                    generation: messageGeneration
+                )
+                for continuation in notificationContinuations.values {
+                    continuation.yield(notification)
+                }
+            }
+            return
+        }
+
+        guard let id = message.id?.integerValue,
+              let pending = pendingRequests.removeValue(forKey: id),
+              pending.generation == messageGeneration
+        else { return }
+        pending.timeoutTask.cancel()
+        if let error = message.error {
+            pending.continuation.resume(throwing: CodexAppServerClientError.remoteError(code: error.code, message: error.message))
+        } else {
+            pending.continuation.resume(returning: message.result ?? .null)
+        }
+    }
+
+    private func sendRPCError(id: CodexRPCIdentifier, code: Int, message: String) async throws {
+        try await write(.object([
+            "jsonrpc": .string("2.0"),
+            "id": id.jsonValue,
+            "error": .object([
+                "code": .number(Double(code)),
+                "message": .string(message),
+            ]),
+        ]))
+    }
+
+    private func expireRequest(id: Int, generation requestGeneration: UInt64) {
+        guard let pending = pendingRequests[id], pending.generation == requestGeneration else { return }
+        pendingRequests.removeValue(forKey: id)
+        pending.continuation.resume(throwing: CodexAppServerClientError.requestTimedOut(method: pending.method))
+    }
+
+    private func failRequest(id: Int, generation requestGeneration: UInt64, error: any Error) {
+        guard let pending = pendingRequests[id], pending.generation == requestGeneration else { return }
+        pendingRequests.removeValue(forKey: id)
+        pending.timeoutTask.cancel()
+        pending.continuation.resume(throwing: error)
+    }
+
+    private func transportEnded(generation endedGeneration: UInt64) {
+        guard endedGeneration == generation else { return }
+        advanceGeneration()
+    }
+
+    private func advanceGeneration() {
+        generation = max(1, generation &+ 1)
+        nextRequestID = 0
+        readerTask?.cancel()
+        readerTask = nil
+        pendingServerRequests.removeAll()
+        initializeResult = nil
+
+        let pending = pendingRequests.values
+        pendingRequests.removeAll()
+        for request in pending {
+            request.timeoutTask.cancel()
+            request.continuation.resume(throwing: CodexAppServerClientError.disconnected)
+        }
+    }
+
+    private func write(_ value: CodexJSONValue) async throws {
+        do {
+            try await transport.writeLine(encodeLine(value))
+        } catch {
+            advanceGeneration()
+            throw CodexAppServerClientError.disconnected
+        }
+    }
+
+    private func encodeLine(_ value: CodexJSONValue) throws -> String {
+        let data = try encoder.encode(value)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func decode<Value: Decodable>(_ type: Value.Type, from value: CodexJSONValue) throws -> Value {
+        let data = try encoder.encode(value)
+        return try decoder.decode(type, from: data)
+    }
+
+    private func decodeEnvelopeOrValue<Envelope: Decodable, Value: Decodable>(
+        _ envelopeType: Envelope.Type,
+        _ valueType: Value.Type,
+        from value: CodexJSONValue,
+        method: String,
+        unwrap: (Envelope) -> Value
+    ) throws -> Value {
+        if let envelope = try? decode(envelopeType, from: value) { return unwrap(envelope) }
+        if let direct = try? decode(valueType, from: value) { return direct }
+        throw CodexAppServerClientError.invalidResponse(method: method)
+    }
+
+    private func removeNotificationContinuation(_ token: UUID) {
+        notificationContinuations.removeValue(forKey: token)
+    }
+
+    private func removeServerRequestContinuation(_ token: UUID) {
+        serverRequestContinuations.removeValue(forKey: token)
+    }
+}
+
+private struct PendingRequest {
+    let method: String
+    let generation: UInt64
+    let continuation: CheckedContinuation<CodexJSONValue, any Error>
+    let timeoutTask: Task<Void, Never>
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerConnection.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerConnection.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// One app-wide App Server process shared by discovery and managed launches.
+/// The process transport is retained by the client for the app lifetime.
+public actor CodexAppServerConnection {
+    public typealias ClientFactory = @Sendable () async throws -> CodexAppServerClient
+
+    public static let shared = CodexAppServerConnection()
+
+    private var connectedClient: CodexAppServerClient?
+    private var connectingTask: Task<CodexAppServerClient, Error>?
+    private let makeClient: ClientFactory
+
+    public init() {
+        self.makeClient = CodexAppServerConnection.launchClient
+    }
+
+    public init(makeClient: @escaping ClientFactory) {
+        self.makeClient = makeClient
+    }
+
+    public func client() async throws -> CodexAppServerClient {
+        if let connectedClient, await connectedClient.isConnected { return connectedClient }
+        if let connectingTask { return try await connectingTask.value }
+        if let connectedClient { await connectedClient.disconnect() }
+        self.connectedClient = nil
+
+        let task = Task { try await makeClient() }
+        connectingTask = task
+        do {
+            let client = try await task.value
+            connectedClient = client
+            connectingTask = nil
+            return client
+        } catch {
+            connectingTask = nil
+            throw error
+        }
+    }
+
+    private static func launchClient() async throws -> CodexAppServerClient {
+        let identity = try CodexExecutableResolver.resolve()
+        let daemonStart = try? await ShellCommand.run(
+            identity.url.path,
+            arguments: ["app-server", "daemon", "start"]
+        )
+        let processArguments = daemonStart?.succeeded == true
+            ? ["app-server", "proxy"]
+            : ["app-server"]
+        let transport = try CodexAppServerProcessTransport.launch(
+            executable: identity.url,
+            arguments: processArguments
+        )
+        let client = CodexAppServerClient(transport: transport)
+        await client.start()
+        _ = try await client.initialize(clientName: "kanban-code", clientVersion: "0.1.1")
+        return client
+    }
+}
+
+/// Merges local rollout metadata with App Server identity/provenance. Local
+/// discovery remains available when the installed Codex protocol is absent.
+public actor CodexHybridSessionDiscovery: SessionDiscovery {
+    private let local: CodexSessionDiscovery
+    private let connection: CodexAppServerConnection
+    private var appServer: CodexAppServerSessionDiscovery?
+
+    public init(
+        local: CodexSessionDiscovery = CodexSessionDiscovery(),
+        connection: CodexAppServerConnection = .shared
+    ) {
+        self.local = local
+        self.connection = connection
+    }
+
+    public func discoverSessions() async throws -> [Session] {
+        let localSessions = try await local.discoverSessions()
+        do {
+            let discovery: CodexAppServerSessionDiscovery
+            if let appServer {
+                discovery = appServer
+            } else {
+                discovery = CodexAppServerSessionDiscovery(client: try await connection.client())
+                appServer = discovery
+            }
+            let appSessions = try await discovery.discoverSessions()
+            var merged = Dictionary(uniqueKeysWithValues: localSessions.map { ($0.id, $0) })
+            for appSession in appSessions {
+                if let localSession = merged[appSession.id] {
+                    var enriched = appSession
+                    enriched.jsonlPath = localSession.jsonlPath
+                    enriched.messageCount = localSession.messageCount
+                    enriched.modifiedTime = localSession.modifiedTime
+                    enriched.firstPrompt = appSession.firstPrompt ?? localSession.firstPrompt
+                    enriched.projectPath = appSession.projectPath ?? localSession.projectPath
+                    merged[appSession.id] = enriched
+                } else {
+                    merged[appSession.id] = appSession
+                }
+            }
+            return merged.values.sorted { $0.modifiedTime > $1.modifiedTime }
+        } catch {
+            return localSessions
+        }
+    }
+
+    public func discoverNewOrModified(since: Date) async throws -> [Session] {
+        try await discoverSessions().filter { $0.modifiedTime > since }
+    }
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerModels.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerModels.swift
@@ -1,0 +1,302 @@
+import Foundation
+
+/// JSON value used at the App Server protocol boundary. Keeping unknown fields
+/// as values lets newer servers add payload data without breaking older clients.
+public enum CodexJSONValue: Codable, Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([CodexJSONValue])
+    case object([String: CodexJSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([CodexJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: CodexJSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+
+    public subscript(key: String) -> CodexJSONValue? {
+        guard case .object(let object) = self else { return nil }
+        return object[key]
+    }
+
+    public var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+}
+
+public enum CodexRPCIdentifier: Codable, Sendable, Hashable, Equatable {
+    case integer(Int)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Int.self) {
+            self = .integer(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "JSON-RPC id must be an integer or string")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .integer(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        }
+    }
+
+    public var jsonValue: CodexJSONValue {
+        switch self {
+        case .integer(let value): .number(Double(value))
+        case .string(let value): .string(value)
+        }
+    }
+
+    var integerValue: Int? {
+        guard case .integer(let value) = self else { return nil }
+        return value
+    }
+}
+
+public struct CodexRPCError: Codable, Sendable, Equatable, Error {
+    public let code: Int
+    public let message: String
+    public let data: CodexJSONValue?
+
+    public init(code: Int, message: String, data: CodexJSONValue? = nil) {
+        self.code = code
+        self.message = message
+        self.data = data
+    }
+}
+
+public struct CodexInitializeResult: Decodable, Sendable, Equatable {
+    public let userAgent: String?
+    public let protocolVersion: String?
+    public let capabilities: CodexJSONValue?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        userAgent = try container.decodeIfPresent(String.self, forKey: "userAgent")
+        protocolVersion = try container.decodeLossyStringIfPresent(forKey: "protocolVersion")
+        capabilities = try container.decodeIfPresent(CodexJSONValue.self, forKey: "capabilities")
+    }
+}
+
+/// Tolerant representation of App Server's evolving thread status shape.
+public struct CodexThreadStatus: Decodable, Sendable, Equatable {
+    public let type: String
+    public let activeFlags: [String]
+    private let explicitWaitingOnApproval: Bool?
+
+    public var waitingOnApproval: Bool {
+        explicitWaitingOnApproval == true
+            || type == "waitingOnApproval"
+            || activeFlags.contains("waitingOnApproval")
+    }
+
+    public var waitingOnUserInput: Bool {
+        type == "waitingOnUserInput" || activeFlags.contains("waitingOnUserInput")
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(),
+           let value = try? single.decode(String.self) {
+            type = value
+            activeFlags = []
+            explicitWaitingOnApproval = nil
+            return
+        }
+
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        let primaryType = try container.decodeIfPresent(String.self, forKey: "type")
+        let fallbackType = try container.decodeIfPresent(String.self, forKey: "status")
+        type = primaryType ?? fallbackType ?? "unknown"
+        let camelFlags = try container.decodeIfPresent([String].self, forKey: "activeFlags")
+        let snakeFlags = try container.decodeIfPresent([String].self, forKey: "active_flags")
+        activeFlags = camelFlags ?? snakeFlags ?? []
+        let camelWaiting = try container.decodeIfPresent(Bool.self, forKey: "waitingOnApproval")
+        let snakeWaiting = try container.decodeIfPresent(Bool.self, forKey: "waiting_on_approval")
+        explicitWaitingOnApproval = camelWaiting ?? snakeWaiting
+    }
+}
+
+public struct CodexThread: Decodable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String?
+    public let preview: String?
+    public let cwd: String?
+    public let sourceKinds: [String]
+    public let status: CodexThreadStatus?
+    public let archived: Bool?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        id = try container.decode(String.self, forKey: "id")
+        name = try container.decodeIfPresent(String.self, forKey: "name")
+        preview = try container.decodeIfPresent(String.self, forKey: "preview")
+        cwd = try container.decodeIfPresent(String.self, forKey: "cwd")
+        status = try container.decodeIfPresent(CodexThreadStatus.self, forKey: "status")
+        archived = try container.decodeIfPresent(Bool.self, forKey: "archived")
+
+        if let values = try? container.decode([String].self, forKey: "sourceKinds") {
+            sourceKinds = values
+        } else if let value = try? container.decode(String.self, forKey: "sourceKind") {
+            sourceKinds = [value]
+        } else if let value = try? container.decode(String.self, forKey: "source") {
+            sourceKinds = [value]
+        } else {
+            sourceKinds = []
+        }
+    }
+}
+
+public struct CodexThreadListResponse: Decodable, Sendable, Equatable {
+    public let data: [CodexThread]
+    public let nextCursor: String?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        let dataValue = try container.decodeIfPresent([CodexThread].self, forKey: "data")
+        let threadsValue = try container.decodeIfPresent([CodexThread].self, forKey: "threads")
+        data = dataValue ?? threadsValue ?? []
+        nextCursor = try container.decodeIfPresent(String.self, forKey: "nextCursor")
+    }
+}
+
+public struct CodexTurn: Decodable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let threadID: String?
+    public let status: String?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        id = try container.decode(String.self, forKey: "id")
+        let camelThreadID = try container.decodeIfPresent(String.self, forKey: "threadId")
+        let snakeThreadID = try container.decodeIfPresent(String.self, forKey: "thread_id")
+        threadID = camelThreadID ?? snakeThreadID
+        status = try container.decodeIfPresent(String.self, forKey: "status")
+    }
+}
+
+public struct CodexThreadStatusChanged: Decodable, Sendable, Equatable {
+    public let threadID: String
+    public let status: CodexThreadStatus
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        let camelThreadID = try container.decodeIfPresent(String.self, forKey: "threadId")
+        threadID = try camelThreadID ?? container.decode(String.self, forKey: "thread_id")
+        status = try container.decode(CodexThreadStatus.self, forKey: "status")
+    }
+}
+
+public struct CodexAppServerNotification: Sendable, Equatable {
+    public let method: String
+    public let params: CodexJSONValue
+    public let generation: UInt64
+
+    public func decodeParams<Value: Decodable>(as type: Value.Type) throws -> Value {
+        let data = try JSONEncoder().encode(params)
+        return try JSONDecoder().decode(type, from: data)
+    }
+}
+
+public struct CodexAppServerRequest: Sendable, Equatable {
+    public let id: CodexRPCIdentifier
+    public let method: String
+    public let params: CodexJSONValue
+    public let generation: UInt64
+
+    public func decodeParams<Value: Decodable>(as type: Value.Type) throws -> Value {
+        let data = try JSONEncoder().encode(params)
+        return try JSONDecoder().decode(type, from: data)
+    }
+}
+
+struct CodexRPCMessage: Decodable {
+    let id: CodexRPCIdentifier?
+    let method: String?
+    let params: CodexJSONValue?
+    let result: CodexJSONValue?
+    let error: CodexRPCError?
+}
+
+struct CodexThreadEnvelope: Decodable {
+    let thread: CodexThread
+}
+
+struct CodexTurnEnvelope: Decodable {
+    let turn: CodexTurn
+}
+
+struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        stringValue = String(intValue)
+        self.intValue = intValue
+    }
+
+    static func key(_ value: String) -> DynamicCodingKey {
+        DynamicCodingKey(stringValue: value)!
+    }
+}
+
+private extension KeyedDecodingContainer where Key == DynamicCodingKey {
+    func decode<T: Decodable>(_ type: T.Type, forKey key: String) throws -> T {
+        try decode(type, forKey: .key(key))
+    }
+
+    func decodeIfPresent<T: Decodable>(_ type: T.Type, forKey key: String) throws -> T? {
+        try decodeIfPresent(type, forKey: .key(key))
+    }
+
+    func decodeLossyStringIfPresent(forKey key: String) throws -> String? {
+        if let string = try? decode(String.self, forKey: key) { return string }
+        if let number = try? decode(Int.self, forKey: key) { return String(number) }
+        return nil
+    }
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerProcessTransport.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerProcessTransport.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+public enum CodexExecutableError: Error, LocalizedError, Sendable, Equatable {
+    case notFound
+    case notExecutable(String)
+    case projectLocalShadow(String)
+    case capabilityProbeFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notFound: "Codex executable was not found"
+        case .notExecutable(let path): "Codex is not executable: \(path)"
+        case .projectLocalShadow(let path): "Refusing project-local Codex executable: \(path)"
+        case .capabilityProbeFailed(let details): "Codex App Server capability probe failed: \(details)"
+        }
+    }
+}
+
+public struct CodexExecutableIdentity: Sendable, Equatable {
+    public let url: URL
+    public let version: String
+    public let isStandardLocation: Bool
+}
+
+/// Resolves and probes a stable absolute Codex binary. PATH is inspected only
+/// during explicit setup; execution always retains the resolved absolute URL.
+public enum CodexExecutableResolver {
+    public static func resolve(
+        configuredPath: String? = nil,
+        environmentPath: String? = ProcessInfo.processInfo.environment["PATH"],
+        projectRoot: String? = nil
+    ) throws -> CodexExecutableIdentity {
+        let candidates = candidateURLs(configuredPath: configuredPath, environmentPath: environmentPath)
+        let fileManager = FileManager.default
+        for candidate in candidates {
+            let resolved = candidate.resolvingSymlinksInPath().standardizedFileURL
+            guard fileManager.fileExists(atPath: resolved.path) else { continue }
+            guard fileManager.isExecutableFile(atPath: resolved.path) else {
+                if configuredPath != nil { throw CodexExecutableError.notExecutable(resolved.path) }
+                continue
+            }
+            if let projectRoot {
+                let project = URL(fileURLWithPath: projectRoot, isDirectory: true)
+                if isProjectLocal(executable: resolved, projectRoot: project) {
+                    throw CodexExecutableError.projectLocalShadow(resolved.path)
+                }
+            }
+
+            let version = try runProbe(executable: resolved, arguments: ["--version"])
+            _ = try runProbe(executable: resolved, arguments: ["app-server", "--help"])
+            let standardPrefixes = ["/usr/local/", "/opt/homebrew/", "/Applications/", "/Users/Shared/"]
+            return CodexExecutableIdentity(
+                url: resolved,
+                version: version.trimmingCharacters(in: .whitespacesAndNewlines),
+                isStandardLocation: standardPrefixes.contains { resolved.path.hasPrefix($0) }
+            )
+        }
+        throw CodexExecutableError.notFound
+    }
+
+    public static func isProjectLocal(executable: URL, projectRoot: URL) -> Bool {
+        let executablePath = executable.resolvingSymlinksInPath().standardizedFileURL.path
+        let rootPath = projectRoot.resolvingSymlinksInPath().standardizedFileURL.path
+        return executablePath == rootPath || executablePath.hasPrefix(rootPath + "/")
+    }
+
+    private static func candidateURLs(configuredPath: String?, environmentPath: String?) -> [URL] {
+        var paths: [String] = []
+        if let configuredPath, !configuredPath.isEmpty { paths.append(configuredPath) }
+        paths.append(contentsOf: [
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex",
+        ])
+        if let environmentPath {
+            paths.append(contentsOf: environmentPath.split(separator: ":").map { "\($0)/codex" })
+        }
+        var seen = Set<String>()
+        return paths.compactMap { path in
+            let expanded = (path as NSString).expandingTildeInPath
+            guard seen.insert(expanded).inserted else { return nil }
+            return URL(fileURLWithPath: expanded)
+        }
+    }
+
+    private static func runProbe(executable: URL, arguments: [String]) throws -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = stderr
+        process.environment = safeEnvironment()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw CodexExecutableError.capabilityProbeFailed(error.localizedDescription)
+        }
+        let output = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errorOutput = stderr.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let details = String(decoding: errorOutput, as: UTF8.self)
+            throw CodexExecutableError.capabilityProbeFailed(details.isEmpty ? "exit \(process.terminationStatus)" : details)
+        }
+        return String(decoding: output.isEmpty ? errorOutput : output, as: UTF8.self)
+    }
+
+    fileprivate static func safeEnvironment() -> [String: String] {
+        let environment = ProcessInfo.processInfo.environment
+        let allowedKeys = ["HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "TERM", "USER", "LOGNAME"]
+        return Dictionary(uniqueKeysWithValues: allowedKeys.compactMap { key in
+            environment[key].map { (key, $0) }
+        })
+    }
+}
+
+public enum CodexAppServerProcessError: Error, LocalizedError, Sendable {
+    case notRunning
+    case invalidUTF8
+    case lineTooLarge
+
+    public var errorDescription: String? {
+        switch self {
+        case .notRunning: "Codex App Server process is not running"
+        case .invalidUTF8: "Codex App Server emitted invalid UTF-8"
+        case .lineTooLarge: "Codex App Server emitted a JSON-RPC line larger than 1 MiB"
+        }
+    }
+}
+
+/// Process-backed line transport. Reads run on a dedicated blocking task so a
+/// pending stdout read never prevents JSON-RPC writes from reaching stdin.
+public final class CodexAppServerProcessTransport: CodexAppServerLineTransport, @unchecked Sendable {
+    private static let maximumLineBytes = 1_048_576
+    private let process: Process
+    private let input: FileHandle
+    private let output: FileHandle
+    private let writeLock = NSLock()
+    private let readLock = NSLock()
+    private var readBuffer = Data()
+
+    private init(process: Process, input: FileHandle, output: FileHandle) {
+        self.process = process
+        self.input = input
+        self.output = output
+    }
+
+    deinit {
+        try? input.close()
+        try? output.close()
+        if process.isRunning { process.terminate() }
+    }
+
+    public static func launch(
+        executable: URL,
+        arguments: [String] = ["app-server"],
+        workingDirectory: URL? = nil,
+        environment: [String: String]? = nil
+    ) throws -> CodexAppServerProcessTransport {
+        let runtimeDirectory = workingDirectory ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".kanban-code/runtime", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: runtimeDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let process = Process()
+        process.executableURL = executable.resolvingSymlinksInPath()
+        process.arguments = arguments
+        process.currentDirectoryURL = runtimeDirectory
+        process.environment = environment ?? CodexExecutableResolver.safeEnvironment()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        // Keep protocol stdout isolated from diagnostics. A companion can drain
+        // and rotate this pipe; the direct development transport discards it.
+        process.standardError = stderr
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            _ = handle.availableData
+        }
+        try process.run()
+        return CodexAppServerProcessTransport(
+            process: process,
+            input: stdin.fileHandleForWriting,
+            output: stdout.fileHandleForReading
+        )
+    }
+
+    public func writeLine(_ line: String) async throws {
+        guard process.isRunning else { throw CodexAppServerProcessError.notRunning }
+        guard var data = line.data(using: .utf8) else { throw CodexAppServerProcessError.invalidUTF8 }
+        data.append(0x0A)
+        try writeLock.withLock {
+            try input.write(contentsOf: data)
+        }
+    }
+
+    public func readLine() async throws -> String? {
+        try await Task.detached(priority: .utility) { [self] in
+            try readLock.withLock { try readLineBlocking() }
+        }.value
+    }
+
+    private func readLineBlocking() throws -> String? {
+        while true {
+            if let newline = readBuffer.firstIndex(of: 0x0A) {
+                let line = readBuffer.prefix(upTo: newline)
+                readBuffer.removeSubrange(...newline)
+                guard let value = String(data: line, encoding: .utf8) else {
+                    throw CodexAppServerProcessError.invalidUTF8
+                }
+                return value
+            }
+            guard process.isRunning || !readBuffer.isEmpty else { return nil }
+            guard let data = try output.read(upToCount: 64 * 1024), !data.isEmpty else {
+                if readBuffer.isEmpty { return nil }
+                guard let value = String(data: readBuffer, encoding: .utf8) else {
+                    throw CodexAppServerProcessError.invalidUTF8
+                }
+                readBuffer.removeAll(keepingCapacity: false)
+                return value
+            }
+            readBuffer.append(data)
+            guard readBuffer.count <= Self.maximumLineBytes else {
+                readBuffer.removeAll(keepingCapacity: false)
+                throw CodexAppServerProcessError.lineTooLarge
+            }
+        }
+    }
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerRuntime.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerRuntime.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Managed Codex App runtime built on the public App Server protocol.
+/// The stable thread and turn identifiers are written back to the card by the
+/// launch scheduler's caller.
+public actor CodexAppServerRuntime: CodexRuntimePort {
+    public nonisolated let backend: CodexRuntimeBackend = .app
+
+    private let client: CodexAppServerClient
+    private var initialized = false
+
+    public init(client: CodexAppServerClient) {
+        self.client = client
+    }
+
+    public func launch(_ request: CodexRuntimeLaunchRequest) async throws -> CodexRuntimeLaunchReceipt {
+        do {
+            try await ensureInitialized()
+        } catch {
+            throw CodexRuntimeError.unavailable(
+                "Codex App Server could not initialize: \(error.localizedDescription)"
+            )
+        }
+
+        let thread: CodexThread
+        do {
+            thread = try await client.startThread(cwd: request.projectPath)
+        } catch {
+            throw CodexRuntimeError.launchUncertain(
+                "Codex App thread creation could not be acknowledged: \(error.localizedDescription)"
+            )
+        }
+
+        let partialBinding = CodexExecutionBinding(
+            backend: .app,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .limited,
+            threadId: thread.id,
+            boundAt: .now
+        )
+        do {
+            let managedPrompt = CodexManagedPrompt.withReviewReadyInstruction(
+                request.prompt,
+                request: request,
+                backend: .app,
+                sessionID: thread.id
+            )
+            let turn = try await client.startTurn(threadID: thread.id, text: managedPrompt)
+            return CodexRuntimeLaunchReceipt(binding: CodexExecutionBinding(
+                backend: .app,
+                ownership: .managed,
+                evidence: .boardCreated,
+                telemetryQuality: .precise,
+                threadId: thread.id,
+                turnId: turn.id,
+                boundAt: .now
+            ))
+        } catch {
+            throw CodexRuntimeError.partialLaunch(
+                "Codex App thread \(thread.id) was created, but its first turn could not be acknowledged: \(error.localizedDescription)",
+                partialBinding
+            )
+        }
+    }
+
+    public func recover(_ request: CodexRuntimeRecoveryRequest) async -> CodexRuntimeRecoveryResult {
+        guard let binding = request.binding, let threadID = binding.threadId else {
+            return .uncertain("The persisted App launch has no stable thread binding")
+        }
+        do {
+            try await ensureInitialized()
+            let thread = try await client.resumeThread(id: threadID)
+            let recovered = CodexExecutionBinding(
+                backend: .app,
+                ownership: .managed,
+                evidence: .boardCreated,
+                telemetryQuality: .precise,
+                threadId: thread.id,
+                turnId: binding.turnId,
+                boundAt: binding.boundAt
+            )
+            switch thread.status?.type {
+            case "idle", "completed", "stopped":
+                return .stopped(recovered)
+            default:
+                return .running(recovered)
+            }
+        } catch {
+            return .uncertain("Could not reconcile Codex App thread \(threadID): \(error.localizedDescription)")
+        }
+    }
+
+    public func sendFeedback(_ request: CodexRuntimeFeedbackRequest) async throws {
+        guard request.binding.backend == .app,
+              let threadID = request.binding.threadId else {
+            throw CodexRuntimeError.invalidBinding("The task has no Codex App thread binding")
+        }
+        try await ensureInitialized()
+        // Review feedback starts a new turn. Steering is reserved for a turn
+        // that is still active; an In Review turn has already completed.
+        _ = try await client.startTurn(threadID: threadID, text: request.body)
+    }
+
+    private func ensureInitialized() async throws {
+        guard !initialized else { return }
+        await client.start()
+        _ = try await client.initialize(clientName: "kanban-code", clientVersion: "0.1.1")
+        initialized = true
+    }
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerSessionDiscovery.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexAppServerSessionDiscovery.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// App Server-backed discovery for Codex desktop and managed threads. The
+/// filesystem discovery remains a content fallback; stable thread identity and
+/// runtime provenance come from this adapter when the protocol is available.
+public actor CodexAppServerSessionDiscovery: SessionDiscovery {
+    private let client: CodexAppServerClient
+    private let pageSize: Int
+    private let cacheLifetime: TimeInterval
+    private var cached: [String: Session] = [:]
+    private var lastRefresh: Date?
+
+    public init(
+        client: CodexAppServerClient,
+        pageSize: Int = 100,
+        cacheLifetime: TimeInterval = 30
+    ) {
+        self.client = client
+        self.pageSize = max(1, min(pageSize, 500))
+        self.cacheLifetime = max(0, cacheLifetime)
+    }
+
+    public func discoverSessions() async throws -> [Session] {
+        if let lastRefresh,
+           Date().timeIntervalSince(lastRefresh) < cacheLifetime {
+            return cached.values.sorted { $0.modifiedTime > $1.modifiedTime }
+        }
+        var cursor: String?
+        var discovered: [String: Session] = [:]
+        repeat {
+            let page = try await client.listThreads(cursor: cursor, limit: pageSize, archived: false)
+            for thread in page.data where thread.archived != true {
+                let provenance = Self.provenance(sourceKinds: thread.sourceKinds)
+                let existing = cached[thread.id]
+                discovered[thread.id] = Session(
+                    id: thread.id,
+                    name: thread.name,
+                    firstPrompt: thread.preview,
+                    projectPath: thread.cwd,
+                    messageCount: existing?.messageCount ?? 0,
+                    modifiedTime: existing?.modifiedTime ?? .now,
+                    jsonlPath: existing?.jsonlPath,
+                    assistant: .codex,
+                    runtimeProvenance: provenance,
+                    runtimeLifecycle: Self.lifecycle(status: thread.status)
+                )
+            }
+            cursor = page.nextCursor
+        } while cursor != nil
+        cached = discovered
+        lastRefresh = .now
+        return discovered.values.sorted { $0.modifiedTime > $1.modifiedTime }
+    }
+
+    public func discoverNewOrModified(since: Date) async throws -> [Session] {
+        let sessions = try await discoverSessions()
+        return sessions.filter { $0.modifiedTime > since }
+    }
+
+    public nonisolated static func provenance(sourceKinds: [String]) -> CodexRuntimeProvenance {
+        let normalized = sourceKinds.map { $0.lowercased() }
+        let hasApp = normalized.contains { value in
+            value.contains("app") || value.contains("desktop") || value.contains("vscode")
+        }
+        let hasCLI = normalized.contains { value in
+            value.contains("cli") || value.contains("terminal") || value.contains("exec")
+        }
+        let backend: CodexRuntimeBackend = if hasApp != hasCLI {
+            hasApp ? .app : .cliTmux
+        } else {
+            .unknown
+        }
+        return CodexRuntimeProvenance(
+            backend: backend,
+            ownership: .observed,
+            evidence: .appServerSource,
+            telemetryQuality: backend == .unknown ? .limited : .precise,
+            observedAt: .now
+        )
+    }
+
+    public nonisolated static func lifecycle(status: CodexThreadStatus?) -> LifecycleSnapshot {
+        guard let status else { return .init(phase: .unknown, telemetryQuality: .limited) }
+        if status.waitingOnApproval {
+            return .init(phase: .waiting, waitReason: .approval, telemetryQuality: .precise)
+        }
+        if status.waitingOnUserInput {
+            return .init(phase: .waiting, waitReason: .input, telemetryQuality: .precise)
+        }
+        switch status.type.lowercased() {
+        case "active", "running", "inprogress":
+            return .init(phase: .running, telemetryQuality: .precise)
+        default:
+            // An old idle thread belongs in All Sessions until a fresh
+            // structured event makes it actionable; do not flood attention.
+            return .init(phase: .unknown, telemetryQuality: .precise)
+        }
+    }
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexCLITmuxRuntime.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexCLITmuxRuntime.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+public struct CodexTmuxOwnershipTag: Codable, Sendable, Equatable {
+    public var cardId: String
+    public var attemptId: String
+    public var generation: Int
+
+    public init(cardId: String, attemptId: String, generation: Int) {
+        self.cardId = cardId
+        self.attemptId = attemptId
+        self.generation = generation
+    }
+}
+
+/// Stores ownership on the tmux session itself. A reserved name alone is not
+/// sufficient evidence because a user-created session could collide with it.
+public protocol CodexTmuxMetadataPort: Sendable {
+    func ownershipTag(for sessionName: String) async throws -> CodexTmuxOwnershipTag?
+    func setOwnershipTag(_ tag: CodexTmuxOwnershipTag, for sessionName: String) async throws
+}
+
+public final class CodexTmuxMetadataAdapter: CodexTmuxMetadataPort, @unchecked Sendable {
+    private static let optionName = "@kanban-code-owner"
+    private let tmuxPath: String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(tmuxPath: String? = nil) {
+        self.tmuxPath = tmuxPath ?? ShellCommand.findExecutable("tmux") ?? "tmux"
+    }
+
+    public func ownershipTag(for sessionName: String) async throws -> CodexTmuxOwnershipTag? {
+        let result = try await ShellCommand.run(
+            tmuxPath,
+            arguments: ["show-options", "-v", "-t", sessionName, Self.optionName]
+        )
+        guard result.succeeded, !result.stdout.isEmpty else { return nil }
+        guard let data = result.stdout.data(using: .utf8) else { return nil }
+        return try decoder.decode(CodexTmuxOwnershipTag.self, from: data)
+    }
+
+    public func setOwnershipTag(_ tag: CodexTmuxOwnershipTag, for sessionName: String) async throws {
+        let data = try encoder.encode(tag)
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw CodexRuntimeError.launchUncertain("Could not encode tmux ownership metadata")
+        }
+        let result = try await ShellCommand.run(
+            tmuxPath,
+            arguments: ["set-option", "-t", sessionName, Self.optionName, value]
+        )
+        guard result.succeeded else {
+            throw CodexRuntimeError.launchUncertain(
+                "tmux session was created, but its ownership tag could not be persisted: \(result.stderr)"
+            )
+        }
+    }
+}
+
+/// Codex CLI implementation of the managed runtime contract. It uses a
+/// deterministic, reserved tmux namespace and never kills an uncertain session.
+public final class CodexCLITmuxRuntime: CodexRuntimePort, @unchecked Sendable {
+    public let backend: CodexRuntimeBackend = .cliTmux
+
+    private let tmux: any TmuxManagerPort
+    private let metadata: any CodexTmuxMetadataPort
+    private let codexExecutablePath: String
+
+    public init(
+        tmux: any TmuxManagerPort,
+        metadata: any CodexTmuxMetadataPort,
+        codexExecutablePath: String? = nil
+    ) {
+        self.tmux = tmux
+        self.metadata = metadata
+        self.codexExecutablePath = codexExecutablePath
+            ?? ShellCommand.findExecutable("codex")
+            ?? "codex"
+    }
+
+    public func launch(_ request: CodexRuntimeLaunchRequest) async throws -> CodexRuntimeLaunchReceipt {
+        guard await tmux.isAvailable() else {
+            throw CodexRuntimeError.unavailable("tmux is not available")
+        }
+
+        let sessionName = Self.sessionName(cardId: request.cardId, generation: request.generation)
+        let expectedTag = CodexTmuxOwnershipTag(
+            cardId: request.cardId,
+            attemptId: request.attemptId,
+            generation: request.generation
+        )
+        let sessions: [TmuxSession]
+        do {
+            sessions = try await tmux.listSessions()
+        } catch {
+            throw CodexRuntimeError.notStarted("Could not inspect tmux before launch: \(error.localizedDescription)")
+        }
+
+        if sessions.contains(where: { $0.name == sessionName }) {
+            let actualTag = try? await metadata.ownershipTag(for: sessionName)
+            guard actualTag == expectedTag else {
+                throw CodexRuntimeError.ownershipConflict(
+                    "Refusing to reuse \(sessionName): its ownership tag does not match this launch attempt"
+                )
+            }
+            return CodexRuntimeLaunchReceipt(binding: binding(for: sessionName))
+        }
+
+        let command = [
+            "KANBAN_CODE_CARD_ID=\(ShellCommand.shellEscape(request.cardId))",
+            "KANBAN_CODE_SESSION_ID=\(ShellCommand.shellEscape(sessionName))",
+            "KANBAN_CODE_ATTEMPT_ID=\(ShellCommand.shellEscape(request.attemptId))",
+            "KANBAN_CODE_GENERATION=\(request.generation)",
+            "KANBAN_CODE_BACKEND=\(CodexRuntimeBackend.cliTmux.rawValue)",
+            "KANBAN_CODE_LIFECYCLE_CAPABILITY=\(ShellCommand.shellEscape(request.lifecycleCapability))",
+            "\(ShellCommand.shellEscape(codexExecutablePath)) --no-alt-screen",
+        ].joined(separator: " ")
+        do {
+            try await tmux.createSession(
+                name: sessionName,
+                path: request.projectPath,
+                command: command
+            )
+        } catch {
+            throw CodexRuntimeError.notStarted("Could not create tmux session: \(error.localizedDescription)")
+        }
+
+        do {
+            try await metadata.setOwnershipTag(expectedTag, for: sessionName)
+            if !request.prompt.isEmpty {
+                try await tmux.pastePrompt(
+                    to: sessionName,
+                    text: CodexManagedPrompt.withReviewReadyInstruction(
+                        request.prompt,
+                        request: request,
+                        backend: .cliTmux,
+                        sessionID: sessionName
+                    )
+                )
+            }
+        } catch let error as CodexRuntimeError {
+            throw error
+        } catch {
+            throw CodexRuntimeError.launchUncertain(
+                "tmux session \(sessionName) exists, but launch acknowledgement failed: \(error.localizedDescription)"
+            )
+        }
+
+        return CodexRuntimeLaunchReceipt(binding: binding(for: sessionName))
+    }
+
+    public func recover(_ request: CodexRuntimeRecoveryRequest) async -> CodexRuntimeRecoveryResult {
+        let sessionName = Self.sessionName(cardId: request.cardId, generation: request.lease.generation)
+        guard let sessions = try? await tmux.listSessions() else {
+            return .uncertain("Could not inspect tmux sessions")
+        }
+        guard sessions.contains(where: { $0.name == sessionName }) else {
+            return .notStarted
+        }
+        guard let tag = try? await metadata.ownershipTag(for: sessionName) else {
+            return .uncertain("The reserved tmux session exists without readable ownership metadata")
+        }
+        let expected = CodexTmuxOwnershipTag(
+            cardId: request.cardId,
+            attemptId: request.lease.attemptId,
+            generation: request.lease.generation
+        )
+        guard tag == expected else {
+            return .uncertain("The reserved tmux session is owned by a different launch attempt")
+        }
+        return .running(binding(for: sessionName))
+    }
+
+    public func sendFeedback(_ request: CodexRuntimeFeedbackRequest) async throws {
+        guard request.binding.backend == .cliTmux,
+              let sessionName = request.binding.tmuxSessionName else {
+            throw CodexRuntimeError.invalidBinding("The task is not bound to a Codex CLI tmux session")
+        }
+        guard let tag = try await metadata.ownershipTag(for: sessionName), tag.cardId == request.cardId else {
+            throw CodexRuntimeError.ownershipConflict(
+                "Refusing to send feedback to a tmux session not owned by this card"
+            )
+        }
+        try await tmux.pastePrompt(to: sessionName, text: request.body)
+    }
+
+    public static func sessionName(cardId: String, generation: Int) -> String {
+        let safeCardId = cardId.unicodeScalars.map { scalar -> Character in
+            CharacterSet.alphanumerics.contains(scalar) || scalar == "-" ? Character(String(scalar)) : "-"
+        }
+        return "kanban-code-\(String(safeCardId))-\(generation)"
+    }
+
+    private func binding(for sessionName: String) -> CodexExecutionBinding {
+        CodexExecutionBinding(
+            backend: .cliTmux,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .limited,
+            tmuxSessionName: sessionName,
+            boundAt: .now
+        )
+    }
+
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexHookInstaller.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexHookInstaller.swift
@@ -1,0 +1,210 @@
+import Foundation
+import CryptoKit
+
+/// Installs Kanban Code's non-authorizing lifecycle observer into the user
+/// `~/.codex/hooks.json` layer without replacing unrelated hooks or settings.
+public enum CodexHookInstaller {
+    public static let eventNames = ["SessionStart", "UserPromptSubmit", "PermissionRequest", "Stop"]
+
+    public static func isInstalled(
+        hooksPath: String? = nil,
+        helperPath: String? = nil,
+        expectedHelperSHA256: String? = nil
+    ) -> Bool {
+        let path = hooksPath ?? defaultHooksPath()
+        let helper = helperPath ?? defaultHelperPath()
+        guard expectedHelperSHA256.map({ helperMatches(path: helper, expectedSHA256: $0) }) ?? true,
+              let root = readJSON(path: path),
+              let hooks = root["hooks"] as? [String: Any] else { return false }
+        let command = hookCommand(helperPath: helper)
+        return eventNames.allSatisfy { eventName in
+            hookEntries(in: hooks[eventName]).contains { entry in
+                entry["type"] as? String == "command" && entry["command"] as? String == command
+            }
+        }
+    }
+
+    public static func install(hooksPath: String? = nil, helperPath: String? = nil) throws {
+        let path = hooksPath ?? defaultHooksPath()
+        let helper = helperPath ?? defaultHelperPath()
+        try validateHelperPath(helper)
+        if isInstalled(hooksPath: path, helperPath: helper) { return }
+
+        var root = try loadJSONForMutation(path: path)
+        if root["hooks"] != nil, root["hooks"] as? [String: Any] == nil {
+            throw CodexLifecycleInboxError.invalidEnvelope("existing Codex hooks config has an invalid hooks object")
+        }
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+        let entry: [String: Any] = [
+            "type": "command",
+            "command": hookCommand(helperPath: helper),
+            "timeout": 5,
+            "statusMessage": "Updating Kanban Code lifecycle",
+        ]
+
+        for eventName in eventNames {
+            var groups = hooks[eventName] as? [[String: Any]] ?? []
+            let installed = hookEntries(in: groups).contains {
+                $0["type"] as? String == "command" && $0["command"] as? String == entry["command"] as? String
+            }
+            guard !installed else { continue }
+            if groups.isEmpty {
+                groups = [["matcher": "", "hooks": [entry]]]
+            } else {
+                var first = groups[0]
+                var entries = first["hooks"] as? [[String: Any]] ?? []
+                entries.append(entry)
+                first["hooks"] = entries
+                groups[0] = first
+            }
+            hooks[eventName] = groups
+        }
+        root["hooks"] = hooks
+        try backupExistingConfig(path: path)
+        try writeJSON(root, path: path)
+    }
+
+    public static func uninstall(hooksPath: String? = nil, helperPath: String? = nil) throws {
+        let path = hooksPath ?? defaultHooksPath()
+        let helper = helperPath ?? defaultHelperPath()
+        guard var root = readJSON(path: path),
+              var hooks = root["hooks"] as? [String: Any] else { return }
+        let command = hookCommand(helperPath: helper)
+
+        for eventName in eventNames {
+            guard var groups = hooks[eventName] as? [[String: Any]] else { continue }
+            for index in groups.indices {
+                var entries = groups[index]["hooks"] as? [[String: Any]] ?? []
+                entries.removeAll {
+                    $0["type"] as? String == "command" && $0["command"] as? String == command
+                }
+                groups[index]["hooks"] = entries
+            }
+            groups.removeAll { ($0["hooks"] as? [[String: Any]])?.isEmpty != false }
+            if groups.isEmpty {
+                hooks.removeValue(forKey: eventName)
+            } else {
+                hooks[eventName] = groups
+            }
+        }
+        root["hooks"] = hooks
+        try writeJSON(root, path: path)
+    }
+
+    /// Copies the code-signed app-bundled helper to the stable per-user path
+    /// used by Codex hooks. This is only called from an explicit Settings action.
+    @discardableResult
+    public static func deployHelper(
+        from bundledHelperPath: String,
+        expectedSHA256: String,
+        helperPath: String? = nil
+    ) throws -> String {
+        let destination = helperPath ?? stableHelperPath()
+        try validateHelperPath(destination)
+        let sourceURL = URL(fileURLWithPath: bundledHelperPath)
+        guard FileManager.default.isExecutableFile(atPath: sourceURL.path) else {
+            throw CodexLifecycleInboxError.invalidEnvelope("bundled lifecycle helper is missing or not executable")
+        }
+        let data = try Data(contentsOf: sourceURL)
+        guard sha256(data) == normalizedHash(expectedSHA256) else {
+            throw CodexLifecycleInboxError.invalidEnvelope("bundled lifecycle helper failed its signed hash check")
+        }
+        let destinationURL = URL(fileURLWithPath: destination)
+        try FileManager.default.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try data.write(to: destinationURL, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: destination)
+        guard helperMatches(path: destination, expectedSHA256: expectedSHA256) else {
+            throw CodexLifecycleInboxError.invalidEnvelope("installed lifecycle helper failed verification")
+        }
+        return destination
+    }
+
+    public static func sha256(path: String) throws -> String {
+        sha256(try Data(contentsOf: URL(fileURLWithPath: path)))
+    }
+
+    public static func helperMatches(path: String, expectedSHA256: String) -> Bool {
+        guard let actual = try? sha256(path: path) else { return false }
+        return actual == normalizedHash(expectedSHA256)
+    }
+
+    public static func stableHelperPath() -> String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".kanban-code/bin/kanban-code-lifecycle")
+    }
+
+    private static func hookEntries(in rawGroups: Any?) -> [[String: Any]] {
+        guard let groups = rawGroups as? [[String: Any]] else { return [] }
+        return groups.flatMap { $0["hooks"] as? [[String: Any]] ?? [] }
+    }
+
+    private static func hookCommand(helperPath: String) -> String {
+        // Codex's hook contract is a command string. Installation only accepts
+        // a conservative absolute path alphabet, so no shell quoting or
+        // interpolation is required here.
+        "\(helperPath) hook-event"
+    }
+
+    private static func validateHelperPath(_ path: String) throws {
+        guard path.hasPrefix("/"), !path.contains(".."), !path.contains("//"),
+              path.utf8.allSatisfy({ byte in
+                  (48...57).contains(byte) || (65...90).contains(byte) || (97...122).contains(byte)
+                      || byte == 45 || byte == 46 || byte == 47 || byte == 95
+              }) else {
+            throw CodexLifecycleInboxError.invalidEnvelope("helper path must be a simple absolute path")
+        }
+    }
+
+    private static func readJSON(path: String) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return root
+    }
+
+    private static func loadJSONForMutation(path: String) throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: path) else { return [:] }
+        guard let root = readJSON(path: path) else {
+            throw CodexLifecycleInboxError.invalidEnvelope("existing Codex hooks config is not a JSON object")
+        }
+        return root
+    }
+
+    private static func backupExistingConfig(path: String) throws {
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let backupURL = URL(fileURLWithPath: path + ".kanban-code.backup")
+        try data.write(to: backupURL, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
+    }
+
+    private static func writeJSON(_ root: [String: Any], path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    private static func defaultHooksPath() -> String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".codex/hooks.json")
+    }
+
+    private static func defaultHelperPath() -> String {
+        stableHelperPath()
+    }
+
+    private static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func normalizedHash(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Sources/KanbanCodeCore/Adapters/Codex/CodexLifecycleInbox.swift
+++ b/Sources/KanbanCodeCore/Adapters/Codex/CodexLifecycleInbox.swift
@@ -1,0 +1,551 @@
+import Foundation
+import Security
+
+/// Versioned, non-authorizing lifecycle signals emitted by Codex hooks and the
+/// bundled review-ready helper. Payload text is never interpreted or executed.
+public struct CodexLifecycleEnvelope: Codable, Sendable, Equatable, Identifiable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let id: String
+    public let cardId: String
+    public let sessionId: String
+    public let attemptId: String
+    public let generation: Int
+    public let kind: CodexLifecycleEventKind
+    public let backend: CodexRuntimeBackend
+    public let turnId: String?
+    public let sequence: Int?
+    public let occurredAt: Date
+    public let capability: String
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        id: String = UUID().uuidString,
+        cardId: String,
+        sessionId: String,
+        attemptId: String,
+        generation: Int,
+        kind: CodexLifecycleEventKind,
+        backend: CodexRuntimeBackend,
+        turnId: String? = nil,
+        sequence: Int? = nil,
+        occurredAt: Date = .now,
+        capability: String
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.cardId = cardId
+        self.sessionId = sessionId
+        self.attemptId = attemptId
+        self.generation = generation
+        self.kind = kind
+        self.backend = backend
+        self.turnId = turnId
+        self.sequence = sequence
+        self.occurredAt = occurredAt
+        self.capability = capability
+    }
+}
+
+/// The exact launch attempt an inbox event is allowed to affect.
+public struct CodexLifecycleExpectedBinding: Sendable, Equatable {
+    public let cardId: String
+    public let sessionId: String
+    public let attemptId: String
+    public let generation: Int
+    public let backend: CodexRuntimeBackend
+    public let capability: String
+
+    public init(
+        cardId: String,
+        sessionId: String,
+        attemptId: String,
+        generation: Int,
+        backend: CodexRuntimeBackend,
+        capability: String
+    ) {
+        self.cardId = cardId
+        self.sessionId = sessionId
+        self.attemptId = attemptId
+        self.generation = generation
+        self.backend = backend
+        self.capability = capability
+    }
+}
+
+public enum CodexLifecycleInboxError: LocalizedError, Equatable {
+    case eventTooLarge(actual: Int, maximum: Int)
+    case invalidEnvelope(String)
+    case randomGenerationFailed(Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .eventTooLarge(let actual, let maximum):
+            "Lifecycle event is \(actual) bytes; maximum is \(maximum) bytes"
+        case .invalidEnvelope(let reason):
+            "Invalid lifecycle event: \(reason)"
+        case .randomGenerationFailed(let status):
+            "Could not generate lifecycle capability (status \(status))"
+        }
+    }
+}
+
+public enum CodexLifecycleInboxDiagnosticReason: String, Sendable, Equatable {
+    case malformed
+    case tooLarge
+    case unsupportedSchema
+    case duplicate
+    case missingBinding
+    case bindingMismatch
+    case invalidCapability
+}
+
+public struct CodexLifecycleInboxDiagnostic: Sendable, Equatable {
+    public let fileName: String
+    public let eventId: String?
+    public let reason: CodexLifecycleInboxDiagnosticReason
+
+    public init(fileName: String, eventId: String?, reason: CodexLifecycleInboxDiagnosticReason) {
+        self.fileName = fileName
+        self.eventId = eventId
+        self.reason = reason
+    }
+}
+
+public struct CodexLifecycleInboxBatch: Sendable, Equatable {
+    public let events: [CodexLifecycleEvent]
+    public let diagnostics: [CodexLifecycleInboxDiagnostic]
+    public let acknowledgements: [CodexLifecycleInboxAcknowledgement]
+
+    public init(
+        events: [CodexLifecycleEvent],
+        diagnostics: [CodexLifecycleInboxDiagnostic],
+        acknowledgements: [CodexLifecycleInboxAcknowledgement] = []
+    ) {
+        self.events = events
+        self.diagnostics = diagnostics
+        self.acknowledgements = acknowledgements
+    }
+}
+
+public struct CodexLifecycleInboxAcknowledgement: Sendable, Equatable {
+    public let fileName: String
+    public let eventId: String?
+}
+
+public struct CodexLifecycleAppendResult: Sendable, Equatable {
+    public let fileName: String
+    public let rotatedEventCount: Int
+}
+
+public enum CodexLifecycleCapability {
+    /// Generates a per-attempt 256-bit capability. It must remain in the
+    /// Swift-owned launch lease and the child process environment only.
+    public static func generate() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw CodexLifecycleInboxError.randomGenerationFailed(status)
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func isValid(_ capability: String) -> Bool {
+        capability.utf8.count == 64 && capability.utf8.allSatisfy {
+            (48...57).contains($0) || (97...102).contains($0)
+        }
+    }
+
+    /// Avoids an early-return timing signal for equal-length capabilities.
+    public static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let left = Array(lhs.utf8)
+        let right = Array(rhs.utf8)
+        let count = max(left.count, right.count)
+        var difference = UInt64(left.count ^ right.count)
+        for index in 0..<count {
+            let a = index < left.count ? left[index] : 0
+            let b = index < right.count ? right[index] : 0
+            difference |= UInt64(a ^ b)
+        }
+        return difference == 0
+    }
+}
+
+/// Atomic, bounded writer shared by the helper executable and app adapters.
+/// Each event is its own file so concurrent helper processes never interleave
+/// JSON bytes as they could with a shared JSONL append.
+public actor CodexLifecycleInboxWriter {
+    public static let maximumEventBytes = 1_048_576
+    public static let maximumQueuedEvents = 10_000
+
+    private let pendingDirectory: URL
+    private let maximumEventBytes: Int
+    private let maximumQueuedEvents: Int
+    private let fileManager: FileManager
+
+    public init(
+        basePath: String? = nil,
+        maximumEventBytes: Int = CodexLifecycleInboxWriter.maximumEventBytes,
+        maximumQueuedEvents: Int = CodexLifecycleInboxWriter.maximumQueuedEvents,
+        fileManager: FileManager = .default
+    ) {
+        let base = basePath ?? (NSHomeDirectory() as NSString).appendingPathComponent(".kanban-code")
+        self.pendingDirectory = URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent("codex-lifecycle-inbox", isDirectory: true)
+            .appendingPathComponent("pending", isDirectory: true)
+        self.maximumEventBytes = min(max(1, maximumEventBytes), Self.maximumEventBytes)
+        self.maximumQueuedEvents = min(max(1, maximumQueuedEvents), Self.maximumQueuedEvents)
+        self.fileManager = fileManager
+    }
+
+    @discardableResult
+    public func append(_ envelope: CodexLifecycleEnvelope) throws -> CodexLifecycleAppendResult {
+        try Self.validate(envelope)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(envelope)
+        guard data.count <= maximumEventBytes else {
+            throw CodexLifecycleInboxError.eventTooLarge(actual: data.count, maximum: maximumEventBytes)
+        }
+
+        try prepareDirectory()
+        let fileName = Self.makeFileName(eventId: envelope.id)
+        let destination = pendingDirectory.appendingPathComponent(fileName, isDirectory: false)
+        try data.write(to: destination, options: [.atomic])
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
+
+        let rotated = try rotateIfNeeded()
+        return CodexLifecycleAppendResult(fileName: fileName, rotatedEventCount: rotated)
+    }
+
+    private func prepareDirectory() throws {
+        let inbox = pendingDirectory.deletingLastPathComponent()
+        try fileManager.createDirectory(at: inbox, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: pendingDirectory, withIntermediateDirectories: true)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: inbox.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: pendingDirectory.path)
+    }
+
+    private func rotateIfNeeded() throws -> Int {
+        var files = try eventFiles()
+        guard files.count > maximumQueuedEvents else { return 0 }
+        let removeCount = files.count - maximumQueuedEvents
+        files.sort { $0.lastPathComponent < $1.lastPathComponent }
+        for file in files.prefix(removeCount) {
+            try fileManager.removeItem(at: file)
+        }
+        return removeCount
+    }
+
+    private func eventFiles() throws -> [URL] {
+        guard fileManager.fileExists(atPath: pendingDirectory.path) else { return [] }
+        return try fileManager.contentsOfDirectory(
+            at: pendingDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "json" }
+    }
+
+    private static func makeFileName(eventId: String) -> String {
+        let nanos = DispatchTime.now().uptimeNanoseconds
+        let safeId = eventId.filter { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
+        return String(format: "%020llu-%@-%@.json", nanos, safeId.prefix(80).description, UUID().uuidString)
+    }
+
+    fileprivate static func validate(_ envelope: CodexLifecycleEnvelope) throws {
+        guard envelope.schemaVersion == CodexLifecycleEnvelope.currentSchemaVersion else {
+            throw CodexLifecycleInboxError.invalidEnvelope("unsupported schema version")
+        }
+        guard !envelope.id.isEmpty, envelope.id.utf8.count <= 256 else {
+            throw CodexLifecycleInboxError.invalidEnvelope("event id is missing or too long")
+        }
+        for (name, value) in [
+            ("card id", envelope.cardId),
+            ("session id", envelope.sessionId),
+            ("attempt id", envelope.attemptId),
+        ] {
+            guard !value.isEmpty, value.utf8.count <= 512 else {
+                throw CodexLifecycleInboxError.invalidEnvelope("\(name) is missing or too long")
+            }
+        }
+        guard envelope.generation >= 0 else {
+            throw CodexLifecycleInboxError.invalidEnvelope("generation is negative")
+        }
+        guard envelope.backend != .unknown else {
+            throw CodexLifecycleInboxError.invalidEnvelope("runtime backend is unknown")
+        }
+        guard CodexLifecycleCapability.isValid(envelope.capability) else {
+            throw CodexLifecycleInboxError.invalidEnvelope("capability is not 256-bit lowercase hex")
+        }
+    }
+}
+
+/// Drains inbox files with persistent replay protection. Draining is a read
+/// phase; callers acknowledge only after the projected state is durable, then
+/// the cursor is committed and processed files are removed.
+public actor CodexLifecycleInboxReader {
+    private struct Cursor: Codable {
+        var seenEventIds: [String] = []
+    }
+
+    private let inboxDirectory: URL
+    private let pendingDirectory: URL
+    private let cursorURL: URL
+    private let maximumEventBytes: Int
+    private let maximumSeenEventIds: Int
+    private let fileManager: FileManager
+
+    public init(
+        basePath: String? = nil,
+        maximumEventBytes: Int = CodexLifecycleInboxWriter.maximumEventBytes,
+        maximumSeenEventIds: Int = CodexLifecycleInboxWriter.maximumQueuedEvents,
+        fileManager: FileManager = .default
+    ) {
+        let base = basePath ?? (NSHomeDirectory() as NSString).appendingPathComponent(".kanban-code")
+        self.inboxDirectory = URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent("codex-lifecycle-inbox", isDirectory: true)
+        self.pendingDirectory = inboxDirectory.appendingPathComponent("pending", isDirectory: true)
+        self.cursorURL = inboxDirectory.appendingPathComponent("cursor.json", isDirectory: false)
+        self.maximumEventBytes = min(max(1, maximumEventBytes), CodexLifecycleInboxWriter.maximumEventBytes)
+        self.maximumSeenEventIds = min(max(1, maximumSeenEventIds), CodexLifecycleInboxWriter.maximumQueuedEvents)
+        self.fileManager = fileManager
+    }
+
+    public func hasPendingEvents() -> Bool {
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: pendingDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return false }
+        return files.contains { $0.pathExtension == "json" }
+    }
+
+    public func drain(bindings: [String: CodexLifecycleExpectedBinding]) throws -> CodexLifecycleInboxBatch {
+        guard fileManager.fileExists(atPath: pendingDirectory.path) else {
+            return CodexLifecycleInboxBatch(events: [], diagnostics: [], acknowledgements: [])
+        }
+
+        let files = try fileManager.contentsOfDirectory(
+            at: pendingDirectory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard !files.isEmpty else {
+            return CodexLifecycleInboxBatch(events: [], diagnostics: [], acknowledgements: [])
+        }
+
+        let cursor = try loadCursor()
+        var seen = Set(cursor.seenEventIds)
+        var events: [CodexLifecycleEvent] = []
+        var diagnostics: [CodexLifecycleInboxDiagnostic] = []
+        var acknowledgements: [CodexLifecycleInboxAcknowledgement] = []
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        for file in files.prefix(CodexLifecycleInboxWriter.maximumQueuedEvents) {
+            acknowledgements.append(.init(fileName: file.lastPathComponent, eventId: nil))
+            let values = try? file.resourceValues(forKeys: [.fileSizeKey])
+            guard let size = values?.fileSize, size <= maximumEventBytes else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: nil, reason: .tooLarge))
+                continue
+            }
+            guard let data = try? Data(contentsOf: file, options: [.mappedIfSafe]),
+                  let envelope = try? decoder.decode(CodexLifecycleEnvelope.self, from: data) else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: nil, reason: .malformed))
+                continue
+            }
+            acknowledgements[acknowledgements.count - 1] = .init(
+                fileName: file.lastPathComponent,
+                eventId: envelope.id
+            )
+            guard envelope.schemaVersion == CodexLifecycleEnvelope.currentSchemaVersion else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: envelope.id, reason: .unsupportedSchema))
+                _ = seen.insert(envelope.id)
+                continue
+            }
+            guard !seen.contains(envelope.id) else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: envelope.id, reason: .duplicate))
+                continue
+            }
+            _ = seen.insert(envelope.id)
+
+            guard let binding = bindings[envelope.cardId] else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: envelope.id, reason: .missingBinding))
+                continue
+            }
+            guard binding.cardId == envelope.cardId,
+                  binding.sessionId == envelope.sessionId,
+                  binding.attemptId == envelope.attemptId,
+                  binding.generation == envelope.generation,
+                  binding.backend == envelope.backend else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: envelope.id, reason: .bindingMismatch))
+                continue
+            }
+            guard CodexLifecycleCapability.isValid(envelope.capability),
+                  CodexLifecycleCapability.constantTimeEquals(binding.capability, envelope.capability) else {
+                diagnostics.append(.init(fileName: file.lastPathComponent, eventId: envelope.id, reason: .invalidCapability))
+                continue
+            }
+
+            events.append(CodexLifecycleEvent(
+                id: envelope.id,
+                cardId: envelope.cardId,
+                kind: envelope.kind,
+                watermark: LifecycleEventWatermark(
+                    eventId: envelope.id,
+                    source: "codex-lifecycle-inbox",
+                    generation: envelope.generation,
+                    turnId: envelope.turnId,
+                    sequence: envelope.sequence,
+                    occurredAt: envelope.occurredAt
+                ),
+                telemetryQuality: .precise
+            ))
+        }
+
+        return CodexLifecycleInboxBatch(
+            events: events,
+            diagnostics: diagnostics,
+            acknowledgements: acknowledgements
+        )
+    }
+
+    /// Commits replay protection only after the caller has durably applied all
+    /// validated lifecycle events in the batch.
+    public func acknowledge(_ batch: CodexLifecycleInboxBatch) throws {
+        var cursor = try loadCursor()
+        var seen = Set(cursor.seenEventIds)
+        for acknowledgement in batch.acknowledgements {
+            if let eventId = acknowledgement.eventId {
+                record(eventId, cursor: &cursor, seen: &seen)
+            }
+        }
+        if cursor.seenEventIds.count > maximumSeenEventIds {
+            cursor.seenEventIds.removeFirst(cursor.seenEventIds.count - maximumSeenEventIds)
+        }
+        try saveCursor(cursor)
+        for acknowledgement in batch.acknowledgements {
+            let fileName = URL(fileURLWithPath: acknowledgement.fileName).lastPathComponent
+            try? fileManager.removeItem(at: pendingDirectory.appendingPathComponent(fileName))
+        }
+    }
+
+    private func record(_ eventId: String, cursor: inout Cursor, seen: inout Set<String>) {
+        guard seen.insert(eventId).inserted else { return }
+        cursor.seenEventIds.append(eventId)
+    }
+
+    private func loadCursor() throws -> Cursor {
+        guard fileManager.fileExists(atPath: cursorURL.path) else { return Cursor() }
+        let data = try Data(contentsOf: cursorURL)
+        return (try? JSONDecoder().decode(Cursor.self, from: data)) ?? Cursor()
+    }
+
+    private func saveCursor(_ cursor: Cursor) throws {
+        try fileManager.createDirectory(at: inboxDirectory, withIntermediateDirectories: true)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: inboxDirectory.path)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(cursor)
+        try data.write(to: cursorURL, options: [.atomic])
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: cursorURL.path)
+    }
+}
+
+/// Hook payload fields documented by Codex. Unknown fields are intentionally
+/// ignored and prompt/tool contents are never persisted.
+public struct CodexHookLifecycleInput: Codable, Sendable, Equatable {
+    public let sessionId: String
+    public let hookEventName: String
+    public let turnId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case hookEventName = "hook_event_name"
+        case turnId = "turn_id"
+    }
+}
+
+/// Pure helper entry point used by the executable and unit tests.
+public enum CodexLifecycleHelper {
+    public static let cardIdEnvironmentKey = "KANBAN_CODE_CARD_ID"
+    public static let sessionIdEnvironmentKey = "KANBAN_CODE_SESSION_ID"
+    public static let attemptIdEnvironmentKey = "KANBAN_CODE_ATTEMPT_ID"
+    public static let generationEnvironmentKey = "KANBAN_CODE_GENERATION"
+    public static let backendEnvironmentKey = "KANBAN_CODE_BACKEND"
+    public static let capabilityEnvironmentKey = "KANBAN_CODE_LIFECYCLE_CAPABILITY"
+    public static let basePathEnvironmentKey = "KANBAN_CODE_STATE_DIRECTORY"
+
+    @discardableResult
+    public static func emit(
+        command: String,
+        standardInput: Data = Data(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) async throws -> CodexLifecycleAppendResult? {
+        guard let cardId = environment[cardIdEnvironmentKey],
+              let expectedSessionId = environment[sessionIdEnvironmentKey],
+              let attemptId = environment[attemptIdEnvironmentKey],
+              let generationString = environment[generationEnvironmentKey],
+              let generation = Int(generationString),
+              let backendString = environment[backendEnvironmentKey],
+              let backend = CodexRuntimeBackend(rawValue: backendString), backend != .unknown,
+              let capability = environment[capabilityEnvironmentKey] else {
+            // External/unmanaged sessions have no per-attempt binding. Their
+            // hooks remain observational and cannot forge precise lifecycle.
+            return nil
+        }
+
+        let kind: CodexLifecycleEventKind
+        let sessionId: String
+        let turnId: String?
+        switch command {
+        case "review-ready":
+            kind = .reviewReady
+            sessionId = expectedSessionId
+            turnId = nil
+        case "hook-event":
+            guard standardInput.count <= CodexLifecycleInboxWriter.maximumEventBytes else {
+                throw CodexLifecycleInboxError.eventTooLarge(
+                    actual: standardInput.count,
+                    maximum: CodexLifecycleInboxWriter.maximumEventBytes
+                )
+            }
+            let input = try JSONDecoder().decode(CodexHookLifecycleInput.self, from: standardInput)
+            guard backend == .cliTmux || input.sessionId == expectedSessionId else {
+                throw CodexLifecycleInboxError.invalidEnvelope("hook session does not match launch binding")
+            }
+            // CLI launches know the owned tmux transport before Codex creates
+            // its internal session UUID. The per-attempt capability and tmux
+            // ownership tag bind the hook, so lifecycle envelopes retain that
+            // stable transport identifier. Other backends require an exact
+            // protocol session match.
+            sessionId = backend == .cliTmux ? expectedSessionId : input.sessionId
+            turnId = input.turnId
+            switch input.hookEventName {
+            case "SessionStart", "UserPromptSubmit": kind = .running
+            case "PermissionRequest": kind = .waitingForApproval
+            case "Stop": kind = .stopped
+            default: return nil
+            }
+        default:
+            throw CodexLifecycleInboxError.invalidEnvelope("unsupported helper command")
+        }
+
+        let envelope = CodexLifecycleEnvelope(
+            cardId: cardId,
+            sessionId: sessionId,
+            attemptId: attemptId,
+            generation: generation,
+            kind: kind,
+            backend: backend,
+            turnId: turnId,
+            capability: capability
+        )
+        let writer = CodexLifecycleInboxWriter(basePath: environment[basePathEnvironmentKey])
+        return try await writer.append(envelope)
+    }
+}

--- a/Sources/KanbanCodeCore/Domain/Entities/CodexRuntime.swift
+++ b/Sources/KanbanCodeCore/Domain/Entities/CodexRuntime.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+/// The execution environment that owns a Codex task. This is deliberately
+/// separate from `CodingAssistant`: Codex is the assistant in both modes.
+public enum CodexRuntimeBackend: String, Codable, Sendable, CaseIterable {
+    case app
+    case cliTmux
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .unknown
+    }
+}
+
+public enum RuntimeOwnership: String, Codable, Sendable, CaseIterable {
+    case managed
+    case observed
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .observed
+    }
+}
+
+public enum RuntimeEvidence: String, Codable, Sendable, CaseIterable {
+    case userConfirmed
+    case boardCreated
+    case tmuxBinding
+    case appServerSource
+    case cliMetadata
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .unknown
+    }
+
+    /// Higher-authority evidence must not be silently replaced by discovery.
+    public var authority: Int {
+        switch self {
+        case .userConfirmed: 5
+        case .boardCreated: 4
+        case .tmuxBinding: 3
+        case .appServerSource: 2
+        case .cliMetadata: 1
+        case .unknown: 0
+        }
+    }
+}
+
+public enum TelemetryQuality: String, Codable, Sendable, CaseIterable {
+    case precise
+    case limited
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .unknown
+    }
+}
+
+/// Discovery-time evidence about where a session originated.
+public struct CodexRuntimeProvenance: Codable, Sendable, Equatable {
+    public var backend: CodexRuntimeBackend
+    public var ownership: RuntimeOwnership
+    public var evidence: RuntimeEvidence
+    public var telemetryQuality: TelemetryQuality
+    public var observedAt: Date?
+
+    public init(
+        backend: CodexRuntimeBackend,
+        ownership: RuntimeOwnership = .observed,
+        evidence: RuntimeEvidence = .unknown,
+        telemetryQuality: TelemetryQuality = .unknown,
+        observedAt: Date? = nil
+    ) {
+        self.backend = backend
+        self.ownership = ownership
+        self.evidence = evidence
+        self.telemetryQuality = telemetryQuality
+        self.observedAt = observedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case backend, ownership, evidence, telemetryQuality, observedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        backend = (try? container.decode(CodexRuntimeBackend.self, forKey: .backend)) ?? .unknown
+        ownership = (try? container.decode(RuntimeOwnership.self, forKey: .ownership)) ?? .observed
+        evidence = (try? container.decode(RuntimeEvidence.self, forKey: .evidence)) ?? .unknown
+        telemetryQuality = (try? container.decode(TelemetryQuality.self, forKey: .telemetryQuality)) ?? .unknown
+        observedAt = try? container.decodeIfPresent(Date.self, forKey: .observedAt)
+    }
+
+    /// Resolves competing discovery evidence without allowing a weaker signal
+    /// to flip a user-confirmed or board-created backend.
+    public func preferring(_ candidate: Self) -> Self {
+        if candidate.evidence.authority != evidence.authority {
+            return candidate.evidence.authority > evidence.authority ? candidate : self
+        }
+        switch (observedAt, candidate.observedAt) {
+        case let (current?, proposed?) where proposed > current:
+            return candidate
+        case (nil, .some):
+            return candidate
+        default:
+            return self
+        }
+    }
+}
+
+/// Stable identifiers needed to return to the exact runtime session.
+public struct CodexExecutionBinding: Codable, Sendable, Equatable {
+    public var backend: CodexRuntimeBackend
+    public var ownership: RuntimeOwnership
+    public var evidence: RuntimeEvidence
+    public var telemetryQuality: TelemetryQuality
+    public var threadId: String?
+    public var turnId: String?
+    public var sessionId: String?
+    public var tmuxSessionName: String?
+    public var boundAt: Date?
+
+    public init(
+        backend: CodexRuntimeBackend,
+        ownership: RuntimeOwnership,
+        evidence: RuntimeEvidence,
+        telemetryQuality: TelemetryQuality,
+        threadId: String? = nil,
+        turnId: String? = nil,
+        sessionId: String? = nil,
+        tmuxSessionName: String? = nil,
+        boundAt: Date? = nil
+    ) {
+        self.backend = backend
+        self.ownership = ownership
+        self.evidence = evidence
+        self.telemetryQuality = telemetryQuality
+        self.threadId = threadId
+        self.turnId = turnId
+        self.sessionId = sessionId
+        self.tmuxSessionName = tmuxSessionName
+        self.boundAt = boundAt
+    }
+}
+
+public enum LifecyclePhase: String, Codable, Sendable, CaseIterable {
+    case queued
+    case launching
+    case running
+    case waiting
+    case inReview
+    case done
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .unknown
+    }
+}
+
+public enum LifecycleWaitReason: String, Codable, Sendable, CaseIterable {
+    case input
+    case approval
+    case ordinaryStop
+    case fault
+    case disconnected
+    case launchUncertain
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: value) ?? .unknown
+    }
+}
+
+/// Source identity and partial-order metadata for a normalized lifecycle event.
+public struct LifecycleEventWatermark: Codable, Sendable, Equatable {
+    public var eventId: String
+    public var source: String
+    public var generation: Int?
+    public var turnId: String?
+    public var sequence: Int?
+    public var occurredAt: Date
+
+    public init(
+        eventId: String,
+        source: String,
+        generation: Int? = nil,
+        turnId: String? = nil,
+        sequence: Int? = nil,
+        occurredAt: Date = .now
+    ) {
+        self.eventId = eventId
+        self.source = source
+        self.generation = generation
+        self.turnId = turnId
+        self.sequence = sequence
+        self.occurredAt = occurredAt
+    }
+}
+
+public struct LifecycleManualCorrection: Codable, Sendable, Equatable {
+    public var phase: LifecyclePhase
+    public var watermark: LifecycleEventWatermark?
+    public var correctedAt: Date
+
+    public init(
+        phase: LifecyclePhase,
+        watermark: LifecycleEventWatermark? = nil,
+        correctedAt: Date = .now
+    ) {
+        self.phase = phase
+        self.watermark = watermark
+        self.correctedAt = correctedAt
+    }
+}
+
+public struct LifecycleSnapshot: Codable, Sendable, Equatable {
+    public var phase: LifecyclePhase
+    public var waitReason: LifecycleWaitReason?
+    public var telemetryQuality: TelemetryQuality
+    public var watermark: LifecycleEventWatermark?
+    public var manualCorrection: LifecycleManualCorrection?
+
+    public init(
+        phase: LifecyclePhase = .unknown,
+        waitReason: LifecycleWaitReason? = nil,
+        telemetryQuality: TelemetryQuality = .unknown,
+        watermark: LifecycleEventWatermark? = nil,
+        manualCorrection: LifecycleManualCorrection? = nil
+    ) {
+        self.phase = phase
+        self.waitReason = waitReason
+        self.telemetryQuality = telemetryQuality
+        self.watermark = watermark
+        self.manualCorrection = manualCorrection
+    }
+}
+
+/// Durable claim written before a runtime launch side effect begins.
+public struct LaunchLease: Codable, Sendable, Equatable {
+    public var attemptId: String
+    public var backend: CodexRuntimeBackend
+    public var generation: Int
+    public var lifecycleCapability: String?
+    public var acquiredAt: Date
+    public var expiresAt: Date?
+
+    public init(
+        attemptId: String,
+        backend: CodexRuntimeBackend,
+        generation: Int,
+        lifecycleCapability: String? = nil,
+        acquiredAt: Date = .now,
+        expiresAt: Date? = nil
+    ) {
+        self.attemptId = attemptId
+        self.backend = backend
+        self.generation = generation
+        self.lifecycleCapability = lifecycleCapability
+        self.acquiredAt = acquiredAt
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Swift-owned runtime state. Kept out of `links.json` so lifecycle writes do
+/// not churn the cross-platform card file.
+public struct CardRuntimeState: Codable, Sendable, Equatable, Identifiable {
+    public var cardId: String
+    public var lifecycle: LifecycleSnapshot
+    public var launchLease: LaunchLease?
+    public var executionBinding: CodexExecutionBinding?
+    public var updatedAt: Date
+
+    public var id: String { cardId }
+
+    public init(
+        cardId: String,
+        lifecycle: LifecycleSnapshot = LifecycleSnapshot(),
+        launchLease: LaunchLease? = nil,
+        executionBinding: CodexExecutionBinding? = nil,
+        updatedAt: Date = .now
+    ) {
+        self.cardId = cardId
+        self.lifecycle = lifecycle
+        self.launchLease = launchLease
+        self.executionBinding = executionBinding
+        self.updatedAt = updatedAt
+    }
+}

--- a/Sources/KanbanCodeCore/Domain/Entities/Link.swift
+++ b/Sources/KanbanCodeCore/Domain/Entities/Link.swift
@@ -179,6 +179,8 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
 
     // Typed links — each independently optional
     public var sessionLink: SessionLink?
+    /// Stable Codex runtime identity and provenance. nil for legacy and non-Codex cards.
+    public var executionBinding: CodexExecutionBinding?
     public var tmuxLink: TmuxLink?
     public var worktreeLink: WorktreeLink?
     public var prLinks: [PRLink]
@@ -248,8 +250,9 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
     }
     /// Worst PR status across all PRs (highest urgency).
     public var worstPRStatus: PRStatus? { prLinks.compactMap(\.status).min() }
-    /// True if ALL PRs are merged or closed.
-    public var allPRsDone: Bool { !prLinks.isEmpty && prLinks.allSatisfy { $0.status == .merged || $0.status == .closed } }
+    /// True only when every relevant PR is merged. A closed-but-unmerged PR is
+    /// not evidence that the task shipped and must never auto-complete a card.
+    public var allPRsDone: Bool { !prLinks.isEmpty && prLinks.allSatisfy { $0.status == .merged } }
 
     // MARK: - Backward-compat computed properties
 
@@ -320,6 +323,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
         promptBody: String? = nil,
         promptImagePaths: [String]? = nil,
         sessionLink: SessionLink? = nil,
+        executionBinding: CodexExecutionBinding? = nil,
         tmuxLink: TmuxLink? = nil,
         worktreeLink: WorktreeLink? = nil,
         prLinks: [PRLink] = [],
@@ -349,6 +353,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
         self.promptBody = promptBody
         self.promptImagePaths = promptImagePaths
         self.sessionLink = sessionLink
+        self.executionBinding = executionBinding
         self.tmuxLink = tmuxLink
         self.worktreeLink = worktreeLink
         self.prLinks = prLinks
@@ -373,7 +378,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
         case manualOverrides, manuallyArchived, source, promptBody, promptImagePaths, isRemote, isLaunching, sortOrder, pinnedAt, pinnedSortOrder
         case discoveredBranches, discoveredRepos, assistant, apiServiceId
         // Typed links (new nested format)
-        case sessionLink, tmuxLink, worktreeLink, prLinks, issueLink, queuedPrompts, browserTabs
+        case sessionLink, executionBinding, tmuxLink, worktreeLink, prLinks, issueLink, queuedPrompts, browserTabs
         // Old format keys (for reading legacy format)
         case prLink
         case sessionId, sessionPath, worktreePath, worktreeBranch
@@ -415,6 +420,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
             let sn = try c.decodeIfPresent(Int.self, forKey: .sessionNumber)
             sessionLink = sid.map { SessionLink(sessionId: $0, sessionPath: sp, sessionNumber: sn) }
         }
+        executionBinding = try? c.decodeIfPresent(CodexExecutionBinding.self, forKey: .executionBinding)
 
         // Tmux link
         if let tl = try c.decodeIfPresent(TmuxLink.self, forKey: .tmuxLink) {
@@ -497,6 +503,7 @@ public struct Link: Identifiable, Codable, Sendable, Equatable {
 
         // Always write new nested format
         try c.encodeIfPresent(sessionLink, forKey: .sessionLink)
+        try c.encodeIfPresent(executionBinding, forKey: .executionBinding)
         try c.encodeIfPresent(tmuxLink, forKey: .tmuxLink)
         try c.encodeIfPresent(worktreeLink, forKey: .worktreeLink)
         if !prLinks.isEmpty {

--- a/Sources/KanbanCodeCore/Domain/Entities/Session.swift
+++ b/Sources/KanbanCodeCore/Domain/Entities/Session.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A discovered coding assistant session, extracted from session files.
-public struct Session: Identifiable, Sendable, Equatable {
+public struct Session: Identifiable, Codable, Sendable, Equatable {
     public let id: String // sessionId (UUID string)
     public var name: String? // Custom name or auto-generated summary
     public var firstPrompt: String? // First user message text
@@ -11,6 +11,8 @@ public struct Session: Identifiable, Sendable, Equatable {
     public var modifiedTime: Date
     public var jsonlPath: String? // Full path to the session file (.jsonl or .json)
     public var assistant: CodingAssistant // Which assistant this session belongs to
+    public var runtimeProvenance: CodexRuntimeProvenance? // nil when origin is not known or not Codex
+    public var runtimeLifecycle: LifecycleSnapshot? // structured App Server status when available
 
     public init(
         id: String,
@@ -21,7 +23,9 @@ public struct Session: Identifiable, Sendable, Equatable {
         messageCount: Int = 0,
         modifiedTime: Date = .now,
         jsonlPath: String? = nil,
-        assistant: CodingAssistant = .claude
+        assistant: CodingAssistant = .claude,
+        runtimeProvenance: CodexRuntimeProvenance? = nil,
+        runtimeLifecycle: LifecycleSnapshot? = nil
     ) {
         self.id = id
         self.name = name
@@ -32,6 +36,8 @@ public struct Session: Identifiable, Sendable, Equatable {
         self.modifiedTime = modifiedTime
         self.jsonlPath = jsonlPath
         self.assistant = assistant
+        self.runtimeProvenance = runtimeProvenance
+        self.runtimeLifecycle = runtimeLifecycle
     }
 
     /// Display title: custom name → summary → first prompt → session ID prefix.
@@ -41,5 +47,27 @@ public struct Session: Identifiable, Sendable, Equatable {
             return String(firstPrompt.prefix(100))
         }
         return String(id.prefix(8)) + "..."
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, firstPrompt, projectPath, gitBranch, messageCount, modifiedTime
+        case jsonlPath, assistant, runtimeProvenance, runtimeLifecycle
+    }
+
+    /// Field-isolated decoding keeps older discovery snapshots readable and
+    /// prevents a future provenance value from invalidating the session.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try? container.decodeIfPresent(String.self, forKey: .name)
+        firstPrompt = try? container.decodeIfPresent(String.self, forKey: .firstPrompt)
+        projectPath = try? container.decodeIfPresent(String.self, forKey: .projectPath)
+        gitBranch = try? container.decodeIfPresent(String.self, forKey: .gitBranch)
+        messageCount = (try? container.decodeIfPresent(Int.self, forKey: .messageCount)) ?? 0
+        modifiedTime = (try? container.decodeIfPresent(Date.self, forKey: .modifiedTime)) ?? .now
+        jsonlPath = try? container.decodeIfPresent(String.self, forKey: .jsonlPath)
+        assistant = (try? container.decodeIfPresent(CodingAssistant.self, forKey: .assistant)) ?? .claude
+        runtimeProvenance = try? container.decodeIfPresent(CodexRuntimeProvenance.self, forKey: .runtimeProvenance)
+        runtimeLifecycle = try? container.decodeIfPresent(LifecycleSnapshot.self, forKey: .runtimeLifecycle)
     }
 }

--- a/Sources/KanbanCodeCore/Domain/Ports/CodexRuntimePort.swift
+++ b/Sources/KanbanCodeCore/Domain/Ports/CodexRuntimePort.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Stable input for a single managed launch attempt. The scheduler persists a
+/// matching `LaunchLease` before handing this value to a runtime adapter.
+public struct CodexRuntimeLaunchRequest: Sendable, Equatable {
+    public var cardId: String
+    public var attemptId: String
+    public var generation: Int
+    public var lifecycleCapability: String
+    public var projectPath: String
+    public var prompt: String
+
+    public init(
+        cardId: String,
+        attemptId: String,
+        generation: Int,
+        lifecycleCapability: String,
+        projectPath: String,
+        prompt: String
+    ) {
+        self.cardId = cardId
+        self.attemptId = attemptId
+        self.generation = generation
+        self.lifecycleCapability = lifecycleCapability
+        self.projectPath = projectPath
+        self.prompt = prompt
+    }
+}
+
+public struct CodexRuntimeRecoveryRequest: Sendable, Equatable {
+    public var cardId: String
+    public var lease: LaunchLease
+    public var binding: CodexExecutionBinding?
+
+    public init(cardId: String, lease: LaunchLease, binding: CodexExecutionBinding? = nil) {
+        self.cardId = cardId
+        self.lease = lease
+        self.binding = binding
+    }
+}
+
+public struct CodexRuntimeFeedbackRequest: Sendable, Equatable {
+    public var cardId: String
+    public var binding: CodexExecutionBinding
+    public var body: String
+
+    public init(cardId: String, binding: CodexExecutionBinding, body: String) {
+        self.cardId = cardId
+        self.binding = binding
+        self.body = body
+    }
+}
+
+public struct CodexRuntimeLaunchReceipt: Sendable, Equatable {
+    public var binding: CodexExecutionBinding
+
+    public init(binding: CodexExecutionBinding) {
+        self.binding = binding
+    }
+}
+
+/// Result of comparing a durable launch lease with external runtime state.
+public enum CodexRuntimeRecoveryResult: Sendable, Equatable {
+    /// The side effect is definitely absent, so starting a new generation is safe.
+    case notStarted
+    case running(CodexExecutionBinding)
+    case stopped(CodexExecutionBinding?)
+    /// The adapter cannot prove whether the side effect exists. The scheduler
+    /// must retain the slot and must not launch again automatically.
+    case uncertain(String)
+}
+
+public enum CodexRuntimeError: Error, Sendable, Equatable, LocalizedError {
+    /// The adapter failed before it could create runtime work.
+    case notStarted(String)
+    /// Work may have been created. Recovery is required before another attempt.
+    case launchUncertain(String)
+    /// A stable runtime binding was acknowledged before a later launch stage
+    /// failed. Persisting the binding lets recovery inspect the exact work.
+    case partialLaunch(String, CodexExecutionBinding)
+    case invalidBinding(String)
+    case ownershipConflict(String)
+    case unavailable(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notStarted(let message), .launchUncertain(let message),
+             .invalidBinding(let message), .ownershipConflict(let message),
+             .unavailable(let message):
+            message
+        case .partialLaunch(let message, _):
+            message
+        }
+    }
+
+    public var mayHaveStartedWork: Bool {
+        switch self {
+        case .launchUncertain, .partialLaunch: true
+        default: false
+        }
+    }
+}
+
+/// Runtime-neutral managed Codex operations. UI and scheduling code depend on
+/// this port instead of directly starting processes or writing bindings.
+public protocol CodexRuntimePort: Sendable {
+    var backend: CodexRuntimeBackend { get }
+
+    func launch(_ request: CodexRuntimeLaunchRequest) async throws -> CodexRuntimeLaunchReceipt
+    func recover(_ request: CodexRuntimeRecoveryRequest) async -> CodexRuntimeRecoveryResult
+    func sendFeedback(_ request: CodexRuntimeFeedbackRequest) async throws
+}
+
+/// Supplies managed agents with the structured, authenticated handoff they
+/// must use instead of relying on natural-language completion guesses.
+public enum CodexManagedPrompt {
+    public static func withReviewReadyInstruction(
+        _ prompt: String,
+        request: CodexRuntimeLaunchRequest,
+        backend: CodexRuntimeBackend,
+        sessionID: String,
+        helperPath: String = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".kanban-code/bin/kanban-code-lifecycle")
+    ) -> String {
+        let command = [
+            "KANBAN_CODE_CARD_ID=\(ShellCommand.shellEscape(request.cardId))",
+            "KANBAN_CODE_SESSION_ID=\(ShellCommand.shellEscape(sessionID))",
+            "KANBAN_CODE_ATTEMPT_ID=\(ShellCommand.shellEscape(request.attemptId))",
+            "KANBAN_CODE_GENERATION=\(request.generation)",
+            "KANBAN_CODE_BACKEND=\(backend.rawValue)",
+            "KANBAN_CODE_LIFECYCLE_CAPABILITY=\(ShellCommand.shellEscape(request.lifecycleCapability))",
+            "\(ShellCommand.shellEscape(helperPath)) review-ready",
+        ].joined(separator: " ")
+        return """
+        \(prompt)
+
+        [Kanban Code lifecycle]
+        When the deliverable is ready for human review, run this exact local command once:
+        \(command)
+        Do not treat a normal turn stop as completion.
+        """
+    }
+
+}

--- a/Sources/KanbanCodeCore/Infrastructure/CodexRuntimeStateStore.swift
+++ b/Sources/KanbanCodeCore/Infrastructure/CodexRuntimeStateStore.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// Atomic, actor-isolated persistence for per-card Codex lifecycle and launch state.
+public actor CodexRuntimeStateStore {
+    private struct Container: Codable {
+        var version: Int
+        var states: [String: CardRuntimeState]
+
+        init(version: Int = 1, states: [String: CardRuntimeState] = [:]) {
+            self.version = version
+            self.states = states
+        }
+    }
+
+    private let fileURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(basePath: String? = nil) {
+        let base = basePath ?? (NSHomeDirectory() as NSString).appendingPathComponent(".kanban-code")
+        fileURL = URL(fileURLWithPath: base, isDirectory: true)
+            .appendingPathComponent("codex-runtime-state.json")
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    public func readAll() throws -> [String: CardRuntimeState] {
+        try readContainer().states
+    }
+
+    public func state(for cardId: String) throws -> CardRuntimeState? {
+        try readContainer().states[cardId]
+    }
+
+    public func upsert(_ state: CardRuntimeState) throws {
+        var container = try readContainer()
+        container.states[state.cardId] = state
+        try write(container)
+    }
+
+    /// Reduces and persists a lifecycle event in one actor-isolated operation.
+    /// This prevents an App Server event and a hook event from both reducing
+    /// against the same stale snapshot across suspension points.
+    @discardableResult
+    public func applyLifecycleEvent(_ event: CodexLifecycleEvent) throws -> CodexLifecycleReduction {
+        var container = try readContainer()
+        let reduction = CodexLifecycleReducer.reduce(
+            current: container.states[event.cardId],
+            event: event
+        )
+        switch reduction {
+        case .applied(let state), .conflicted(let state):
+            container.states[event.cardId] = state
+            try write(container)
+        case .duplicate, .ignoredStale:
+            break
+        }
+        return reduction
+    }
+
+    public func remove(cardId: String) throws {
+        var container = try readContainer()
+        guard container.states.removeValue(forKey: cardId) != nil else { return }
+        try write(container)
+    }
+
+    public func rekey(sourceCardId: String, targetCardId: String) throws {
+        var container = try readContainer()
+        guard var source = container.states[sourceCardId] else { return }
+        if let target = container.states[targetCardId], target != source {
+            throw CodexRuntimeStateStoreError.conflictingTarget(targetCardId)
+        }
+        source.cardId = targetCardId
+        container.states[targetCardId] = source
+        container.states.removeValue(forKey: sourceCardId)
+        try write(container)
+    }
+
+    private func readContainer() throws -> Container {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return Container() }
+        let data = try Data(contentsOf: fileURL)
+        do {
+            return try decoder.decode(Container.self, from: data)
+        } catch {
+            let backupURL = fileURL.appendingPathExtension("bkp")
+            try? FileManager.default.removeItem(at: backupURL)
+            try? FileManager.default.copyItem(at: fileURL, to: backupURL)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
+            throw CodexRuntimeStateStoreError.corrupt(fileURL.path)
+        }
+    }
+
+    private func write(_ container: Container) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: fileURL.deletingLastPathComponent().path
+        )
+        try encoder.encode(container).write(to: fileURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+    }
+}
+
+public enum CodexRuntimeStateStoreError: Error, LocalizedError {
+    case conflictingTarget(String)
+    case corrupt(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .conflictingTarget(let cardId):
+            "Codex runtime state already exists for target card \(cardId)"
+        case .corrupt(let path):
+            "Codex runtime state is corrupt at \(path)"
+        }
+    }
+}

--- a/Sources/KanbanCodeCore/Infrastructure/DependencyChecker.swift
+++ b/Sources/KanbanCodeCore/Infrastructure/DependencyChecker.swift
@@ -7,6 +7,10 @@ public enum DependencyChecker {
         public let claudeAvailable: Bool
         public let geminiAvailable: Bool
         public let codexAvailable: Bool
+        public let codexAppServerAvailable: Bool
+        public let codexDesktopAvailable: Bool
+        public let codexExecutablePath: String?
+        public let codexVersion: String?
         public let hooksInstalled: Bool
         public let pandocAvailable: Bool
         public let wkhtmltoimageAvailable: Bool
@@ -22,6 +26,10 @@ public enum DependencyChecker {
 
         public init(
             claudeAvailable: Bool, geminiAvailable: Bool = false, codexAvailable: Bool = false,
+            codexAppServerAvailable: Bool = false,
+            codexDesktopAvailable: Bool = false,
+            codexExecutablePath: String? = nil,
+            codexVersion: String? = nil,
             hooksInstalled: Bool,
             assistantHooks: [CodingAssistant: Bool] = [:],
             pandocAvailable: Bool,
@@ -33,6 +41,10 @@ public enum DependencyChecker {
             self.claudeAvailable = claudeAvailable
             self.geminiAvailable = geminiAvailable
             self.codexAvailable = codexAvailable
+            self.codexAppServerAvailable = codexAppServerAvailable
+            self.codexDesktopAvailable = codexDesktopAvailable
+            self.codexExecutablePath = codexExecutablePath
+            self.codexVersion = codexVersion
             self.hooksInstalled = hooksInstalled
             self.pandocAvailable = pandocAvailable
             self.wkhtmltoimageAvailable = wkhtmltoimageAvailable
@@ -53,6 +65,12 @@ public enum DependencyChecker {
         async let claude = ShellCommand.isAvailable("claude")
         async let gemini = ShellCommand.isAvailable("gemini")
         async let codex = ShellCommand.isAvailable("codex")
+        async let codexIdentity: CodexExecutableIdentity? = Task.detached(priority: .utility) {
+            try? CodexExecutableResolver.resolve()
+        }.value
+        async let codexDesktop = Task.detached(priority: .utility) {
+            FileManager.default.fileExists(atPath: "/Applications/Codex.app")
+        }.value
         async let pandoc = ShellCommand.isAvailable("pandoc")
         async let wkhtmltoimage = ShellCommand.isAvailable("wkhtmltoimage")
         async let gh = ShellCommand.isAvailable("gh")
@@ -76,10 +94,15 @@ public enum DependencyChecker {
             pushover = false
         }
 
+        let identity = await codexIdentity
         return await Status(
             claudeAvailable: claude,
             geminiAvailable: gemini,
             codexAvailable: codex,
+            codexAppServerAvailable: identity != nil,
+            codexDesktopAvailable: codexDesktop,
+            codexExecutablePath: identity?.url.path,
+            codexVersion: identity?.version,
             hooksInstalled: hooks[.claude] ?? false,
             assistantHooks: hooks,
             pandocAvailable: pandoc,

--- a/Sources/KanbanCodeCore/Infrastructure/SettingsStore.swift
+++ b/Sources/KanbanCodeCore/Infrastructure/SettingsStore.swift
@@ -20,6 +20,8 @@ public struct Settings: Codable, Sendable {
     public var defaultAPIServiceIds: [String: String]
     /// Automatic context-limit guard for Claude sessions.
     public var selfCompact: SelfCompactSettings
+    /// Global Codex board runtime and scheduler capacity.
+    public var codexBoard: CodexBoardSettings
 
     public init(
         projects: [Project] = [],
@@ -36,7 +38,8 @@ public struct Settings: Codable, Sendable {
         enabledAssistants: [CodingAssistant] = CodingAssistant.allCases,
         apiServices: [APIService] = [],
         defaultAPIServiceIds: [String: String] = [:],
-        selfCompact: SelfCompactSettings = SelfCompactSettings()
+        selfCompact: SelfCompactSettings = SelfCompactSettings(),
+        codexBoard: CodexBoardSettings = CodexBoardSettings()
     ) {
         self.projects = projects
         self.globalView = globalView
@@ -53,6 +56,7 @@ public struct Settings: Codable, Sendable {
         self.apiServices = apiServices
         self.defaultAPIServiceIds = defaultAPIServiceIds
         self.selfCompact = selfCompact
+        self.codexBoard = codexBoard
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -60,7 +64,7 @@ public struct Settings: Codable, Sendable {
         case promptTemplate, githubIssuePromptTemplate, columnOrder, hasCompletedOnboarding, defaultAssistant
         case enabledAssistants
         case apiServices, defaultAPIServiceIds
-        case selfCompact
+        case selfCompact, codexBoard
         case skill // backward-compat: old name for promptTemplate
     }
 
@@ -100,6 +104,7 @@ public struct Settings: Codable, Sendable {
         apiServices = (try? container.decodeIfPresent([APIService].self, forKey: .apiServices)) ?? []
         defaultAPIServiceIds = (try? container.decodeIfPresent([String: String].self, forKey: .defaultAPIServiceIds)) ?? [:]
         selfCompact = (try? container.decodeIfPresent(SelfCompactSettings.self, forKey: .selfCompact)) ?? SelfCompactSettings()
+        codexBoard = (try? container.decodeIfPresent(CodexBoardSettings.self, forKey: .codexBoard)) ?? CodexBoardSettings()
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -119,7 +124,46 @@ public struct Settings: Codable, Sendable {
         try container.encode(apiServices, forKey: .apiServices)
         try container.encode(defaultAPIServiceIds, forKey: .defaultAPIServiceIds)
         try container.encode(selfCompact, forKey: .selfCompact)
+        try container.encode(codexBoard, forKey: .codexBoard)
         // Note: "skill" is NOT encoded — only read for backward-compat
+    }
+}
+
+public struct CodexBoardSettings: Codable, Sendable, Equatable {
+    public static let concurrencyRange = 1 ... 32
+
+    public var runtime: CodexRuntimeBackend
+    private var storedMaxConcurrency: Int
+
+    public var maxConcurrency: Int {
+        get { storedMaxConcurrency }
+        set { storedMaxConcurrency = Self.clampedConcurrency(newValue) }
+    }
+
+    public init(runtime: CodexRuntimeBackend = .cliTmux, maxConcurrency: Int = 3) {
+        self.runtime = runtime
+        storedMaxConcurrency = Self.clampedConcurrency(maxConcurrency)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case runtime, maxConcurrency
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        runtime = (try? container.decodeIfPresent(CodexRuntimeBackend.self, forKey: .runtime)) ?? .cliTmux
+        let concurrency = (try? container.decodeIfPresent(Int.self, forKey: .maxConcurrency)) ?? 3
+        storedMaxConcurrency = Self.clampedConcurrency(concurrency)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(runtime, forKey: .runtime)
+        try container.encode(maxConcurrency, forKey: .maxConcurrency)
+    }
+
+    public static func clampedConcurrency(_ value: Int) -> Int {
+        min(max(value, concurrencyRange.lowerBound), concurrencyRange.upperBound)
     }
 }
 

--- a/Sources/KanbanCodeCore/Infrastructure/ShellCommand.swift
+++ b/Sources/KanbanCodeCore/Infrastructure/ShellCommand.swift
@@ -143,4 +143,9 @@ public enum ShellCommand {
         }
         return nil
     }
+
+    /// POSIX-shell single-quote escaping used by launch command builders.
+    public static func shellEscape(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
 }

--- a/Sources/KanbanCodeCore/UseCases/AssignColumn.swift
+++ b/Sources/KanbanCodeCore/UseCases/AssignColumn.swift
@@ -51,7 +51,7 @@ public enum AssignColumn {
 
         // PR exists and session not actively working → inReview
         // This skips Waiting when addressing review feedback: Claude stops → goes directly to In Review
-        if hasPR, let state = activityState,
+        if link.effectiveAssistant != .codex, hasPR, let state = activityState,
            state == .needsAttention || state == .idleWaiting || state == .ended || state == .stale {
             return .inReview
         }

--- a/Sources/KanbanCodeCore/UseCases/BoardStore.swift
+++ b/Sources/KanbanCodeCore/UseCases/BoardStore.swift
@@ -71,6 +71,13 @@ public final class AppState: @unchecked Sendable {
     public var isLoading: Bool = false
     public var lastRefresh: Date?
 
+    /// Runtime selected for the five workflow lanes. Changing this projection
+    /// never starts, stops or migrates an existing session.
+    public var codexBoardRuntime: CodexRuntimeBackend = .cliTmux
+
+    /// Swift-owned canonical lifecycle state, loaded independently from links.json.
+    public var codexRuntimeStates: [String: CardRuntimeState] = [:]
+
     /// Configured projects (refreshed from settings on each reconciliation).
     public var configuredProjects: [Project] = []
     /// Cached excluded paths for global view.
@@ -222,6 +229,15 @@ public final class AppState: @unchecked Sendable {
     /// Visible columns — cached for independent observation.
     public internal(set) var visibleColumns: [KanbanCodeColumn] = []
 
+    /// Mode-filtered Codex cards for the five-lane board. `filteredCards` stays
+    /// available to legacy search and All Sessions surfaces.
+    public internal(set) var codexBoardCards: [KanbanCodeCard] = []
+
+    public internal(set) var codexBoardCardsByColumn: [KanbanCodeColumn: [KanbanCodeCard]] = [:]
+
+    /// Global attention crosses runtime and project filters by design.
+    public internal(set) var attentionItems: [AttentionItem] = []
+
     /// Cards presented above the normal lanes while retaining their real column.
     public internal(set) var pinnedCards: [KanbanCodeCard] = []
 
@@ -232,7 +248,20 @@ public final class AppState: @unchecked Sendable {
             let session = link.sessionLink.flatMap { sessions[$0.sessionId] }
             let activity = link.sessionLink.flatMap { activityMap[$0.sessionId] }
             let rateLimited = link.projectPath.map { rateLimitedRepos.contains($0) } ?? false
-            return KanbanCodeCard(link: link, session: session, activityState: activity, isBusy: busyCards.contains(link.id), isRateLimited: rateLimited)
+            var projectedLink = link
+            if projectedLink.executionBinding == nil,
+               let recoveredBinding = codexRuntimeStates[link.id]?.executionBinding {
+                projectedLink.executionBinding = recoveredBinding
+            }
+            if link.effectiveAssistant == .codex || codexRuntimeStates[link.id] != nil {
+                projectedLink.column = CodexBoardProjection.column(
+                    for: link,
+                    runtimeState: codexRuntimeStates[link.id],
+                    legacyActivity: activity,
+                    hasLiveWork: link.tmuxLink.map { tmuxSessions.contains($0.sessionName) } ?? false
+                )
+            }
+            return KanbanCodeCard(link: projectedLink, session: session, activityState: activity, isBusy: busyCards.contains(link.id), isRateLimited: rateLimited)
         }
         if newCards != cards { cards = newCards }
 
@@ -275,15 +304,34 @@ public final class AppState: @unchecked Sendable {
         }
         if newByColumn != cardsByColumn { cardsByColumn = newByColumn }
 
-        let alwaysVisible: [KanbanCodeColumn] = [.backlog, .inProgress, .waiting, .inReview, .done]
-        var newVisible = alwaysVisible
-        if (newByColumn[.allSessions]?.count ?? 0) > 0 { newVisible.append(.allSessions) }
+        let newVisible = CodexBoardProjection.lanes
         if newVisible != visibleColumns { visibleColumns = newVisible }
+
+        let newBoardCards = newFiltered.filter {
+            CodexBoardProjection.matchesBoardRuntime($0.link, runtime: codexBoardRuntime)
+        }
+        if newBoardCards != codexBoardCards { codexBoardCards = newBoardCards }
+
+        var newBoardByColumn: [KanbanCodeColumn: [KanbanCodeCard]] = [:]
+        for column in CodexBoardProjection.lanes {
+            newBoardByColumn[column] = newBoardCards.filter { $0.column == column }
+        }
+        if newBoardByColumn != codexBoardCardsByColumn { codexBoardCardsByColumn = newBoardByColumn }
+
+        let newAttention = CodexBoardProjection.attentionItems(
+            links: links,
+            runtimeStates: codexRuntimeStates
+        )
+        if newAttention != attentionItems { attentionItems = newAttention }
     }
 
     /// Cards for a specific column (pre-computed, cached).
     public func cards(in column: KanbanCodeColumn) -> [KanbanCodeCard] {
         cardsByColumn[column] ?? []
+    }
+
+    public func codexBoardCards(in column: KanbanCodeColumn) -> [KanbanCodeCard] {
+        codexBoardCardsByColumn[column] ?? []
     }
 
     /// Lane presentation excludes pinned cards, but their underlying column is unchanged.
@@ -410,6 +458,10 @@ public enum Action: Sendable {
     case reconciled(ReconciliationResult)
     case gitHubIssuesUpdated(links: [Link])
     case activityChanged([String: ActivityState]) // sessionId → state
+    case codexRuntimeStatesLoaded([String: CardRuntimeState])
+    case codexRuntimeStateChanged(CardRuntimeState)
+    case bindCodexRuntime(cardId: String, binding: CodexExecutionBinding)
+    case setCodexBoardRuntime(CodexRuntimeBackend)
 
     // Busy state (transient spinners)
     case setBusy(cardId: String, busy: Bool)
@@ -521,6 +573,8 @@ public enum Effect: Sendable {
     case sendPromptToTmux(sessionName: String, promptBody: String, assistant: CodingAssistant)
     case sendPromptWithImagesToTmux(sessionName: String, promptBody: String, imagePaths: [String], assistant: CodingAssistant)
     case deleteFiles([String])
+    case rekeyCodexRuntimeState(sourceCardId: String, targetCardId: String)
+    case upsertCodexRuntimeState(CardRuntimeState)
 
     // Channels
     case loadChannels
@@ -1596,6 +1650,18 @@ public enum Reducer {
                 state.error = "Cannot merge: both cards have different issues"
                 return []
             }
+            if let sourceBinding = source.executionBinding,
+               let targetBinding = target.executionBinding,
+               sourceBinding != targetBinding {
+                state.error = "Cannot merge: both cards have different Codex runtime bindings"
+                return []
+            }
+            if let sourceRuntime = state.codexRuntimeStates[sourceId],
+               let targetRuntime = state.codexRuntimeStates[targetId],
+               sourceRuntime.executionBinding != targetRuntime.executionBinding {
+                state.error = "Cannot merge: both cards have different Codex runtime state"
+                return []
+            }
 
             // Transfer links from source → target (only fill nil slots)
             if target.sessionLink == nil { target.sessionLink = source.sessionLink }
@@ -1605,6 +1671,7 @@ public enum Reducer {
             if target.projectPath == nil { target.projectPath = source.projectPath }
             if target.name == nil { target.name = source.name }
             if target.promptBody == nil { target.promptBody = source.promptBody }
+            if target.executionBinding == nil { target.executionBinding = source.executionBinding }
             if target.pinnedAt == nil {
                 target.pinnedAt = source.pinnedAt
                 target.pinnedSortOrder = source.pinnedSortOrder
@@ -1645,8 +1712,17 @@ public enum Reducer {
             }
             if state.selectedCardId == sourceId { state.selectedCardId = targetId }
 
+            var effects: [Effect] = [.upsertLink(target), .removeLink(sourceId)]
+            if var runtime = state.codexRuntimeStates.removeValue(forKey: sourceId) {
+                runtime.cardId = targetId
+                if state.codexRuntimeStates[targetId] == nil {
+                    state.codexRuntimeStates[targetId] = runtime
+                }
+                effects.append(.rekeyCodexRuntimeState(sourceCardId: sourceId, targetCardId: targetId))
+            }
+
             KanbanCodeLog.info("store", "Merge: \(sourceId.prefix(12)) → \(targetId.prefix(12))")
-            return [.upsertLink(target), .removeLink(sourceId)]
+            return effects
 
         // MARK: Async Completions
 
@@ -1982,6 +2058,9 @@ public enum Reducer {
             // Lightweight column update — no full reconciliation, just activity → column
             var changed = false
             for (id, var link) in state.links where link.isLaunching != true {
+                // Canonical lifecycle is authoritative once available. Legacy
+                // mtime/activity heuristics must not overwrite it.
+                if state.codexRuntimeStates[id] != nil { continue }
                 guard let sessionId = link.sessionLink?.sessionId,
                       let activity = activityMap[sessionId] else { continue }
                 let hasWorktree = link.worktreeLink?.branch != nil
@@ -1994,6 +2073,34 @@ public enum Reducer {
             }
             if state.activityMap != activityMap { state.activityMap = activityMap }
             return changed ? [.persistLinks(Array(state.links.values))] : []
+
+        case .codexRuntimeStatesLoaded(let runtimeStates):
+            guard state.codexRuntimeStates != runtimeStates else { return [] }
+            state.codexRuntimeStates = runtimeStates
+            state.rebuildCards()
+            return []
+
+        case .codexRuntimeStateChanged(let runtimeState):
+            guard state.codexRuntimeStates[runtimeState.cardId] != runtimeState else { return [] }
+            state.codexRuntimeStates[runtimeState.cardId] = runtimeState
+            state.rebuildCards()
+            return [.upsertCodexRuntimeState(runtimeState)]
+
+        case .bindCodexRuntime(let cardId, let binding):
+            guard var link = state.links[cardId] else { return [] }
+            link.assistant = .codex
+            link.executionBinding = binding
+            if binding.backend == .cliTmux, let sessionName = binding.tmuxSessionName {
+                link.tmuxLink = TmuxLink(sessionName: sessionName)
+            }
+            link.updatedAt = .now
+            state.links[cardId] = link
+            return [.upsertLink(link)]
+
+        case .setCodexBoardRuntime(let runtime):
+            guard runtime != .unknown else { return [] }
+            state.codexBoardRuntime = runtime
+            return []
 
         // MARK: Busy State
 
@@ -2094,6 +2201,7 @@ public final class BoardStore: @unchecked Sendable {
     private let ghAdapter: GhCliAdapter?
     private let worktreeAdapter: GitWorktreeAdapter?
     private let tmuxAdapter: TmuxManagerPort?
+    private let codexRuntimeStateStore: CodexRuntimeStateStore
 
     public let sessionStore: SessionStore
 
@@ -2106,7 +2214,8 @@ public final class BoardStore: @unchecked Sendable {
         ghAdapter: GhCliAdapter? = nil,
         worktreeAdapter: GitWorktreeAdapter? = nil,
         tmuxAdapter: TmuxManagerPort? = nil,
-        sessionStore: SessionStore = ClaudeCodeSessionStore()
+        sessionStore: SessionStore = ClaudeCodeSessionStore(),
+        codexRuntimeStateStore: CodexRuntimeStateStore = CodexRuntimeStateStore()
     ) {
         self.state = AppState()
         self.effectHandler = effectHandler
@@ -2118,12 +2227,14 @@ public final class BoardStore: @unchecked Sendable {
         self.worktreeAdapter = worktreeAdapter
         self.tmuxAdapter = tmuxAdapter
         self.sessionStore = sessionStore
+        self.codexRuntimeStateStore = codexRuntimeStateStore
     }
 
     /// Actions that only toggle UI state and don't affect card data — skip rebuildCards().
     private static func needsRebuild(_ action: Action) -> Bool {
         switch action {
-        case .reconciled, .setRateLimitedRepos:
+        case .reconciled, .setRateLimitedRepos,
+             .codexRuntimeStatesLoaded, .codexRuntimeStateChanged:
             // These reducers diff their card inputs and rebuild only when the
             // derived card snapshots can actually change. A periodic PR/status
             // pass that produces the same links must not relayout the board.
@@ -2272,7 +2383,11 @@ public final class BoardStore: @unchecked Sendable {
                     excludedPaths: settings.globalView.excludedPaths,
                     remote: settings.remote
                 ))
+                dispatch(.setCodexBoardRuntime(settings.codexBoard.runtime))
             }
+        }
+        if let runtimeStates = try? await codexRuntimeStateStore.readAll() {
+            dispatch(.codexRuntimeStatesLoaded(runtimeStates))
         }
         // Also load cached links so cards appear instantly
         if state.links.isEmpty {
@@ -2579,6 +2694,27 @@ public final class BoardStore: @unchecked Sendable {
                 globalRemoteSettings: globalRemoteSettings
             )
             dispatch(.reconciled(result))
+            // App Server discovery supplies structured status for imported
+            // threads. Persist it under the reconciled card ID so subsequent
+            // notifications and the global attention strip share one source
+            // of truth with board-created work.
+            let linkBySessionID = Dictionary(
+                state.links.values.compactMap { link in
+                    link.sessionLink.map { ($0.sessionId, link) }
+                },
+                uniquingKeysWith: { current, _ in current }
+            )
+            for session in sessions where session.assistant == .codex {
+                guard let lifecycle = session.runtimeLifecycle,
+                      let link = linkBySessionID[session.id],
+                      state.codexRuntimeStates[link.id]?.launchLease == nil else { continue }
+                dispatch(.codexRuntimeStateChanged(CardRuntimeState(
+                    cardId: link.id,
+                    lifecycle: lifecycle,
+                    executionBinding: link.executionBinding,
+                    updatedAt: .now
+                )))
+            }
             KanbanCodeLog.info("reconcile", "dispatch: \(t5.duration(to: .now))")
 
             // Fetch GitHub issues if enough time has elapsed

--- a/Sources/KanbanCodeCore/UseCases/CardReconciler.swift
+++ b/Sources/KanbanCodeCore/UseCases/CardReconciler.swift
@@ -88,6 +88,8 @@ public enum CardReconciler {
             if let cardId, var link = linksById[cardId] {
                 // Archived cards stay archived — just mark matched to prevent duplicates
                 if link.manuallyArchived {
+                    enrichRuntimeIdentity(link: &link, from: session)
+                    linksById[cardId] = link
                     matchedSessionIds.insert(session.id)
                     continue
                 }
@@ -106,6 +108,7 @@ public enum CardReconciler {
                 // Different sessionId (e.g., shell tab session) — just mark matched,
                 // don't overwrite the card's primary session.
                 link.lastActivity = session.modifiedTime
+                enrichRuntimeIdentity(link: &link, from: session)
                 if link.projectPath == nil, let pp = session.projectPath {
                     link.projectPath = pp
                 }
@@ -152,7 +155,9 @@ public enum CardReconciler {
                     sessionLink: SessionLink(
                         sessionId: session.id,
                         sessionPath: session.jsonlPath
-                    )
+                    ),
+                    executionBinding: executionBinding(from: session),
+                    assistant: session.assistant
                 )
                 linksById[newLink.id] = newLink
                 cardIdBySessionId[session.id] = newLink.id
@@ -475,6 +480,26 @@ public enum CardReconciler {
         }
 
         return Array(linksById.values)
+    }
+
+    private static func enrichRuntimeIdentity(link: inout Link, from session: Session) {
+        if link.assistant == nil { link.assistant = session.assistant }
+        if link.executionBinding == nil {
+            link.executionBinding = executionBinding(from: session)
+        }
+    }
+
+    private static func executionBinding(from session: Session) -> CodexExecutionBinding? {
+        guard session.assistant == .codex, let provenance = session.runtimeProvenance else { return nil }
+        return CodexExecutionBinding(
+            backend: provenance.backend,
+            ownership: provenance.ownership,
+            evidence: provenance.evidence,
+            telemetryQuality: provenance.telemetryQuality,
+            threadId: provenance.backend == .app ? session.id : nil,
+            sessionId: session.id,
+            boundAt: provenance.observedAt
+        )
     }
 
     // MARK: - Private

--- a/Sources/KanbanCodeCore/UseCases/CodexLaunchScheduler.swift
+++ b/Sources/KanbanCodeCore/UseCases/CodexLaunchScheduler.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// Immutable queue input. Queue order is persisted by the card's creation time
+/// and made deterministic with its ID as a tie-breaker.
+public struct CodexQueuedTask: Sendable, Equatable, Identifiable {
+    public var id: String { cardId }
+    public var cardId: String
+    public var backend: CodexRuntimeBackend
+    public var enqueuedAt: Date
+    public var projectPath: String
+    public var prompt: String
+
+    public init(
+        cardId: String,
+        backend: CodexRuntimeBackend,
+        enqueuedAt: Date,
+        projectPath: String,
+        prompt: String
+    ) {
+        self.cardId = cardId
+        self.backend = backend
+        self.enqueuedAt = enqueuedAt
+        self.projectPath = projectPath
+        self.prompt = prompt
+    }
+}
+
+public enum CodexLaunchOutcome: Sendable, Equatable {
+    case launched(cardId: String, binding: CodexExecutionBinding)
+    case failed(cardId: String, message: String)
+    case uncertain(cardId: String, message: String)
+}
+
+public enum CodexLaunchRecoveryOutcome: Sendable, Equatable {
+    case notStarted(cardId: String)
+    case running(cardId: String, binding: CodexExecutionBinding)
+    case stopped(cardId: String, binding: CodexExecutionBinding?)
+    case uncertain(cardId: String, message: String)
+}
+
+/// Serialized, durable auto-claim coordinator. A lease is committed before a
+/// runtime side effect and recovery runs before the first scheduling pass.
+public actor CodexLaunchScheduler {
+    public typealias AttemptID = @Sendable () -> String
+    public typealias Clock = @Sendable () -> Date
+
+    private let stateStore: CodexRuntimeStateStore
+    private let runtimes: [CodexRuntimeBackend: any CodexRuntimePort]
+    private let makeAttemptID: AttemptID
+    private let now: Clock
+    private var didRecover = false
+    private var isScheduling = false
+
+    public init(
+        stateStore: CodexRuntimeStateStore,
+        runtimes: [CodexRuntimeBackend: any CodexRuntimePort],
+        makeAttemptID: @escaping AttemptID = { UUID().uuidString },
+        now: @escaping Clock = { .now }
+    ) {
+        self.stateStore = stateStore
+        self.runtimes = runtimes
+        self.makeAttemptID = makeAttemptID
+        self.now = now
+    }
+
+    /// Runs one atomic scheduling pass. Queued work for an inactive backend is
+    /// deliberately ignored; already-running work for every backend still
+    /// counts against the global capacity.
+    @discardableResult
+    public func schedule(
+        queuedTasks: [CodexQueuedTask],
+        activeBackend: CodexRuntimeBackend,
+        maxConcurrency: Int
+    ) async throws -> [CodexLaunchOutcome] {
+        // Actors are re-entrant at every await. Reserve the whole scheduling
+        // pass before the first suspension so overlapping UI refreshes cannot
+        // claim and launch the same card twice.
+        guard !isScheduling else { return [] }
+        isScheduling = true
+        defer { isScheduling = false }
+
+        if !didRecover {
+            _ = await recoverPersistedAttempts()
+            didRecover = true
+        }
+
+        var states = try await stateStore.readAll()
+        let capacity = CodexBoardSettings.clampedConcurrency(maxConcurrency)
+        var available = max(0, capacity - states.values.filter(Self.occupiesSlot).count)
+        guard available > 0, runtimes[activeBackend] != nil else { return [] }
+
+        let candidates = queuedTasks
+            .filter { $0.backend == activeBackend }
+            .filter { task in
+                guard let state = states[task.cardId] else { return true }
+                return state.lifecycle.phase == .queued
+            }
+            .sorted {
+                if $0.enqueuedAt != $1.enqueuedAt { return $0.enqueuedAt < $1.enqueuedAt }
+                return $0.cardId < $1.cardId
+            }
+
+        var outcomes: [CodexLaunchOutcome] = []
+        for task in candidates where available > 0 {
+            guard let runtime = runtimes[task.backend] else { continue }
+            let previous = states[task.cardId]
+            let generation = (previous?.launchLease?.generation ?? 0) + 1
+            let attemptedAt = now()
+            let lease = LaunchLease(
+                attemptId: makeAttemptID(),
+                backend: task.backend,
+                generation: generation,
+                lifecycleCapability: try CodexLifecycleCapability.generate(),
+                acquiredAt: attemptedAt
+            )
+            var claimed = previous ?? CardRuntimeState(cardId: task.cardId)
+            claimed.lifecycle = LifecycleSnapshot(
+                phase: .launching,
+                telemetryQuality: .precise
+            )
+            claimed.launchLease = lease
+            claimed.updatedAt = attemptedAt
+
+            // This durable write is the commit point before any external effect.
+            try await stateStore.upsert(claimed)
+            states[task.cardId] = claimed
+            available -= 1
+
+            let request = CodexRuntimeLaunchRequest(
+                cardId: task.cardId,
+                attemptId: lease.attemptId,
+                generation: generation,
+                lifecycleCapability: lease.lifecycleCapability!,
+                projectPath: task.projectPath,
+                prompt: task.prompt
+            )
+
+            do {
+                let receipt = try await runtime.launch(request)
+                claimed.lifecycle = LifecycleSnapshot(
+                    phase: .running,
+                    telemetryQuality: receipt.binding.telemetryQuality
+                )
+                claimed.executionBinding = receipt.binding
+                claimed.updatedAt = now()
+                try await stateStore.upsert(claimed)
+                states[task.cardId] = claimed
+                outcomes.append(.launched(cardId: task.cardId, binding: receipt.binding))
+            } catch {
+                let runtimeError = error as? CodexRuntimeError
+                let uncertain = runtimeError?.mayHaveStartedWork == true
+                if case .partialLaunch(_, let binding)? = runtimeError {
+                    claimed.executionBinding = binding
+                }
+                claimed.lifecycle = LifecycleSnapshot(
+                    phase: .waiting,
+                    waitReason: uncertain ? .launchUncertain : .fault,
+                    telemetryQuality: .limited
+                )
+                claimed.updatedAt = now()
+                try await stateStore.upsert(claimed)
+                states[task.cardId] = claimed
+                let message = runtimeError?.localizedDescription ?? error.localizedDescription
+                if uncertain {
+                    outcomes.append(.uncertain(cardId: task.cardId, message: message))
+                } else {
+                    // A definite pre-launch failure releases the slot immediately.
+                    available += 1
+                    outcomes.append(.failed(cardId: task.cardId, message: message))
+                }
+            }
+        }
+        return outcomes
+    }
+
+    /// Reconciles all persisted slot-holding attempts. This is safe to call
+    /// repeatedly and never creates new runtime work.
+    public func recoverPersistedAttempts() async -> [CodexLaunchRecoveryOutcome] {
+        guard let states = try? await stateStore.readAll() else { return [] }
+        var outcomes: [CodexLaunchRecoveryOutcome] = []
+        for var state in states.values where Self.occupiesSlot(state) {
+            guard let lease = state.launchLease, let runtime = runtimes[lease.backend] else {
+                continue
+            }
+            let request = CodexRuntimeRecoveryRequest(
+                cardId: state.cardId,
+                lease: lease,
+                binding: state.executionBinding
+            )
+            let result = await runtime.recover(request)
+            switch result {
+            case .notStarted:
+                state.lifecycle = LifecycleSnapshot(phase: .queued, telemetryQuality: .precise)
+                outcomes.append(.notStarted(cardId: state.cardId))
+            case .running(let binding):
+                state.lifecycle = LifecycleSnapshot(
+                    phase: .running,
+                    telemetryQuality: binding.telemetryQuality
+                )
+                state.executionBinding = binding
+                outcomes.append(.running(cardId: state.cardId, binding: binding))
+            case .stopped(let binding):
+                state.lifecycle = LifecycleSnapshot(
+                    phase: .waiting,
+                    waitReason: .ordinaryStop,
+                    telemetryQuality: .precise
+                )
+                if let binding { state.executionBinding = binding }
+                outcomes.append(.stopped(cardId: state.cardId, binding: binding))
+            case .uncertain(let message):
+                state.lifecycle = LifecycleSnapshot(
+                    phase: .waiting,
+                    waitReason: .launchUncertain,
+                    telemetryQuality: .limited
+                )
+                outcomes.append(.uncertain(cardId: state.cardId, message: message))
+            }
+            state.updatedAt = now()
+            try? await stateStore.upsert(state)
+        }
+        return outcomes
+    }
+
+    public static func occupiesSlot(_ state: CardRuntimeState) -> Bool {
+        guard state.launchLease != nil else { return false }
+        switch state.lifecycle.phase {
+        case .launching, .running, .unknown:
+            return true
+        case .waiting:
+            return state.lifecycle.waitReason == .disconnected || state.lifecycle.waitReason == .launchUncertain
+        case .queued, .inReview, .done:
+            return false
+        }
+    }
+}

--- a/Sources/KanbanCodeCore/UseCases/CodexLifecycle.swift
+++ b/Sources/KanbanCodeCore/UseCases/CodexLifecycle.swift
@@ -1,0 +1,340 @@
+import Foundation
+
+/// Canonical lifecycle inputs produced by App Server and hook adapters.
+/// Adapters normalize their wire payloads before the board sees them.
+public enum CodexLifecycleEventKind: String, Codable, Sendable, CaseIterable {
+    case queued
+    case launchStarted
+    case running
+    case waitingForInput
+    case waitingForApproval
+    case stopped
+    case faulted
+    case disconnected
+    case reviewReady
+    case accepted
+
+    fileprivate var semanticPrecedence: Int {
+        switch self {
+        case .queued: 0
+        case .launchStarted: 10
+        case .running: 20
+        case .stopped: 30
+        case .disconnected: 35
+        case .waitingForInput: 40
+        case .waitingForApproval: 50
+        case .faulted: 60
+        case .reviewReady: 70
+        case .accepted: 80
+        }
+    }
+}
+
+public struct CodexLifecycleEvent: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let cardId: String
+    public let kind: CodexLifecycleEventKind
+    public let watermark: LifecycleEventWatermark
+    public let telemetryQuality: TelemetryQuality
+
+    public init(
+        id: String,
+        cardId: String,
+        kind: CodexLifecycleEventKind,
+        watermark: LifecycleEventWatermark,
+        telemetryQuality: TelemetryQuality = .precise
+    ) {
+        self.id = id
+        self.cardId = cardId
+        self.kind = kind
+        self.watermark = watermark
+        self.telemetryQuality = telemetryQuality
+    }
+}
+
+public enum CodexLifecycleReduction: Sendable, Equatable {
+    case applied(CardRuntimeState)
+    case duplicate(CardRuntimeState)
+    case ignoredStale(CardRuntimeState)
+    case conflicted(CardRuntimeState)
+}
+
+/// Deterministic reducer for lifecycle signals. It intentionally compares
+/// launch generation and turn identity before timestamps: arrival order is not
+/// authority when App Server reconnects or hook files are drained in batches.
+public enum CodexLifecycleReducer {
+    public static func reduce(
+        current: CardRuntimeState?,
+        event: CodexLifecycleEvent,
+        now: Date = .now
+    ) -> CodexLifecycleReduction {
+        var state = current ?? CardRuntimeState(cardId: event.cardId)
+        guard state.cardId == event.cardId else { return .ignoredStale(state) }
+
+        if state.lifecycle.watermark?.eventId == event.id {
+            return .duplicate(state)
+        }
+
+        if let existing = state.lifecycle.watermark {
+            switch compare(event: event, to: existing, currentPhase: state.lifecycle.phase) {
+            case .older:
+                return .ignoredStale(state)
+            case .incomparable:
+                // Do not let an incomparable source clear a precise state. Mark
+                // the projection limited so the UI never overclaims certainty.
+                state.lifecycle.telemetryQuality = .limited
+                state.updatedAt = now
+                return .conflicted(state)
+            case .same, .newer:
+                break
+            }
+        }
+
+        if let correction = state.lifecycle.manualCorrection {
+            if let correctionWatermark = correction.watermark,
+               compare(event: event, to: correctionWatermark, currentPhase: correction.phase) != .newer {
+                return .ignoredStale(state)
+            }
+            state.lifecycle.manualCorrection = nil
+        }
+
+        let projection = lifecycle(for: event.kind)
+        state.lifecycle.phase = projection.phase
+        state.lifecycle.waitReason = projection.reason
+        state.lifecycle.telemetryQuality = event.telemetryQuality
+        state.lifecycle.watermark = event.watermark
+        state.updatedAt = now
+        return .applied(state)
+    }
+
+    private enum Order { case older, same, newer, incomparable }
+
+    private static func compare(
+        event: CodexLifecycleEvent,
+        to existing: LifecycleEventWatermark,
+        currentPhase: LifecyclePhase
+    ) -> Order {
+        if event.id == existing.eventId { return .same }
+
+        if let incomingGeneration = event.watermark.generation,
+           let existingGeneration = existing.generation,
+           incomingGeneration != existingGeneration {
+            return incomingGeneration > existingGeneration ? .newer : .older
+        }
+
+        // Explicit, acknowledgement-backed human actions are authoritative
+        // within the same launch generation even when the helper that entered
+        // review did not know the App Server turn identifier.
+        if event.kind == .accepted, event.watermark.source == "board:accept" {
+            return .newer
+        }
+        if event.kind == .reviewReady, event.watermark.source == "board:manual-review" {
+            return .newer
+        }
+        if event.kind == .running,
+           (event.watermark.source == "board:continue" || event.watermark.source == "board:response") {
+            return .newer
+        }
+
+        // A structured review-ready signal is authoritative for the current
+        // launch. Codex normally emits Stop immediately afterwards; that Stop
+        // describes the same completed work and must not move the card back to
+        // Waiting.
+        if currentPhase == .inReview, event.kind == .stopped {
+            return .older
+        }
+
+        if let incomingTurn = event.watermark.turnId,
+           let existingTurn = existing.turnId {
+            if incomingTurn != existingTurn {
+                // Different turns are ordered only by an explicit sequence or
+                // trusted occurrence time. Otherwise neither source can erase
+                // the other.
+                if let incomingSequence = event.watermark.sequence,
+                   let existingSequence = existing.sequence,
+                   incomingSequence != existingSequence {
+                    return incomingSequence > existingSequence ? .newer : .older
+                }
+                if event.watermark.occurredAt != existing.occurredAt {
+                    return event.watermark.occurredAt > existing.occurredAt ? .newer : .older
+                }
+                return .incomparable
+            }
+
+            if let incomingSequence = event.watermark.sequence,
+               let existingSequence = existing.sequence,
+               incomingSequence != existingSequence {
+                return incomingSequence > existingSequence ? .newer : .older
+            }
+
+
+            // Approval and input requests suspend a turn rather than ending
+            // it. A later running signal for that same turn resumes it.
+            if currentPhase == .waiting,
+               event.kind == .running,
+               event.watermark.occurredAt > existing.occurredAt {
+                return .newer
+            }
+            let currentPrecedence = semanticPrecedence(for: currentPhase)
+            if event.kind.semanticPrecedence != currentPrecedence {
+                return event.kind.semanticPrecedence > currentPrecedence ? .newer : .older
+            }
+        }
+
+        if event.watermark.source == existing.source {
+            if event.watermark.occurredAt != existing.occurredAt {
+                return event.watermark.occurredAt > existing.occurredAt ? .newer : .older
+            }
+            return .newer
+        }
+        return .incomparable
+    }
+
+    private static func semanticPrecedence(for phase: LifecyclePhase) -> Int {
+        switch phase {
+        case .queued: 0
+        case .launching: 10
+        case .running: 20
+        case .waiting: 30
+        case .inReview: 70
+        case .done: 80
+        case .unknown: -1
+        }
+    }
+
+    private static func lifecycle(
+        for kind: CodexLifecycleEventKind
+    ) -> (phase: LifecyclePhase, reason: LifecycleWaitReason?) {
+        switch kind {
+        case .queued: (.queued, nil)
+        case .launchStarted: (.launching, nil)
+        case .running: (.running, nil)
+        case .waitingForInput: (.waiting, .input)
+        case .waitingForApproval: (.waiting, .approval)
+        case .stopped: (.waiting, .ordinaryStop)
+        case .faulted: (.waiting, .fault)
+        case .disconnected: (.waiting, .disconnected)
+        case .reviewReady: (.inReview, nil)
+        case .accepted: (.done, nil)
+        }
+    }
+}
+
+public enum AttentionPrimaryAction: String, Sendable, Equatable {
+    case respond
+    case approve
+    case retry
+    case inspect
+}
+
+public struct AttentionItem: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let cardId: String
+    public let title: String
+    public let runtime: CodexRuntimeBackend
+    public let project: String?
+    public let reason: LifecycleWaitReason
+    public let age: TimeInterval
+    public let telemetryQuality: TelemetryQuality
+    public let primaryAction: AttentionPrimaryAction
+    public let canOpenSession: Bool
+
+    fileprivate var priority: Int {
+        switch reason {
+        case .approval: 0
+        case .input: 1
+        case .fault: 2
+        case .launchUncertain: 3
+        case .ordinaryStop: 4
+        case .disconnected: 5
+        case .unknown: 6
+        }
+    }
+}
+
+/// Pure projections used by both SwiftUI and tests. All Sessions is deliberately
+/// not returned as a board lane; it remains a separate search/archive surface.
+public enum CodexBoardProjection {
+    public static let lanes: [KanbanCodeColumn] = [
+        .backlog, .inProgress, .waiting, .inReview, .done,
+    ]
+
+    public static func column(
+        for link: Link,
+        runtimeState: CardRuntimeState?,
+        legacyActivity: ActivityState? = nil,
+        hasLiveWork: Bool = false
+    ) -> KanbanCodeColumn {
+        if link.manuallyArchived { return .allSessions }
+
+        // Completion is intentionally strict: closed-but-unmerged is not done,
+        // and every linked PR must be merged.
+        if link.allPRsDone {
+            return .done
+        }
+
+        let lifecycle = runtimeState?.lifecycle
+        let phase = lifecycle?.manualCorrection?.phase ?? lifecycle?.phase
+        switch phase {
+        case .queued: return .backlog
+        case .launching, .running: return .inProgress
+        case .waiting: return .waiting
+        case .inReview: return .inReview
+        case .done: return .done
+        case .unknown, nil:
+            return AssignColumn.assign(
+                link: link,
+                activityState: legacyActivity,
+                // A PR is optional evidence, never a Codex lifecycle state.
+                // Only the strict all-merged check above can affect the lane.
+                hasPR: false,
+                allPRsDone: false,
+                hasWorktree: hasLiveWork
+            )
+        }
+    }
+
+    public static func matchesBoardRuntime(_ link: Link, runtime: CodexRuntimeBackend) -> Bool {
+        guard link.effectiveAssistant == .codex else { return false }
+        return link.executionBinding?.backend == runtime
+    }
+
+    public static func attentionItems(
+        links: [String: Link],
+        runtimeStates: [String: CardRuntimeState],
+        now: Date = .now
+    ) -> [AttentionItem] {
+        runtimeStates.values.compactMap { state -> AttentionItem? in
+            guard let link = links[state.cardId], !link.manuallyArchived,
+                  state.lifecycle.phase == .waiting,
+                  let reason = state.lifecycle.waitReason,
+                  reason != .unknown
+            else { return nil }
+
+            let action: AttentionPrimaryAction = switch reason {
+            case .approval: .approve
+            case .input: .respond
+            case .launchUncertain: .retry
+            case .ordinaryStop, .fault, .disconnected, .unknown: .inspect
+            }
+            return AttentionItem(
+                id: "\(state.cardId):\(reason.rawValue)",
+                cardId: state.cardId,
+                title: link.displayTitle,
+                runtime: link.executionBinding?.backend ?? .unknown,
+                project: link.projectPath.map { ($0 as NSString).lastPathComponent },
+                reason: reason,
+                age: max(0, now.timeIntervalSince(state.updatedAt)),
+                telemetryQuality: state.lifecycle.telemetryQuality,
+                primaryAction: action,
+                canOpenSession: link.executionBinding?.threadId != nil
+                    || link.executionBinding?.tmuxSessionName != nil
+                    || link.tmuxLink != nil
+            )
+        }.sorted {
+            if $0.priority != $1.priority { return $0.priority < $1.priority }
+            if $0.age != $1.age { return $0.age > $1.age }
+            return $0.cardId < $1.cardId
+        }
+    }
+}

--- a/Sources/KanbanCodeCore/UseCases/EffectHandler.swift
+++ b/Sources/KanbanCodeCore/UseCases/EffectHandler.swift
@@ -11,6 +11,7 @@ public actor EffectHandler {
     private let setClipboardImage: (@Sendable (Data) -> Void)?
     private let channelsStore: ChannelsStore
     private let notifier: NotifierPort?
+    private let codexRuntimeStateStore: CodexRuntimeStateStore?
 
     // MARK: - Chat notification burst throttler
     //
@@ -35,13 +36,15 @@ public actor EffectHandler {
         tmuxAdapter: TmuxManagerPort? = nil,
         setClipboardImage: (@Sendable (Data) -> Void)? = nil,
         channelsStore: ChannelsStore? = nil,
-        notifier: NotifierPort? = nil
+        notifier: NotifierPort? = nil,
+        codexRuntimeStateStore: CodexRuntimeStateStore? = nil
     ) {
         self.coordinationStore = coordinationStore
         self.tmuxAdapter = tmuxAdapter
         self.setClipboardImage = setClipboardImage
         self.channelsStore = channelsStore ?? ChannelsStore()
         self.notifier = notifier
+        self.codexRuntimeStateStore = codexRuntimeStateStore
     }
 
     public func execute(_ effect: Effect, dispatch: @MainActor @Sendable (Action) -> Void) async {
@@ -168,6 +171,23 @@ public actor EffectHandler {
         case .deleteFiles(let paths):
             for path in paths {
                 try? FileManager.default.removeItem(atPath: path)
+            }
+
+        case .rekeyCodexRuntimeState(let sourceCardId, let targetCardId):
+            do {
+                try await codexRuntimeStateStore?.rekey(
+                    sourceCardId: sourceCardId,
+                    targetCardId: targetCardId
+                )
+            } catch {
+                await dispatch(.setError("Could not merge Codex runtime state: \(error.localizedDescription)"))
+            }
+
+        case .upsertCodexRuntimeState(let state):
+            do {
+                try await codexRuntimeStateStore?.upsert(state)
+            } catch {
+                await dispatch(.setError("Could not persist Codex runtime state: \(error.localizedDescription)"))
             }
 
         case .loadChannels:

--- a/Sources/KanbanCodeCore/UseCases/LaunchSession.swift
+++ b/Sources/KanbanCodeCore/UseCases/LaunchSession.swift
@@ -44,7 +44,7 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
         }
 
         // Prepend cd to ensure we're in the right directory even if zshrc changes it
-        var fullCmd = "cd \(shellEscape(projectPath))"
+        var fullCmd = "cd \(ShellCommand.shellEscape(projectPath))"
         if let preamble, !preamble.isEmpty {
             fullCmd += " && \(preamble)"
         }
@@ -94,7 +94,7 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
         }
 
         // Prepend cd to ensure we're in the right directory even if zshrc changes it
-        var fullCmd = "cd \(shellEscape(projectPath))"
+        var fullCmd = "cd \(ShellCommand.shellEscape(projectPath))"
         if let preamble, !preamble.isEmpty {
             fullCmd += " && \(preamble)"
         }
@@ -122,7 +122,7 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
                     let escaped = value.replacingOccurrences(of: "\"", with: "\\\"")
                     parts.append("\(key)=\"\(escaped)\"")
                 } else {
-                    parts.append("\(key)=\(shellEscape(value))")
+                    parts.append("\(key)=\(ShellCommand.shellEscape(value))")
                 }
             }
         }
@@ -138,7 +138,4 @@ public final class LaunchSession: SessionLauncher, @unchecked Sendable {
         return projectName
     }
 
-    private func shellEscape(_ str: String) -> String {
-        "'" + str.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
 }

--- a/Sources/KanbanCodeLifecycle/main.swift
+++ b/Sources/KanbanCodeLifecycle/main.swift
@@ -1,0 +1,38 @@
+import Foundation
+import KanbanCodeCore
+
+@main
+enum KanbanCodeLifecycleCommand {
+    static func main() async {
+        do {
+            guard CommandLine.arguments.count == 2 else {
+                throw CodexLifecycleInboxError.invalidEnvelope("expected review-ready or hook-event")
+            }
+            let command = CommandLine.arguments[1]
+            let input: Data
+            if command == "hook-event" {
+                input = try readBoundedStandardInput()
+            } else {
+                input = Data()
+            }
+            _ = try await CodexLifecycleHelper.emit(command: command, standardInput: input)
+        } catch {
+            // Never print event contents or the per-attempt capability.
+            FileHandle.standardError.write(Data("kanban-code-lifecycle: \(error.localizedDescription)\n".utf8))
+            Foundation.exit(EXIT_FAILURE)
+        }
+    }
+
+    private static func readBoundedStandardInput() throws -> Data {
+        let maximum = CodexLifecycleInboxWriter.maximumEventBytes
+        var input = Data()
+        while let chunk = try FileHandle.standardInput.read(upToCount: min(64 * 1024, maximum + 1 - input.count)),
+              !chunk.isEmpty {
+            input.append(chunk)
+            guard input.count <= maximum else {
+                throw CodexLifecycleInboxError.eventTooLarge(actual: input.count, maximum: maximum)
+            }
+        }
+        return input
+    }
+}

--- a/Tests/KanbanCodeCoreTests/CardLifecycleTests.swift
+++ b/Tests/KanbanCodeCoreTests/CardLifecycleTests.swift
@@ -56,8 +56,8 @@ struct CardLifecycleTests {
         #expect(link.column == .inReview)
     }
 
-    @Test("All PRs merged/closed → done")
-    func allPRsDone() {
+    @Test("A closed but unmerged PR keeps the card in review")
+    func closedUnmergedIsNotDone() {
         var link = Link(
             column: .inReview,
             sessionLink: SessionLink(sessionId: "s1"),
@@ -67,7 +67,7 @@ struct CardLifecycleTests {
             ]
         )
         UpdateCardColumn.update(link: &link, activityState: .ended, hasWorktree: false)
-        #expect(link.column == .done)
+        #expect(link.column == .inReview)
     }
 
     @Test("Actively working overrides manual column to inProgress")

--- a/Tests/KanbanCodeCoreTests/Codex/CodexAppServerClientTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexAppServerClientTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("CodexAppServerClient")
+struct CodexAppServerClientTests {
+    @Test("Correlates interleaved responses and sends initialized notification")
+    func correlatesInterleavedResponses() async throws {
+        let transport = FakeCodexAppServerLineTransport()
+        let client = CodexAppServerClient(transport: transport, requestTimeout: .seconds(1))
+        await client.start()
+
+        async let initialized = client.initialize(clientName: "tests", clientVersion: "1")
+        let initializeRequest = try await transport.nextSentMessage()
+        #expect(initializeRequest.method == "initialize")
+        await transport.receive(response: .object([
+            "userAgent": .string("codex-test"),
+            "protocolVersion": .string("1"),
+        ]), for: initializeRequest.id)
+        let initializeResult = try await initialized
+        #expect(initializeResult.userAgent == "codex-test")
+
+        let initializedNotification = try await transport.nextSentMessage()
+        #expect(initializedNotification.method == "initialized")
+        #expect(initializedNotification.id == nil)
+
+        async let list = client.listThreads(limit: 25, sourceKinds: ["appServer", "cli"])
+        async let started = client.startThread(cwd: "/tmp/project")
+        let first = try await transport.nextSentMessage()
+        let second = try await transport.nextSentMessage()
+        let listRequest = first.method == "thread/list" ? first : second
+        let startRequest = first.method == "thread/start" ? first : second
+
+        await transport.receive(response: .object([
+            "thread": .object([
+                "id": .string("thread-new"),
+                "cwd": .string("/tmp/project"),
+                "sourceKind": .string("appServer"),
+                "status": .object([
+                    "type": .string("active"),
+                    "activeFlags": .array([.string("waitingOnApproval")]),
+                ]),
+            ]),
+        ]), for: startRequest.id)
+        await transport.receive(response: .object([
+            "data": .array([
+                .object([
+                    "id": .string("thread-existing"),
+                    "sourceKinds": .array([.string("cli"), .string("future-source")]),
+                    "status": .string("idle"),
+                ]),
+            ]),
+            "nextCursor": .string("page-2"),
+        ]), for: listRequest.id)
+
+        let startResult = try await started
+        let listResult = try await list
+        #expect(startResult.id == "thread-new")
+        #expect(startResult.sourceKinds == ["appServer"])
+        #expect(startResult.status?.waitingOnApproval == true)
+        #expect(listResult.data.first?.sourceKinds == ["cli", "future-source"])
+        #expect(listResult.data.first?.status?.type == "idle")
+        #expect(listResult.nextCursor == "page-2")
+    }
+
+    @Test("Builds resume, turn start, and turn steer requests")
+    func buildsThreadAndTurnRequests() async throws {
+        let transport = FakeCodexAppServerLineTransport()
+        let client = CodexAppServerClient(transport: transport, requestTimeout: .seconds(1))
+        await client.start()
+
+        async let resumed = client.resumeThread(id: "thread-1")
+        let resumeRequest = try await transport.nextSentMessage()
+        #expect(resumeRequest.method == "thread/resume")
+        #expect(resumeRequest.params?["threadId"] == .string("thread-1"))
+        await transport.receive(response: .object([
+            "thread": .object(["id": .string("thread-1")]),
+        ]), for: resumeRequest.id)
+        #expect((try await resumed).id == "thread-1")
+
+        async let turn = client.startTurn(threadID: "thread-1", text: "implement it")
+        let turnRequest = try await transport.nextSentMessage()
+        #expect(turnRequest.method == "turn/start")
+        #expect(turnRequest.params?["threadId"] == .string("thread-1"))
+        await transport.receive(response: .object([
+            "turn": .object(["id": .string("turn-1"), "status": .string("inProgress")]),
+        ]), for: turnRequest.id)
+        #expect((try await turn).id == "turn-1")
+
+        async let steered = client.steerTurn(threadID: "thread-1", turnID: "turn-1", text: "also add tests")
+        let steerRequest = try await transport.nextSentMessage()
+        #expect(steerRequest.method == "turn/steer")
+        #expect(steerRequest.params?["expectedTurnId"] == .string("turn-1"))
+        await transport.receive(response: .object([
+            "turnId": .string("turn-1"),
+        ]), for: steerRequest.id)
+        #expect(try await steered == "turn-1")
+    }
+
+    @Test("Streams notifications and only allowlisted server requests")
+    func streamsInboundMessages() async throws {
+        let transport = FakeCodexAppServerLineTransport()
+        let client = CodexAppServerClient(transport: transport, requestTimeout: .seconds(1))
+        let notifications = await client.notifications()
+        let requests = await client.serverRequests()
+        await client.start()
+
+        let notificationTask = Task { try await firstValue(from: notifications) }
+        await transport.receive(method: "thread/status/changed", params: .object([
+            "threadId": .string("thread-1"),
+            "status": .object([
+                "type": .string("active"),
+                "activeFlags": .array([.string("waitingOnApproval")]),
+            ]),
+        ]))
+        let notification = try await notificationTask.value
+        let changed = try notification.decodeParams(as: CodexThreadStatusChanged.self)
+        #expect(changed.threadID == "thread-1")
+        #expect(changed.status.waitingOnApproval)
+
+        await transport.receive(
+            id: .string("server-1"),
+            method: "item/commandExecution/requestApproval",
+            params: .object(["command": .string("swift test")])
+        )
+        var requestIterator = requests.makeAsyncIterator()
+        let request = await requestIterator.next()
+        #expect(request?.method == "item/commandExecution/requestApproval")
+        try await client.respond(to: request!, result: .object(["decision": .string("accept")]))
+        let response = try await transport.nextSentMessage()
+        #expect(response.id == .string("server-1"))
+        #expect(response.result?["decision"] == .string("accept"))
+
+        await transport.receive(
+            id: .string("server-2"),
+            method: "dangerous/unknownRequest",
+            params: .object([:])
+        )
+        let rejection = try await transport.nextSentMessage()
+        #expect(rejection.id == .string("server-2"))
+        #expect(rejection.error?.code == -32601)
+    }
+
+    @Test("Times out pending requests and fails them on disconnect")
+    func timeoutAndDisconnect() async throws {
+        let timeoutTransport = FakeCodexAppServerLineTransport()
+        let timeoutClient = CodexAppServerClient(transport: timeoutTransport, requestTimeout: .milliseconds(30))
+        await timeoutClient.start()
+
+        do {
+            _ = try await timeoutClient.listThreads()
+            Issue.record("Expected timeout")
+        } catch let error as CodexAppServerClientError {
+            #expect(error == .requestTimedOut(method: "thread/list"))
+        }
+
+        let disconnectTransport = FakeCodexAppServerLineTransport()
+        let disconnectClient = CodexAppServerClient(transport: disconnectTransport, requestTimeout: .seconds(1))
+        await disconnectClient.start()
+        let initialGeneration = await disconnectClient.generation
+        let pending = Task { try await disconnectClient.resumeThread(id: "thread-1") }
+        _ = try await disconnectTransport.nextSentMessage()
+        await disconnectTransport.finish()
+
+        do {
+            _ = try await pending.value
+            Issue.record("Expected disconnect")
+        } catch let error as CodexAppServerClientError {
+            #expect(error == .disconnected)
+        }
+        #expect(await disconnectClient.generation == initialGeneration + 1)
+    }
+
+    @Test("Concurrent connection callers share one in-flight client factory")
+    func connectionCoalescesConcurrentCallers() async throws {
+        let factory = CountingClientFactory()
+        let connection = CodexAppServerConnection(makeClient: { try await factory.make() })
+
+        async let first = connection.client()
+        async let second = connection.client()
+        let (a, b) = try await (first, second)
+
+        #expect(a === b)
+        #expect(await factory.count == 1)
+    }
+
+    private func firstValue<Element: Sendable>(from stream: AsyncStream<Element>) async throws -> Element {
+        var iterator = stream.makeAsyncIterator()
+        guard let value = await iterator.next() else {
+            throw TestError.streamEnded
+        }
+        return value
+    }
+
+    private enum TestError: Error {
+        case streamEnded
+    }
+}
+
+private actor CountingClientFactory {
+    private(set) var count = 0
+
+    func make() async throws -> CodexAppServerClient {
+        count += 1
+        try await Task.sleep(for: .milliseconds(30))
+        let client = CodexAppServerClient(transport: FakeCodexAppServerLineTransport())
+        await client.start()
+        return client
+    }
+}
+
+private actor FakeCodexAppServerLineTransport: CodexAppServerLineTransport {
+    private var inbound: [String] = []
+    private var inboundWaiters: [CheckedContinuation<String?, Error>] = []
+    private var sent: [String] = []
+    private var sentWaiters: [CheckedContinuation<String, Never>] = []
+    private var finished = false
+
+    func writeLine(_ line: String) async throws {
+        if let waiter = sentWaiters.first {
+            sentWaiters.removeFirst()
+            waiter.resume(returning: line)
+        } else {
+            sent.append(line)
+        }
+    }
+
+    func readLine() async throws -> String? {
+        if !inbound.isEmpty { return inbound.removeFirst() }
+        if finished { return nil }
+        return try await withCheckedThrowingContinuation { inboundWaiters.append($0) }
+    }
+
+    func nextSentMessage() async throws -> TestRPCMessage {
+        let line: String
+        if !sent.isEmpty {
+            line = sent.removeFirst()
+        } else {
+            line = await withCheckedContinuation { sentWaiters.append($0) }
+        }
+        return try JSONDecoder().decode(TestRPCMessage.self, from: Data(line.utf8))
+    }
+
+    func receive(response: CodexJSONValue, for id: CodexRPCIdentifier?) {
+        guard let id else { return }
+        receiveObject(["jsonrpc": .string("2.0"), "id": id.jsonValue, "result": response])
+    }
+
+    func receive(method: String, params: CodexJSONValue) {
+        receiveObject(["jsonrpc": .string("2.0"), "method": .string(method), "params": params])
+    }
+
+    func receive(id: CodexRPCIdentifier, method: String, params: CodexJSONValue) {
+        receiveObject([
+            "jsonrpc": .string("2.0"),
+            "id": id.jsonValue,
+            "method": .string(method),
+            "params": params,
+        ])
+    }
+
+    func finish() {
+        finished = true
+        let waiters = inboundWaiters
+        inboundWaiters.removeAll()
+        for waiter in waiters { waiter.resume(returning: nil) }
+    }
+
+    private func receiveObject(_ object: [String: CodexJSONValue]) {
+        let data = try! JSONEncoder().encode(CodexJSONValue.object(object))
+        let line = String(decoding: data, as: UTF8.self)
+        if let waiter = inboundWaiters.first {
+            inboundWaiters.removeFirst()
+            waiter.resume(returning: line)
+        } else {
+            inbound.append(line)
+        }
+    }
+}
+
+private struct TestRPCMessage: Decodable {
+    let id: CodexRPCIdentifier?
+    let method: String?
+    let params: CodexJSONValue?
+    let result: CodexJSONValue?
+    let error: CodexRPCError?
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexAppServerProcessTransportTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexAppServerProcessTransportTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("Codex App Server process transport")
+struct CodexAppServerProcessTransportTests {
+    @Test("Project-local executables are rejected after path normalization")
+    func projectLocalExecutable() {
+        let root = URL(fileURLWithPath: "/tmp/example-project")
+        #expect(CodexExecutableResolver.isProjectLocal(
+            executable: root.appendingPathComponent("node_modules/.bin/codex"),
+            projectRoot: root
+        ))
+        #expect(!CodexExecutableResolver.isProjectLocal(
+            executable: URL(fileURLWithPath: "/opt/homebrew/bin/codex"),
+            projectRoot: root
+        ))
+    }
+
+    @Test("Line transport separates concurrent reads and writes")
+    func lineTransportRoundTrip() async throws {
+        let executable = URL(fileURLWithPath: "/usr/bin/env")
+        let transport = try CodexAppServerProcessTransport.launch(
+            executable: executable,
+            environment: ["PATH": "/usr/bin:/bin"]
+        )
+        // `env app-server` exits because there is no such executable. The
+        // transport must report EOF cleanly rather than hanging a reader.
+        let line = try await transport.readLine()
+        #expect(line == nil)
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexAppServerSessionDiscoveryTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexAppServerSessionDiscoveryTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import KanbanCodeCore
+
+@Suite("Codex App Server session discovery")
+struct CodexAppServerSessionDiscoveryTests {
+    @Test("Source kinds classify app and CLI evidence without guessing conflicts")
+    func sourceClassification() {
+        let app = CodexAppServerSessionDiscovery.provenance(sourceKinds: ["desktopApp"])
+        #expect(app.backend == .app)
+        #expect(app.telemetryQuality == .precise)
+
+        let cli = CodexAppServerSessionDiscovery.provenance(sourceKinds: ["cli"])
+        #expect(cli.backend == .cliTmux)
+
+        let conflict = CodexAppServerSessionDiscovery.provenance(sourceKinds: ["app", "cli"])
+        #expect(conflict.backend == .unknown)
+        #expect(conflict.telemetryQuality == .limited)
+
+        let absent = CodexAppServerSessionDiscovery.provenance(sourceKinds: [])
+        #expect(absent.backend == .unknown)
+    }
+
+    @Test("Structured thread status maps existing App sessions into active and waiting lifecycle")
+    func statusProjection() throws {
+        let waiting = try JSONDecoder().decode(CodexThread.self, from: Data(#"{"id":"one","status":{"type":"active","activeFlags":["waitingOnApproval"]}}"#.utf8))
+        let running = try JSONDecoder().decode(CodexThread.self, from: Data(#"{"id":"two","status":{"type":"active"}}"#.utf8))
+        let historical = try JSONDecoder().decode(CodexThread.self, from: Data(#"{"id":"three","status":{"type":"idle"}}"#.utf8))
+
+        #expect(CodexAppServerSessionDiscovery.lifecycle(status: waiting.status).waitReason == .approval)
+        #expect(CodexAppServerSessionDiscovery.lifecycle(status: running.status).phase == .running)
+        #expect(CodexAppServerSessionDiscovery.lifecycle(status: historical.status).phase == .unknown)
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexCLITmuxRuntimeTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexCLITmuxRuntimeTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("Codex CLI tmux runtime")
+struct CodexCLITmuxRuntimeTests {
+    final class FakeTmux: TmuxManagerPort, @unchecked Sendable {
+        var sessions: [TmuxSession] = []
+        var created: [(String, String, String?)] = []
+        var prompts: [(String, String)] = []
+        var available = true
+        var createError: Error?
+        var promptError: Error?
+
+        func listSessions() async throws -> [TmuxSession] { sessions }
+        func createSession(name: String, path: String, command: String?) async throws {
+            if let createError { throw createError }
+            created.append((name, path, command))
+            sessions.append(TmuxSession(name: name, path: path, attached: false))
+        }
+        func killSession(name: String) async throws {}
+        func sendPrompt(to sessionName: String, text: String) async throws {}
+        func pastePrompt(to sessionName: String, text: String) async throws {
+            if let promptError { throw promptError }
+            prompts.append((sessionName, text))
+        }
+        func pasteText(to sessionName: String, text: String) async throws {}
+        func submitPrompt(to sessionName: String) async throws {}
+        func capturePane(sessionName: String) async throws -> String { "" }
+        func sendBracketedPaste(to sessionName: String) async throws {}
+        func findSessionForWorktree(sessions: [TmuxSession], worktreePath: String, branch: String?) -> TmuxSession? { nil }
+        func isAvailable() async -> Bool { available }
+    }
+
+    final class FakeMetadata: CodexTmuxMetadataPort, @unchecked Sendable {
+        var tags: [String: CodexTmuxOwnershipTag] = [:]
+        var setError: Error?
+
+        func ownershipTag(for sessionName: String) async throws -> CodexTmuxOwnershipTag? {
+            tags[sessionName]
+        }
+
+        func setOwnershipTag(_ tag: CodexTmuxOwnershipTag, for sessionName: String) async throws {
+            if let setError { throw setError }
+            tags[sessionName] = tag
+        }
+    }
+
+    private func request(cardId: String = "card-1", attempt: String = "attempt-1", generation: Int = 1) -> CodexRuntimeLaunchRequest {
+        CodexRuntimeLaunchRequest(
+            cardId: cardId,
+            attemptId: attempt,
+            generation: generation,
+            lifecycleCapability: String(repeating: "a", count: 64),
+            projectPath: "/tmp/project",
+            prompt: "implement it"
+        )
+    }
+
+    @Test("Launch uses reserved namespace, tags ownership, then submits prompt")
+    func launchContract() async throws {
+        let tmux = FakeTmux()
+        let metadata = FakeMetadata()
+        let runtime = CodexCLITmuxRuntime(
+            tmux: tmux,
+            metadata: metadata,
+            codexExecutablePath: "/opt/homebrew/bin/codex"
+        )
+
+        let receipt = try await runtime.launch(request())
+        let name = "kanban-code-card-1-1"
+
+        #expect(tmux.created.count == 1)
+        #expect(tmux.created.first?.0 == name)
+        #expect(tmux.created.first?.2?.contains("KANBAN_CODE_CARD_ID='card-1'") == true)
+        #expect(tmux.created.first?.2?.contains("KANBAN_CODE_LIFECYCLE_CAPABILITY='\(String(repeating: "a", count: 64))'") == true)
+        #expect(tmux.created.first?.2?.hasSuffix("'/opt/homebrew/bin/codex' --no-alt-screen") == true)
+        #expect(metadata.tags[name] == .init(cardId: "card-1", attemptId: "attempt-1", generation: 1))
+        #expect(tmux.prompts.first?.0 == name)
+        #expect(tmux.prompts.first?.1.contains("implement it") == true)
+        #expect(tmux.prompts.first?.1.contains("review-ready") == true)
+        #expect(receipt.binding.tmuxSessionName == name)
+        #expect(receipt.binding.ownership == .managed)
+    }
+
+    @Test("Same lease is idempotent and never submits the prompt twice")
+    func sameLeaseIsIdempotent() async throws {
+        let tmux = FakeTmux()
+        let metadata = FakeMetadata()
+        let name = "kanban-code-card-1-1"
+        tmux.sessions = [TmuxSession(name: name, path: "/tmp/project", attached: false)]
+        metadata.tags[name] = .init(cardId: "card-1", attemptId: "attempt-1", generation: 1)
+        let runtime = CodexCLITmuxRuntime(tmux: tmux, metadata: metadata)
+
+        _ = try await runtime.launch(request())
+
+        #expect(tmux.created.isEmpty)
+        #expect(tmux.prompts.isEmpty)
+    }
+
+    @Test("Reserved-name collision without matching ownership is rejected")
+    func collisionRejected() async {
+        let tmux = FakeTmux()
+        let metadata = FakeMetadata()
+        let name = "kanban-code-card-1-1"
+        tmux.sessions = [TmuxSession(name: name, path: "/tmp/other", attached: false)]
+        metadata.tags[name] = .init(cardId: "other", attemptId: "other", generation: 1)
+        let runtime = CodexCLITmuxRuntime(tmux: tmux, metadata: metadata)
+
+        do {
+            _ = try await runtime.launch(request())
+            Issue.record("Expected ownership conflict")
+        } catch let error as CodexRuntimeError {
+            #expect(error == .ownershipConflict(
+                "Refusing to reuse \(name): its ownership tag does not match this launch attempt"
+            ))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(tmux.created.isEmpty)
+    }
+
+    @Test("Recovery distinguishes absent, owned, and ambiguous sessions")
+    func recoveryContract() async {
+        let tmux = FakeTmux()
+        let metadata = FakeMetadata()
+        let runtime = CodexCLITmuxRuntime(tmux: tmux, metadata: metadata)
+        let lease = LaunchLease(attemptId: "attempt-1", backend: .cliTmux, generation: 1)
+        let recovery = CodexRuntimeRecoveryRequest(cardId: "card-1", lease: lease)
+
+        #expect(await runtime.recover(recovery) == .notStarted)
+
+        let name = "kanban-code-card-1-1"
+        tmux.sessions = [TmuxSession(name: name, path: "/tmp/project", attached: false)]
+        if case .uncertain = await runtime.recover(recovery) {} else {
+            Issue.record("Expected missing metadata to be uncertain")
+        }
+
+        metadata.tags[name] = .init(cardId: "card-1", attemptId: "attempt-1", generation: 1)
+        if case .running(let binding) = await runtime.recover(recovery) {
+            #expect(binding.tmuxSessionName == name)
+        } else {
+            Issue.record("Expected owned session to recover as running")
+        }
+    }
+
+    @Test("Failure after tmux creation is classified as launch uncertain")
+    func postCreationFailureIsUncertain() async {
+        struct TestError: Error {}
+        let tmux = FakeTmux()
+        let metadata = FakeMetadata()
+        metadata.setError = TestError()
+        let runtime = CodexCLITmuxRuntime(tmux: tmux, metadata: metadata)
+
+        do {
+            _ = try await runtime.launch(request())
+            Issue.record("Expected launch failure")
+        } catch let error as CodexRuntimeError {
+            #expect(error.mayHaveStartedWork)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(tmux.sessions.count == 1)
+    }
+
+    @Test("Feedback is only sent to the card-owned binding")
+    func feedbackOwnership() async throws {
+        let tmux = FakeTmux()
+        let metadata = FakeMetadata()
+        let name = "kanban-code-card-1-1"
+        tmux.sessions = [TmuxSession(name: name, path: "/tmp/project", attached: false)]
+        metadata.tags[name] = .init(cardId: "card-1", attemptId: "attempt-1", generation: 1)
+        let runtime = CodexCLITmuxRuntime(tmux: tmux, metadata: metadata)
+        let binding = CodexExecutionBinding(
+            backend: .cliTmux,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .limited,
+            tmuxSessionName: name
+        )
+
+        try await runtime.sendFeedback(.init(cardId: "card-1", binding: binding, body: "revise"))
+        #expect(tmux.prompts.last?.1 == "revise")
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexLaunchSchedulerTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexLaunchSchedulerTests.swift
@@ -1,0 +1,305 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("Codex launch scheduler")
+struct CodexLaunchSchedulerTests {
+    actor FakeRuntime: CodexRuntimePort {
+        nonisolated let backend: CodexRuntimeBackend
+        var launched: [CodexRuntimeLaunchRequest] = []
+        var recoveries: [CodexRuntimeRecoveryRequest] = []
+        var launchErrors: [String: CodexRuntimeError] = [:]
+        var recoveryResults: [String: CodexRuntimeRecoveryResult] = [:]
+
+        init(backend: CodexRuntimeBackend) {
+            self.backend = backend
+        }
+
+        func launch(_ request: CodexRuntimeLaunchRequest) async throws -> CodexRuntimeLaunchReceipt {
+            launched.append(request)
+            if let error = launchErrors[request.cardId] { throw error }
+            return CodexRuntimeLaunchReceipt(
+                binding: CodexExecutionBinding(
+                    backend: backend,
+                    ownership: .managed,
+                    evidence: .boardCreated,
+                    telemetryQuality: .precise,
+                    threadId: backend == .app ? "thread-\(request.cardId)" : nil,
+                    tmuxSessionName: backend == .cliTmux ? "tmux-\(request.cardId)" : nil
+                )
+            )
+        }
+
+        func recover(_ request: CodexRuntimeRecoveryRequest) async -> CodexRuntimeRecoveryResult {
+            recoveries.append(request)
+            return recoveryResults[request.cardId] ?? .notStarted
+        }
+
+        func sendFeedback(_ request: CodexRuntimeFeedbackRequest) async throws {}
+
+        func setLaunchError(_ error: CodexRuntimeError, cardId: String) {
+            launchErrors[cardId] = error
+        }
+
+        func setRecovery(_ result: CodexRuntimeRecoveryResult, cardId: String) {
+            recoveryResults[cardId] = result
+        }
+
+        func launchedCardIds() -> [String] { launched.map(\.cardId) }
+    }
+
+    actor SuspendedRuntime: CodexRuntimePort {
+        nonisolated let backend: CodexRuntimeBackend = .cliTmux
+        private var launches = 0
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func launch(_ request: CodexRuntimeLaunchRequest) async throws -> CodexRuntimeLaunchReceipt {
+            launches += 1
+            await withCheckedContinuation { continuation = $0 }
+            return .init(binding: .init(
+                backend: .cliTmux,
+                ownership: .managed,
+                evidence: .boardCreated,
+                telemetryQuality: .precise,
+                tmuxSessionName: "tmux-\(request.cardId)"
+            ))
+        }
+
+        func recover(_ request: CodexRuntimeRecoveryRequest) async -> CodexRuntimeRecoveryResult { .notStarted }
+        func sendFeedback(_ request: CodexRuntimeFeedbackRequest) async throws {}
+        func launchCount() -> Int { launches }
+        func release() { continuation?.resume(); continuation = nil }
+    }
+
+    private func makeStore() throws -> (CodexRuntimeStateStore, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-scheduler-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return (CodexRuntimeStateStore(basePath: directory.path), directory)
+    }
+
+    private func task(
+        _ id: String,
+        backend: CodexRuntimeBackend = .cliTmux,
+        order: TimeInterval
+    ) -> CodexQueuedTask {
+        CodexQueuedTask(
+            cardId: id,
+            backend: backend,
+            enqueuedAt: Date(timeIntervalSince1970: order),
+            projectPath: "/tmp/project",
+            prompt: "work on \(id)"
+        )
+    }
+
+    @Test("Claims FIFO up to the bounded global capacity")
+    func fifoAndCapacity() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cli = FakeRuntime(backend: .cliTmux)
+        let scheduler = CodexLaunchScheduler(
+            stateStore: store,
+            runtimes: [.cliTmux: cli],
+            makeAttemptID: { "attempt" }
+        )
+
+        let outcomes = try await scheduler.schedule(
+            queuedTasks: [task("third", order: 3), task("first", order: 1), task("second", order: 2)],
+            activeBackend: .cliTmux,
+            maxConcurrency: 2
+        )
+
+        #expect(await cli.launchedCardIds() == ["first", "second"])
+        #expect(outcomes.count == 2)
+        #expect(try await store.state(for: "third") == nil)
+        #expect(try await store.state(for: "first")?.lifecycle.phase == .running)
+    }
+
+    @Test("Overlapping scheduling passes cannot launch the same card twice")
+    func overlappingPassesAreSerialized() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let runtime = SuspendedRuntime()
+        let scheduler = CodexLaunchScheduler(stateStore: store, runtimes: [.cliTmux: runtime])
+        let queued = [task("one", order: 1)]
+
+        let first = Task {
+            try await scheduler.schedule(queuedTasks: queued, activeBackend: .cliTmux, maxConcurrency: 1)
+        }
+        while await runtime.launchCount() == 0 { await Task.yield() }
+        let overlapping = try await scheduler.schedule(
+            queuedTasks: queued,
+            activeBackend: .cliTmux,
+            maxConcurrency: 1
+        )
+        #expect(overlapping.isEmpty)
+        await runtime.release()
+        _ = try await first.value
+        #expect(await runtime.launchCount() == 1)
+    }
+
+    @Test("Capacity is clamped to 1 through 32")
+    func clampsCapacity() async throws {
+        let (lowerStore, lowerDirectory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: lowerDirectory) }
+        let lowerRuntime = FakeRuntime(backend: .cliTmux)
+        let lower = CodexLaunchScheduler(stateStore: lowerStore, runtimes: [.cliTmux: lowerRuntime])
+        _ = try await lower.schedule(
+            queuedTasks: [task("one", order: 1), task("two", order: 2)],
+            activeBackend: .cliTmux,
+            maxConcurrency: -10
+        )
+        #expect(await lowerRuntime.launchedCardIds().count == 1)
+
+        let (upperStore, upperDirectory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: upperDirectory) }
+        let upperRuntime = FakeRuntime(backend: .cliTmux)
+        let upper = CodexLaunchScheduler(stateStore: upperStore, runtimes: [.cliTmux: upperRuntime])
+        let tasks = (0..<40).map { task("card-\($0)", order: TimeInterval($0)) }
+        _ = try await upper.schedule(queuedTasks: tasks, activeBackend: .cliTmux, maxConcurrency: 100)
+        #expect(await upperRuntime.launchedCardIds().count == 32)
+    }
+
+    @Test("Inactive queue pauses while running work across modes consumes capacity")
+    func inactiveQueueAndGlobalCapacity() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let app = FakeRuntime(backend: .app)
+        let cli = FakeRuntime(backend: .cliTmux)
+        let scheduler = CodexLaunchScheduler(stateStore: store, runtimes: [.app: app, .cliTmux: cli])
+
+        try await store.upsert(
+            CardRuntimeState(
+                cardId: "app-running",
+                lifecycle: .init(phase: .running, telemetryQuality: .precise),
+                launchLease: .init(attemptId: "a", backend: .app, generation: 1)
+            )
+        )
+        await app.setRecovery(
+            .running(.init(
+                backend: .app,
+                ownership: .managed,
+                evidence: .boardCreated,
+                telemetryQuality: .precise,
+                threadId: "thread-a"
+            )),
+            cardId: "app-running"
+        )
+
+        _ = try await scheduler.schedule(
+            queuedTasks: [task("hidden-app", backend: .app, order: 1), task("visible-cli", order: 2)],
+            activeBackend: .cliTmux,
+            maxConcurrency: 2
+        )
+
+        #expect(await app.launchedCardIds().isEmpty)
+        #expect(await cli.launchedCardIds() == ["visible-cli"])
+    }
+
+    @Test("Restart recovery does not duplicate running or uncertain work")
+    func recoveryPreventsDuplicateLaunch() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cli = FakeRuntime(backend: .cliTmux)
+        let lease = LaunchLease(attemptId: "existing", backend: .cliTmux, generation: 4)
+        try await store.upsert(
+            CardRuntimeState(
+                cardId: "leased",
+                lifecycle: .init(phase: .launching, telemetryQuality: .precise),
+                launchLease: lease
+            )
+        )
+        await cli.setRecovery(.uncertain("transport unavailable"), cardId: "leased")
+        let scheduler = CodexLaunchScheduler(stateStore: store, runtimes: [.cliTmux: cli])
+
+        _ = try await scheduler.schedule(
+            queuedTasks: [task("leased", order: 1), task("next", order: 2)],
+            activeBackend: .cliTmux,
+            maxConcurrency: 1
+        )
+
+        #expect(await cli.launchedCardIds().isEmpty)
+        #expect(try await store.state(for: "leased")?.lifecycle.waitReason == .launchUncertain)
+    }
+
+    @Test("Definitely absent lease is safely relaunched with a new generation")
+    func absentLeaseCanRelaunch() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cli = FakeRuntime(backend: .cliTmux)
+        try await store.upsert(
+            CardRuntimeState(
+                cardId: "leased",
+                lifecycle: .init(phase: .launching, telemetryQuality: .precise),
+                launchLease: .init(attemptId: "old", backend: .cliTmux, generation: 2)
+            )
+        )
+        let scheduler = CodexLaunchScheduler(
+            stateStore: store,
+            runtimes: [.cliTmux: cli],
+            makeAttemptID: { "new" }
+        )
+
+        _ = try await scheduler.schedule(
+            queuedTasks: [task("leased", order: 1)],
+            activeBackend: .cliTmux,
+            maxConcurrency: 1
+        )
+
+        #expect(await cli.launchedCardIds() == ["leased"])
+        #expect(await cli.launched.first?.generation == 3)
+    }
+
+    @Test("Definite launch failure releases capacity but uncertain failure retains it")
+    func launchFailureSlotBehavior() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cli = FakeRuntime(backend: .cliTmux)
+        await cli.setLaunchError(.notStarted("missing executable"), cardId: "first")
+        await cli.setLaunchError(.launchUncertain("lost acknowledgement"), cardId: "third")
+        let scheduler = CodexLaunchScheduler(stateStore: store, runtimes: [.cliTmux: cli])
+
+        _ = try await scheduler.schedule(
+            queuedTasks: [
+                task("first", order: 1), task("second", order: 2),
+                task("third", order: 3), task("fourth", order: 4),
+            ],
+            activeBackend: .cliTmux,
+            maxConcurrency: 2
+        )
+
+        #expect(await cli.launchedCardIds() == ["first", "second", "third"])
+        #expect(try await store.state(for: "first")?.lifecycle.waitReason == .fault)
+        #expect(try await store.state(for: "third")?.lifecycle.waitReason == .launchUncertain)
+        #expect(try await store.state(for: "fourth") == nil)
+    }
+
+    @Test("Partial App launch persists its acknowledged thread for recovery")
+    func partialLaunchPersistsBinding() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let app = FakeRuntime(backend: .app)
+        let binding = CodexExecutionBinding(
+            backend: .app,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .limited,
+            threadId: "thread-created"
+        )
+        await app.setLaunchError(
+            .partialLaunch("turn acknowledgement lost", binding),
+            cardId: "partial"
+        )
+        let scheduler = CodexLaunchScheduler(stateStore: store, runtimes: [.app: app])
+
+        let outcomes = try await scheduler.schedule(
+            queuedTasks: [task("partial", backend: .app, order: 1)],
+            activeBackend: .app,
+            maxConcurrency: 1
+        )
+
+        #expect(outcomes == [.uncertain(cardId: "partial", message: "turn acknowledgement lost")])
+        #expect(try await store.state(for: "partial")?.executionBinding?.threadId == "thread-created")
+        #expect(try await store.state(for: "partial")?.lifecycle.waitReason == .launchUncertain)
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexLifecycleInboxTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexLifecycleInboxTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("Codex lifecycle inbox")
+struct CodexLifecycleInboxTests {
+    private let capability = String(repeating: "ab", count: 32)
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kanban-code-lifecycle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func envelope(
+        id: String = UUID().uuidString,
+        sessionId: String = "session-1",
+        generation: Int = 2,
+        kind: CodexLifecycleEventKind = .reviewReady,
+        capability: String? = nil
+    ) -> CodexLifecycleEnvelope {
+        CodexLifecycleEnvelope(
+            id: id,
+            cardId: "card-1",
+            sessionId: sessionId,
+            attemptId: "attempt-1",
+            generation: generation,
+            kind: kind,
+            backend: .cliTmux,
+            turnId: "turn-1",
+            sequence: 7,
+            occurredAt: Date(timeIntervalSince1970: 1_750_000_000),
+            capability: capability ?? self.capability
+        )
+    }
+
+    private func binding(capability: String? = nil) -> CodexLifecycleExpectedBinding {
+        CodexLifecycleExpectedBinding(
+            cardId: "card-1",
+            sessionId: "session-1",
+            attemptId: "attempt-1",
+            generation: 2,
+            backend: .cliTmux,
+            capability: capability ?? self.capability
+        )
+    }
+
+    @Test("Atomic writer and reader normalize an authenticated review-ready event")
+    func authenticatedRoundTrip() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let writer = CodexLifecycleInboxWriter(basePath: directory.path)
+        let reader = CodexLifecycleInboxReader(basePath: directory.path)
+
+        let result = try await writer.append(envelope(id: "event-1"))
+        #expect(result.rotatedEventCount == 0)
+
+        let batch = try await reader.drain(bindings: ["card-1": binding()])
+        #expect(batch.diagnostics.isEmpty)
+        #expect(batch.events.count == 1)
+        #expect(batch.events.first?.id == "event-1")
+        #expect(batch.events.first?.kind == .reviewReady)
+        #expect(batch.events.first?.watermark.generation == 2)
+        #expect(batch.events.first?.watermark.turnId == "turn-1")
+        try await reader.acknowledge(batch)
+
+        let inbox = directory.appendingPathComponent("codex-lifecycle-inbox")
+        let cursorAttributes = try FileManager.default.attributesOfItem(
+            atPath: inbox.appendingPathComponent("cursor.json").path
+        )
+        #expect((cursorAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+    }
+
+    @Test("Persistent cursor rejects an event ID replay")
+    func replayIsDeduplicated() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let writer = CodexLifecycleInboxWriter(basePath: directory.path)
+        let reader = CodexLifecycleInboxReader(basePath: directory.path)
+
+        try await writer.append(envelope(id: "same-event"))
+        let first = try await reader.drain(bindings: ["card-1": binding()])
+        #expect(first.events.count == 1)
+        try await reader.acknowledge(first)
+
+        try await writer.append(envelope(id: "same-event", kind: .running))
+        let replay = try await reader.drain(bindings: ["card-1": binding()])
+        #expect(replay.events.isEmpty)
+        #expect(replay.diagnostics.map(\.reason) == [.duplicate])
+        try await reader.acknowledge(replay)
+    }
+
+    @Test("Cross-session, stale generation, and wrong capability are rejected")
+    func bindingValidation() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let writer = CodexLifecycleInboxWriter(basePath: directory.path)
+        let reader = CodexLifecycleInboxReader(basePath: directory.path)
+
+        try await writer.append(envelope(id: "wrong-session", sessionId: "session-2"))
+        try await writer.append(envelope(id: "stale", generation: 1))
+        try await writer.append(envelope(
+            id: "wrong-capability",
+            capability: String(repeating: "cd", count: 32)
+        ))
+
+        let batch = try await reader.drain(bindings: ["card-1": binding()])
+        #expect(batch.events.isEmpty)
+        #expect(batch.diagnostics.map(\.reason).filter { $0 == .bindingMismatch }.count == 2)
+        #expect(batch.diagnostics.map(\.reason).contains(.invalidCapability))
+    }
+
+    @Test("Oversized and malformed payloads are bounded and diagnosed")
+    func invalidPayloads() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let smallWriter = CodexLifecycleInboxWriter(basePath: directory.path, maximumEventBytes: 32)
+
+        await #expect(throws: CodexLifecycleInboxError.self) {
+            try await smallWriter.append(envelope())
+        }
+
+        let pending = directory
+            .appendingPathComponent("codex-lifecycle-inbox", isDirectory: true)
+            .appendingPathComponent("pending", isDirectory: true)
+        try FileManager.default.createDirectory(at: pending, withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(to: pending.appendingPathComponent("malformed.json"))
+        try Data(repeating: 0x41, count: 65).write(to: pending.appendingPathComponent("oversized.json"))
+
+        let reader = CodexLifecycleInboxReader(basePath: directory.path, maximumEventBytes: 64)
+        let batch = try await reader.drain(bindings: [:])
+        #expect(Set(batch.diagnostics.map(\.reason)) == Set([.malformed, .tooLarge]))
+    }
+
+    @Test("Queue rotation keeps only the configured newest event count")
+    func boundedBacklogRotation() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let writer = CodexLifecycleInboxWriter(basePath: directory.path, maximumQueuedEvents: 2)
+
+        try await writer.append(envelope(id: "one"))
+        try await writer.append(envelope(id: "two"))
+        let third = try await writer.append(envelope(id: "three"))
+        #expect(third.rotatedEventCount == 1)
+
+        let reader = CodexLifecycleInboxReader(basePath: directory.path)
+        let batch = try await reader.drain(bindings: ["card-1": binding()])
+        #expect(batch.events.count == 2)
+        #expect(Set(batch.events.map(\.id)) == Set(["two", "three"]))
+    }
+
+    @Test("Helper emits review-ready and maps Stop to ordinary stop")
+    func helperNormalization() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let environment = [
+            CodexLifecycleHelper.cardIdEnvironmentKey: "card-1",
+            CodexLifecycleHelper.sessionIdEnvironmentKey: "session-1",
+            CodexLifecycleHelper.attemptIdEnvironmentKey: "attempt-1",
+            CodexLifecycleHelper.generationEnvironmentKey: "2",
+            CodexLifecycleHelper.backendEnvironmentKey: CodexRuntimeBackend.cliTmux.rawValue,
+            CodexLifecycleHelper.capabilityEnvironmentKey: capability,
+            CodexLifecycleHelper.basePathEnvironmentKey: directory.path,
+        ]
+
+        try await CodexLifecycleHelper.emit(command: "review-ready", environment: environment)
+        // Codex creates its own UUID after the tmux transport is launched.
+        // Capability-bound CLI events retain the stable owned tmux identity.
+        let stop = #"{"session_id":"codex-generated-uuid","hook_event_name":"Stop","turn_id":"turn-2"}"#
+        try await CodexLifecycleHelper.emit(
+            command: "hook-event",
+            standardInput: Data(stop.utf8),
+            environment: environment
+        )
+
+        let reader = CodexLifecycleInboxReader(basePath: directory.path)
+        let batch = try await reader.drain(bindings: ["card-1": binding()])
+        #expect(batch.events.map(\.kind).contains(.reviewReady))
+        #expect(batch.events.map(\.kind).contains(.stopped))
+        #expect(batch.events.filter { $0.kind == .reviewReady }.count == 1)
+        #expect(batch.events.allSatisfy { $0.cardId == "card-1" })
+    }
+
+    @Test("Unmanaged hooks remain non-authorizing")
+    func helperNeedsManagedBinding() async throws {
+        let result = try await CodexLifecycleHelper.emit(
+            command: "review-ready",
+            environment: [:]
+        )
+        #expect(result == nil)
+    }
+
+    @Test("Capability generation is 256-bit lowercase hex")
+    func capabilityGeneration() throws {
+        let generated = try CodexLifecycleCapability.generate()
+        #expect(CodexLifecycleCapability.isValid(generated))
+        #expect(CodexLifecycleCapability.constantTimeEquals(generated, generated))
+        #expect(!CodexLifecycleCapability.constantTimeEquals(generated, capability))
+        #expect(!CodexLifecycleCapability.constantTimeEquals(generated, generated + "00"))
+    }
+}
+
+@Suite("Codex hook installer")
+struct CodexHookInstallerTests {
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kanban-code-codex-hooks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test("Helper deployment verifies the bundled and installed hashes")
+    func deploysOnlyVerifiedHelper() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source-helper")
+        let destination = directory.appendingPathComponent("installed-helper")
+        try Data("trusted helper".utf8).write(to: source)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: source.path)
+        let hash = try CodexHookInstaller.sha256(path: source.path)
+
+        _ = try CodexHookInstaller.deployHelper(
+            from: source.path,
+            expectedSHA256: hash,
+            helperPath: destination.path
+        )
+        #expect(CodexHookInstaller.helperMatches(path: destination.path, expectedSHA256: hash))
+        #expect(throws: CodexLifecycleInboxError.self) {
+            _ = try CodexHookInstaller.deployHelper(
+                from: source.path,
+                expectedSHA256: String(repeating: "0", count: 64),
+                helperPath: destination.path
+            )
+        }
+    }
+
+    @Test("Install merges idempotently and uninstall preserves unrelated config")
+    func mergeAndUninstall() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let hooksPath = directory.appendingPathComponent("hooks.json").path
+        let helperPath = "/usr/local/bin/kanban-code-lifecycle"
+        let existing = #"{"theme":"dark","hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"/usr/local/bin/other-hook"}]}]}}"#
+        try Data(existing.utf8).write(to: URL(fileURLWithPath: hooksPath))
+
+        try CodexHookInstaller.install(hooksPath: hooksPath, helperPath: helperPath)
+        try CodexHookInstaller.install(hooksPath: hooksPath, helperPath: helperPath)
+        #expect(CodexHookInstaller.isInstalled(hooksPath: hooksPath, helperPath: helperPath))
+        #expect(FileManager.default.fileExists(atPath: hooksPath + ".kanban-code.backup"))
+
+        var root = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: URL(fileURLWithPath: hooksPath))) as? [String: Any]
+        )
+        #expect(root["theme"] as? String == "dark")
+        var hooks = try #require(root["hooks"] as? [String: Any])
+        let stopGroups = try #require(hooks["Stop"] as? [[String: Any]])
+        let stopEntries = try #require(stopGroups.first?["hooks"] as? [[String: Any]])
+        #expect(stopEntries.count == 2)
+
+        try CodexHookInstaller.uninstall(hooksPath: hooksPath, helperPath: helperPath)
+        #expect(!CodexHookInstaller.isInstalled(hooksPath: hooksPath, helperPath: helperPath))
+
+        root = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: URL(fileURLWithPath: hooksPath))) as? [String: Any]
+        )
+        hooks = try #require(root["hooks"] as? [String: Any])
+        let remainingGroups = try #require(hooks["Stop"] as? [[String: Any]])
+        let remaining = try #require(remainingGroups.first?["hooks"] as? [[String: Any]])
+        #expect(remaining.count == 1)
+        #expect(remaining.first?["command"] as? String == "/usr/local/bin/other-hook")
+        #expect(root["theme"] as? String == "dark")
+    }
+
+    @Test("Installer rejects paths that would require shell escaping")
+    func rejectUnsafePath() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: CodexLifecycleInboxError.self) {
+            try CodexHookInstaller.install(
+                hooksPath: directory.appendingPathComponent("hooks.json").path,
+                helperPath: "/tmp/helper;touch-bad"
+            )
+        }
+    }
+
+    @Test("Installer refuses to overwrite malformed user config")
+    func preserveMalformedConfig() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let hooksPath = directory.appendingPathComponent("hooks.json").path
+        let original = "not-json"
+        try original.write(toFile: hooksPath, atomically: true, encoding: .utf8)
+
+        #expect(throws: CodexLifecycleInboxError.self) {
+            try CodexHookInstaller.install(
+                hooksPath: hooksPath,
+                helperPath: "/usr/local/bin/kanban-code-lifecycle"
+            )
+        }
+        #expect(try String(contentsOfFile: hooksPath, encoding: .utf8) == original)
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexLifecycleProjectionTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexLifecycleProjectionTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("Codex lifecycle and board projection")
+struct CodexLifecycleProjectionTests {
+    private func event(
+        _ kind: CodexLifecycleEventKind,
+        id: String,
+        cardId: String = "card-1",
+        source: String = "app-server",
+        generation: Int = 1,
+        turn: String = "turn-1",
+        sequence: Int
+    ) -> CodexLifecycleEvent {
+        CodexLifecycleEvent(
+            id: id,
+            cardId: cardId,
+            kind: kind,
+            watermark: LifecycleEventWatermark(
+                eventId: id,
+                source: source,
+                generation: generation,
+                turnId: turn,
+                sequence: sequence,
+                occurredAt: Date(timeIntervalSince1970: TimeInterval(sequence))
+            )
+        )
+    }
+
+    @Test("Duplicate and stale events cannot rewind lifecycle")
+    func duplicateAndStaleEvents() {
+        let running = event(.running, id: "running", sequence: 2)
+        guard case .applied(let state) = CodexLifecycleReducer.reduce(current: nil, event: running) else {
+            Issue.record("running event should apply")
+            return
+        }
+
+        #expect(CodexLifecycleReducer.reduce(current: state, event: running) == .duplicate(state))
+        let stale = event(.queued, id: "queued", sequence: 1)
+        #expect(CodexLifecycleReducer.reduce(current: state, event: stale) == .ignoredStale(state))
+    }
+
+    @Test("Review-ready outranks a duplicated ordinary stop in the same turn")
+    func reviewReadyOutranksStop() {
+        let review = event(.reviewReady, id: "review", sequence: 8)
+        guard case .applied(let state) = CodexLifecycleReducer.reduce(current: nil, event: review) else {
+            Issue.record("review event should apply")
+            return
+        }
+        let delayedStop = event(.stopped, id: "stop", sequence: 7)
+        #expect(CodexLifecycleReducer.reduce(current: state, event: delayedStop) == .ignoredStale(state))
+        #expect(state.lifecycle.phase == .inReview)
+    }
+
+    @Test("A later Stop cannot erase review-ready even without turn provenance")
+    func reviewReadySurvivesLaterStop() {
+        let review = CodexLifecycleEvent(
+            id: "review",
+            cardId: "card-1",
+            kind: .reviewReady,
+            watermark: .init(
+                eventId: "review",
+                source: "codex-lifecycle-inbox",
+                generation: 1,
+                occurredAt: Date(timeIntervalSince1970: 10)
+            )
+        )
+        guard case .applied(let state) = CodexLifecycleReducer.reduce(current: nil, event: review) else {
+            Issue.record("review event should apply")
+            return
+        }
+        let stop = CodexLifecycleEvent(
+            id: "stop",
+            cardId: "card-1",
+            kind: .stopped,
+            watermark: .init(
+                eventId: "stop",
+                source: "codex-lifecycle-inbox",
+                generation: 1,
+                turnId: "turn-1",
+                occurredAt: Date(timeIntervalSince1970: 11)
+            )
+        )
+        #expect(CodexLifecycleReducer.reduce(current: state, event: stop) == .ignoredStale(state))
+    }
+
+    @Test("A later running event resumes the same waiting turn")
+    func waitingTurnResumes() {
+        let waiting = event(.waitingForApproval, id: "approval", sequence: 4)
+        guard case .applied(let state) = CodexLifecycleReducer.reduce(current: nil, event: waiting) else {
+            Issue.record("approval event should apply")
+            return
+        }
+        let resumed = event(.running, id: "resumed", sequence: 5)
+        guard case .applied(let result) = CodexLifecycleReducer.reduce(current: state, event: resumed) else {
+            Issue.record("later running event should resume the turn")
+            return
+        }
+        #expect(result.lifecycle.phase == .running)
+    }
+
+    @Test("Acknowledged review feedback resumes the original turn")
+    func reviewFeedbackResumes() {
+        let review = CodexLifecycleEvent(
+            id: "review",
+            cardId: "card-1",
+            kind: .reviewReady,
+            watermark: .init(
+                eventId: "review",
+                source: "helper",
+                generation: 1,
+                occurredAt: Date(timeIntervalSince1970: 5)
+            )
+        )
+        let current = CodexLifecycleReducer.reduce(current: nil, event: review).projectedState
+        let continued = CodexLifecycleEvent(
+            id: "continued",
+            cardId: "card-1",
+            kind: .running,
+            watermark: .init(
+                eventId: "continued",
+                source: "board:continue",
+                generation: 1,
+                turnId: "turn-1",
+                occurredAt: review.watermark.occurredAt.addingTimeInterval(1)
+            )
+        )
+        #expect(CodexLifecycleReducer.reduce(current: current, event: continued).projectedState.lifecycle.phase == .running)
+    }
+
+    @Test("Human acceptance completes review even when helper had no turn id")
+    func reviewAcceptanceCompletes() {
+        let review = CodexLifecycleEvent(
+            id: "review",
+            cardId: "card-1",
+            kind: .reviewReady,
+            watermark: .init(eventId: "review", source: "helper", generation: 1, occurredAt: .now)
+        )
+        let current = CodexLifecycleReducer.reduce(current: nil, event: review).projectedState
+        let accepted = CodexLifecycleEvent(
+            id: "accepted",
+            cardId: "card-1",
+            kind: .accepted,
+            watermark: .init(eventId: "accepted", source: "board:accept", generation: 1, turnId: "turn-1", occurredAt: .now)
+        )
+        #expect(CodexLifecycleReducer.reduce(current: current, event: accepted).projectedState.lifecycle.phase == .done)
+    }
+
+    @Test("A manual review action is authoritative for a running task")
+    func manualReviewReady() {
+        let running = event(.running, id: "running", source: "app-server", sequence: 3)
+        let current = CodexLifecycleReducer.reduce(current: nil, event: running).projectedState
+        let review = CodexLifecycleEvent(
+            id: "manual-review",
+            cardId: "card-1",
+            kind: .reviewReady,
+            watermark: .init(
+                eventId: "manual-review",
+                source: "board:manual-review",
+                generation: 1,
+                occurredAt: Date(timeIntervalSince1970: 4)
+            )
+        )
+        #expect(CodexLifecycleReducer.reduce(current: current, event: review).projectedState.lifecycle.phase == .inReview)
+    }
+
+    @Test("Incomparable sources retain the precise state and mark telemetry limited")
+    func incomparableSources() {
+        let running = event(.running, id: "running", source: "app-server", sequence: 2)
+        guard case .applied(let state) = CodexLifecycleReducer.reduce(current: nil, event: running) else {
+            Issue.record("running event should apply")
+            return
+        }
+        var hook = event(.stopped, id: "hook-stop", source: "hook", sequence: 2)
+        hook = CodexLifecycleEvent(
+            id: hook.id,
+            cardId: hook.cardId,
+            kind: hook.kind,
+            watermark: LifecycleEventWatermark(
+                eventId: hook.id,
+                source: "hook",
+                generation: nil,
+                turnId: nil,
+                sequence: nil,
+                occurredAt: state.updatedAt
+            ),
+            telemetryQuality: .limited
+        )
+        guard case .conflicted(let conflicted) = CodexLifecycleReducer.reduce(current: state, event: hook) else {
+            Issue.record("incomparable event should conflict")
+            return
+        }
+        #expect(conflicted.lifecycle.phase == .running)
+        #expect(conflicted.lifecycle.telemetryQuality == .limited)
+    }
+
+    @Test("Only all-merged PRs auto-complete")
+    func strictPRCompletion() {
+        var link = Link(id: "card-1", source: .manual)
+        link.prLinks = [PRLink(number: 1, status: .closed)]
+        #expect(CodexBoardProjection.column(for: link, runtimeState: nil) != .done)
+
+        link.prLinks = [PRLink(number: 1, status: .merged)]
+        #expect(CodexBoardProjection.column(for: link, runtimeState: nil) == .done)
+
+        link.prLinks.append(PRLink(number: 2, status: .reviewNeeded))
+        #expect(CodexBoardProjection.column(for: link, runtimeState: nil) != .done)
+    }
+
+    @Test("A stopped Codex task with an open PR stays Waiting")
+    func stoppedWithPROnlyWaits() {
+        var link = Link(id: "card-1", source: .manual, assistant: .codex)
+        link.prLinks = [PRLink(number: 1, status: .reviewNeeded)]
+        let state = CardRuntimeState(
+            cardId: link.id,
+            lifecycle: LifecycleSnapshot(
+                phase: .waiting,
+                waitReason: .ordinaryStop,
+                telemetryQuality: .precise
+            )
+        )
+        #expect(CodexBoardProjection.column(for: link, runtimeState: state) == .waiting)
+    }
+
+    @Test("Attention is global but includes only actionable waiting states")
+    func globalAttentionProjection() {
+        var appLink = Link(id: "app", name: "Approve App", projectPath: "/tmp/app", source: .manual, assistant: .codex)
+        appLink.executionBinding = CodexExecutionBinding(
+            backend: .app,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .precise,
+            threadId: "thread-1"
+        )
+        var cliLink = Link(id: "cli", name: "Running CLI", source: .manual, assistant: .codex)
+        cliLink.executionBinding = CodexExecutionBinding(
+            backend: .cliTmux,
+            ownership: .managed,
+            evidence: .tmuxBinding,
+            telemetryQuality: .precise,
+            tmuxSessionName: "codex-cli"
+        )
+        let states = [
+            "app": CardRuntimeState(cardId: "app", lifecycle: LifecycleSnapshot(phase: .waiting, waitReason: .approval, telemetryQuality: .precise)),
+            "cli": CardRuntimeState(cardId: "cli", lifecycle: LifecycleSnapshot(phase: .running, telemetryQuality: .precise)),
+        ]
+        let attention = CodexBoardProjection.attentionItems(
+            links: ["app": appLink, "cli": cliLink],
+            runtimeStates: states
+        )
+        #expect(attention.map(\.cardId) == ["app"])
+        #expect(attention.first?.primaryAction == .approve)
+        #expect(CodexBoardProjection.matchesBoardRuntime(appLink, runtime: .cliTmux) == false)
+        #expect(CodexBoardProjection.matchesBoardRuntime(cliLink, runtime: .cliTmux))
+    }
+
+    @Test("The board exposes exactly five workflow lanes")
+    func fiveLanes() {
+        #expect(CodexBoardProjection.lanes == [.backlog, .inProgress, .waiting, .inReview, .done])
+        #expect(!CodexBoardProjection.lanes.contains(.allSessions))
+    }
+}
+
+private extension CodexLifecycleReduction {
+    var projectedState: CardRuntimeState {
+        switch self {
+        case .applied(let state), .duplicate(let state), .ignoredStale(let state), .conflicted(let state):
+            state
+        }
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexRuntimeDomainTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexRuntimeDomainTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("Codex runtime domain")
+struct CodexRuntimeDomainTests {
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    @Test("Legacy Link decodes without an execution binding")
+    func legacyLinkDecodes() throws {
+        let json = """
+        {
+          "id": "card-legacy",
+          "column": "backlog",
+          "manualOverrides": {},
+          "manuallyArchived": false,
+          "source": "manual",
+          "isRemote": false
+        }
+        """
+
+        let link = try decoder.decode(Link.self, from: Data(json.utf8))
+
+        #expect(link.executionBinding == nil)
+    }
+
+    @Test("Codex execution binding round-trips on Link")
+    func executionBindingRoundTrip() throws {
+        let binding = CodexExecutionBinding(
+            backend: .app,
+            ownership: .managed,
+            evidence: .boardCreated,
+            telemetryQuality: .precise,
+            threadId: "thread-123",
+            sessionId: "session-123"
+        )
+        let link = Link(id: "card-runtime", executionBinding: binding, assistant: .codex)
+
+        let decoded = try decoder.decode(Link.self, from: encoder.encode(link))
+
+        #expect(decoded.executionBinding == binding)
+    }
+
+    @Test("Unknown runtime enum values degrade safely")
+    func unknownRuntimeValuesDegradeSafely() throws {
+        let json = """
+        {
+          "backend": "futureBackend",
+          "ownership": "futureOwnership",
+          "evidence": "futureEvidence",
+          "telemetryQuality": "futureQuality"
+        }
+        """
+
+        let provenance = try decoder.decode(CodexRuntimeProvenance.self, from: Data(json.utf8))
+
+        #expect(provenance.backend == .unknown)
+        #expect(provenance.ownership == .observed)
+        #expect(provenance.evidence == .unknown)
+        #expect(provenance.telemetryQuality == .unknown)
+    }
+
+    @Test("User-confirmed provenance outranks conflicting discovery")
+    func provenanceAuthority() {
+        let confirmed = CodexRuntimeProvenance(
+            backend: .app,
+            ownership: .observed,
+            evidence: .userConfirmed,
+            telemetryQuality: .precise,
+            observedAt: Date(timeIntervalSince1970: 100)
+        )
+        let discovered = CodexRuntimeProvenance(
+            backend: .cliTmux,
+            ownership: .observed,
+            evidence: .tmuxBinding,
+            telemetryQuality: .limited,
+            observedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        #expect(confirmed.preferring(discovered).backend == .app)
+        #expect(discovered.preferring(confirmed).backend == .app)
+    }
+
+    @Test("Session provenance is optional and Codable")
+    func sessionProvenanceCodable() throws {
+        let legacyJSON = """
+        {
+          "id": "legacy-session",
+          "messageCount": 2,
+          "modifiedTime": "2026-07-18T00:00:00Z",
+          "assistant": "codex"
+        }
+        """
+        let legacy = try decoder.decode(Session.self, from: Data(legacyJSON.utf8))
+        #expect(legacy.runtimeProvenance == nil)
+
+        let provenance = CodexRuntimeProvenance(
+            backend: .cliTmux,
+            ownership: .observed,
+            evidence: .tmuxBinding,
+            telemetryQuality: .limited
+        )
+        let session = Session(id: "session-1", assistant: .codex, runtimeProvenance: provenance)
+        let decoded = try decoder.decode(Session.self, from: encoder.encode(session))
+        #expect(decoded.runtimeProvenance == provenance)
+    }
+
+    @Test("Lifecycle state captures manual correction and launch lease")
+    func lifecycleStateRoundTrip() throws {
+        let watermark = LifecycleEventWatermark(
+            eventId: "event-1",
+            source: "hook",
+            generation: 4,
+            turnId: "turn-2",
+            sequence: 7,
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let correction = LifecycleManualCorrection(
+            phase: .inReview,
+            watermark: watermark,
+            correctedAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        let lease = LaunchLease(
+            attemptId: "attempt-1",
+            backend: .app,
+            generation: 4,
+            acquiredAt: Date(timeIntervalSince1970: 1_700_000_200),
+            expiresAt: Date(timeIntervalSince1970: 1_700_000_500)
+        )
+        let state = CardRuntimeState(
+            cardId: "card-1",
+            lifecycle: LifecycleSnapshot(
+                phase: .inReview,
+                waitReason: nil,
+                telemetryQuality: .precise,
+                watermark: watermark,
+                manualCorrection: correction
+            ),
+            launchLease: lease,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_300)
+        )
+
+        let decoded = try decoder.decode(CardRuntimeState.self, from: encoder.encode(state))
+
+        #expect(decoded == state)
+    }
+}

--- a/Tests/KanbanCodeCoreTests/Codex/CodexRuntimeStateStoreTests.swift
+++ b/Tests/KanbanCodeCoreTests/Codex/CodexRuntimeStateStoreTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import KanbanCodeCore
+
+@Suite("CodexRuntimeStateStore")
+struct CodexRuntimeStateStoreTests {
+    private func makeTempDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kanban-code-runtime-state-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    @Test("Runtime state persists independently from links")
+    func roundTripIsIsolatedFromLinks() async throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = CodexRuntimeStateStore(basePath: directory.path)
+        let state = CardRuntimeState(
+            cardId: "card-1",
+            lifecycle: LifecycleSnapshot(
+                phase: .waiting,
+                waitReason: .approval,
+                telemetryQuality: .precise
+            ),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        try await store.upsert(state)
+
+        #expect(try await store.state(for: "card-1") == state)
+        let stateURL = directory.appendingPathComponent("codex-runtime-state.json")
+        #expect(FileManager.default.fileExists(atPath: stateURL.path))
+        let directoryMode = try #require(
+            FileManager.default.attributesOfItem(atPath: directory.path)[.posixPermissions] as? NSNumber
+        )
+        let fileMode = try #require(
+            FileManager.default.attributesOfItem(atPath: stateURL.path)[.posixPermissions] as? NSNumber
+        )
+        #expect(directoryMode.intValue & 0o777 == 0o700)
+        #expect(fileMode.intValue & 0o777 == 0o600)
+        #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("links.json").path))
+    }
+
+    @Test("Store replaces and removes state by card ID")
+    func replaceAndRemove() async throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = CodexRuntimeStateStore(basePath: directory.path)
+
+        try await store.upsert(CardRuntimeState(cardId: "card-1", lifecycle: .init(phase: .queued)))
+        try await store.upsert(CardRuntimeState(cardId: "card-1", lifecycle: .init(phase: .running)))
+        #expect(try await store.state(for: "card-1")?.lifecycle.phase == .running)
+
+        try await store.remove(cardId: "card-1")
+        #expect(try await store.state(for: "card-1") == nil)
+    }
+
+    @Test("Legacy empty or absent store reads as no states")
+    func missingStoreReadsEmpty() async throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = CodexRuntimeStateStore(basePath: directory.path)
+
+        #expect(try await store.readAll().isEmpty)
+    }
+
+    @Test("Corrupt state is backed up and fails closed")
+    func corruptStoreFailsClosed() async throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let stateURL = directory.appendingPathComponent("codex-runtime-state.json")
+        try Data("not-json".utf8).write(to: stateURL)
+        let store = CodexRuntimeStateStore(basePath: directory.path)
+
+        await #expect(throws: CodexRuntimeStateStoreError.self) {
+            try await store.readAll()
+        }
+        #expect(FileManager.default.fileExists(atPath: stateURL.appendingPathExtension("bkp").path))
+    }
+}

--- a/Tests/KanbanCodeCoreTests/SettingsStoreTests.swift
+++ b/Tests/KanbanCodeCoreTests/SettingsStoreTests.swift
@@ -26,10 +26,45 @@ struct SettingsStoreTests {
         #expect(settings.github.pollIntervalSeconds == 60)
         #expect(settings.sessionTimeout.activeThresholdMinutes == 1440)
         #expect(settings.promptTemplate == "")
+        #expect(settings.codexBoard.runtime == .cliTmux)
+        #expect(settings.codexBoard.maxConcurrency == 3)
 
         // File should exist now
         let filePath = (dir as NSString).appendingPathComponent("settings.json")
         #expect(FileManager.default.fileExists(atPath: filePath))
+    }
+
+    @Test("Codex board settings clamp concurrency and round-trip")
+    func codexBoardSettingsRoundTrip() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let store = SettingsStore(basePath: dir)
+
+        var settings = Settings()
+        settings.codexBoard.runtime = .app
+        settings.codexBoard.maxConcurrency = 100
+        #expect(settings.codexBoard.maxConcurrency == 32)
+        try await store.write(settings)
+
+        let read = try await store.read()
+        #expect(read.codexBoard.runtime == .app)
+        #expect(read.codexBoard.maxConcurrency == 32)
+    }
+
+    @Test("Missing and invalid Codex board settings use safe defaults")
+    func codexBoardSettingsBackwardCompatibility() throws {
+        let missing = try JSONDecoder().decode(Settings.self, from: Data("{}".utf8))
+        #expect(missing.codexBoard.runtime == .cliTmux)
+        #expect(missing.codexBoard.maxConcurrency == 3)
+
+        let invalid = try JSONDecoder().decode(
+            Settings.self,
+            from: Data("""
+            { "codexBoard": { "runtime": "futureRuntime", "maxConcurrency": 0 } }
+            """.utf8)
+        )
+        #expect(invalid.codexBoard.runtime == .unknown)
+        #expect(invalid.codexBoard.maxConcurrency == 1)
     }
 
     @Test("Write and read round-trip")

--- a/Tests/KanbanCodeTests/CodexBoardUITests.swift
+++ b/Tests/KanbanCodeTests/CodexBoardUITests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import KanbanCode
+import KanbanCodeCore
+
+@Suite("Codex Board UI")
+struct CodexBoardUITests {
+    @Test("Codex thread deep links encode the complete thread identifier")
+    func deepLinkEncoding() {
+        let url = CodexSessionNavigation.codexThreadURL(threadId: "thread with/slash")
+
+        #expect(url?.absoluteString == "codex://threads/thread%20with%2Fslash")
+    }
+
+    @Test("App execution binding takes the user to the exact Codex thread")
+    func appDestination() {
+        let link = Link(
+            id: "app-card",
+            column: .waiting,
+            executionBinding: CodexExecutionBinding(
+                backend: .app,
+                ownership: .observed,
+                evidence: .appServerSource,
+                telemetryQuality: .precise,
+                threadId: "019f-thread"
+            ),
+            assistant: .codex
+        )
+
+        #expect(
+            CodexSessionNavigation.destination(
+                executionBinding: link.executionBinding,
+                legacyTmuxSessionName: link.tmuxLink?.sessionName
+            )
+                == .codexThread(URL(string: "codex://threads/019f-thread")!)
+        )
+    }
+
+    @Test("CLI execution binding locates tmux even without the legacy tmux link")
+    func cliDestination() {
+        let link = Link(
+            id: "cli-card",
+            column: .inProgress,
+            executionBinding: CodexExecutionBinding(
+                backend: .cliTmux,
+                ownership: .managed,
+                evidence: .boardCreated,
+                telemetryQuality: .precise,
+                tmuxSessionName: "kanban-code-cli-card-1"
+            ),
+            assistant: .codex
+        )
+
+        #expect(
+            CodexSessionNavigation.destination(
+                executionBinding: link.executionBinding,
+                legacyTmuxSessionName: link.tmuxLink?.sessionName
+            )
+                == .tmux("kanban-code-cli-card-1")
+        )
+    }
+
+    @Test("Legacy sessions without a runtime binding remain openable as details")
+    func legacyDestination() {
+        let link = Link(
+            id: "legacy-card",
+            column: .allSessions,
+            sessionLink: SessionLink(sessionId: "legacy-session")
+        )
+
+        #expect(
+            CodexSessionNavigation.destination(
+                executionBinding: link.executionBinding,
+                legacyTmuxSessionName: link.tmuxLink?.sessionName
+            ) == .details
+        )
+    }
+}

--- a/cli/pnpm-workspace.yaml
+++ b/cli/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/cli/src/agents.test.ts
+++ b/cli/src/agents.test.ts
@@ -116,6 +116,28 @@ describe("cards: persistence (sandboxed)", () => {
     assert.equal(findCardByName("x-renamed")?.id, "card_x");
   });
 
+  test("upsertCard preserves runtime and unknown fields from newer clients", () => {
+    const existing = {
+      ...makeCard("card_runtime", "before"),
+      executionBinding: {
+        backend: "app",
+        ownership: "managed",
+        evidence: "boardCreated",
+        telemetryQuality: "precise",
+        threadId: "thread_123",
+      },
+      futureMacField: { nested: [1, { kept: true }] },
+    };
+    writeLinks([existing as Link]);
+
+    upsertCard(makeCard("card_runtime", "after"));
+
+    const raw = JSON.parse(readFileSync(join(home, "links.json"), "utf-8"));
+    assert.equal(raw.links[0].name, "after");
+    assert.equal(raw.links[0].executionBinding.threadId, "thread_123");
+    assert.equal(raw.links[0].futureMacField.nested[1].kept, true);
+  });
+
   test("a daily backup is rotated on overwrite", () => {
     writeLinks([makeCard("card_1", "a")]);
     writeLinks([makeCard("card_1", "a"), makeCard("card_2", "b")]);

--- a/cli/src/cards.ts
+++ b/cli/src/cards.ts
@@ -77,7 +77,10 @@ function rotateDailyBackup(file: string): void {
 export function upsertCard(card: Link): void {
   const links = readLinks();
   const index = links.findIndex((l) => l.id === card.id);
-  if (index >= 0) links[index] = card;
+  // Preserve fields written by newer clients that this CLI does not type yet.
+  // In particular, the CLI must not erase Swift-owned runtime metadata when an
+  // agent launch updates the same card with an older-shaped Link object.
+  if (index >= 0) links[index] = { ...links[index], ...card };
   else links.push(card);
   writeLinks(links);
 }

--- a/cli/src/codex-board-projection.test.ts
+++ b/cli/src/codex-board-projection.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { applyCodexRuntimeProjection, readCodexRuntimeStates, toCardSummary } from "./data.js";
+import type { Link } from "./types.js";
+
+test("CLI projects the Swift-owned Codex lifecycle without writing it", () => {
+  const home = mkdtempSync(join(tmpdir(), "kanban-codex-projection-"));
+  const previous = process.env.KANBAN_CODE_HOME;
+  process.env.KANBAN_CODE_HOME = home;
+  try {
+    writeFileSync(join(home, "codex-runtime-state.json"), JSON.stringify({
+      version: 1,
+      states: {
+        card_1: {
+          cardId: "card_1",
+          lifecycle: {
+            phase: "waiting",
+            waitReason: "approval",
+            telemetryQuality: "precise",
+          },
+          updatedAt: "2026-07-18T00:00:00Z",
+        },
+      },
+    }));
+    const link: Link = {
+      id: "card_1",
+      name: "Review permissions",
+      column: "backlog",
+      createdAt: "2026-07-18T00:00:00Z",
+      updatedAt: "2026-07-18T00:00:00Z",
+      manualOverrides: {
+        worktreePath: false, tmuxSession: false, name: false,
+        column: false, prLink: false, issueLink: false,
+      },
+      manuallyArchived: false,
+      source: "manual",
+      isRemote: false,
+      assistant: "codex",
+    };
+    const states = readCodexRuntimeStates();
+    const projected = applyCodexRuntimeProjection([link], states);
+    assert.equal(projected[0].column, "requires_attention");
+    const summary = toCardSummary(projected[0], new Set(), states);
+    assert.equal(summary.lifecycle?.waitReason, "approval");
+    assert.equal(summary.needsAttention, true);
+  } finally {
+    if (previous === undefined) delete process.env.KANBAN_CODE_HOME;
+    else process.env.KANBAN_CODE_HOME = previous;
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -26,8 +26,9 @@ import {
   CardDetail,
   TranscriptTurn,
   KanbanColumn,
+  CodexRuntimeState,
 } from "./types.js";
-import { linksPath, settingsPath, contextDir, claudeProjectsDir } from "./paths.js";
+import { linksPath, settingsPath, contextDir, claudeProjectsDir, codexRuntimeStatePath } from "./paths.js";
 
 // ── Reading state files ──────────────────────────────────────────────
 
@@ -46,6 +47,36 @@ export function readSettings(): Settings {
   if (!existsSync(path))
     return { projects: [] };
   return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+export function readCodexRuntimeStates(): Record<string, CodexRuntimeState> {
+  const path = codexRuntimeStatePath();
+  if (!existsSync(path)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    return raw && raw.states && typeof raw.states === "object" ? raw.states : {};
+  } catch {
+    return {};
+  }
+}
+
+export function applyCodexRuntimeProjection(
+  links: Link[],
+  states: Record<string, CodexRuntimeState> = readCodexRuntimeStates()
+): Link[] {
+  const columns: Partial<Record<CodexRuntimeState["lifecycle"]["phase"], KanbanColumn>> = {
+    queued: "backlog",
+    launching: "in_progress",
+    running: "in_progress",
+    waiting: "requires_attention",
+    inReview: "in_review",
+    done: "done",
+  };
+  return links.map((link) => {
+    const state = states[link.id];
+    const column = state ? columns[state.lifecycle.phase] : undefined;
+    return column ? { ...link, column } : link;
+  });
 }
 
 // ── Session context (tokens/cost) ────────────────────────────────────
@@ -544,18 +575,23 @@ function projectName(link: Link): string | undefined {
 
 export function toCardSummary(
   link: Link,
-  liveTmux: Set<string>
+  liveTmux: Set<string>,
+  runtimeStates: Record<string, CodexRuntimeState> = readCodexRuntimeStates()
 ): CardSummary {
   const tmuxName = link.tmuxLink?.sessionName;
   const ctx = link.sessionLink?.sessionId
     ? readSessionContext(link.sessionLink.sessionId)
     : undefined;
+  const lifecycle = runtimeStates[link.id]?.lifecycle;
   return {
     id: link.id,
     name: displayTitle(link),
     column: link.column,
     project: projectName(link),
     assistant: link.assistant,
+    executionBinding: link.executionBinding,
+    lifecycle,
+    needsAttention: lifecycle?.phase === "waiting",
     sessionId: link.sessionLink?.sessionId,
     tmuxSession: tmuxName,
     tmuxAlive: tmuxName ? liveTmux.has(tmuxName) : false,
@@ -589,9 +625,10 @@ export function toCardSummary(
 export function toCardDetail(
   link: Link,
   liveTmux: Set<string>,
-  transcriptTurns: number = 3
+  transcriptTurns: number = 3,
+  runtimeStates: Record<string, CodexRuntimeState> = readCodexRuntimeStates()
 ): CardDetail {
-  const summary = toCardSummary(link, liveTmux);
+  const summary = toCardSummary(link, liveTmux, runtimeStates);
   const transcript = link.sessionLink?.sessionPath
     ? readLastTranscriptTurns(link.sessionLink.sessionPath, transcriptTurns)
     : [];

--- a/cli/src/kanban.ts
+++ b/cli/src/kanban.ts
@@ -22,6 +22,8 @@ import {
   findCard,
   toCardSummary,
   toCardDetail,
+  applyCodexRuntimeProjection,
+  readCodexRuntimeStates,
 } from "./data.js";
 import {
   formatCardList,
@@ -131,7 +133,8 @@ program
   .option("--with-capture-peek", "Include a short peek at each card's tmux pane")
   .option("-j, --json", "Output as JSON")
   .action((opts) => {
-    let links = readLinks();
+    const runtimeStates = readCodexRuntimeStates();
+    let links = applyCodexRuntimeProjection(readLinks(), runtimeStates);
     const tmux = listTmuxSessions();
     const liveTmux = new Set(tmux.map((t) => t.name));
 
@@ -165,7 +168,7 @@ program
     });
 
     const summaries = links.map((l) => {
-      const s = toCardSummary(l, liveTmux);
+      const s = toCardSummary(l, liveTmux, runtimeStates);
       if (opts.withLastMessage && l.sessionLink?.sessionPath) {
         const turns = readLastTranscriptTurns(l.sessionLink.sessionPath, 1);
         if (turns.length) s.lastMessage = turns[turns.length - 1].text;
@@ -197,7 +200,8 @@ program
   .option("-t, --transcript <n>", "Number of transcript turns to show", "5")
   .option("-j, --json", "Output as JSON")
   .action((cardQuery: string, opts) => {
-    const links = readLinks();
+    const runtimeStates = readCodexRuntimeStates();
+    const links = applyCodexRuntimeProjection(readLinks(), runtimeStates);
     const card = findCard(links, cardQuery);
     if (!card) {
       console.error(`Card not found: ${cardQuery}`);
@@ -206,7 +210,7 @@ program
 
     const tmux = listTmuxSessions();
     const liveTmux = new Set(tmux.map((t) => t.name));
-    const detail = toCardDetail(card, liveTmux, parseInt(opts.transcript));
+    const detail = toCardDetail(card, liveTmux, parseInt(opts.transcript), runtimeStates);
 
     if (opts.json) {
       output(detail, { json: true });

--- a/cli/src/paths.ts
+++ b/cli/src/paths.ts
@@ -15,6 +15,10 @@ export function settingsPath(): string {
   return join(kanbanHome(), "settings.json");
 }
 
+export function codexRuntimeStatePath(): string {
+  return join(kanbanHome(), "codex-runtime-state.json");
+}
+
 export function contextDir(): string {
   return join(kanbanHome(), "context");
 }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -27,6 +27,66 @@ export type PRStatus =
 
 export type LinkSource = "discovered" | "hook" | "manual" | "githubIssue";
 export type CodingAssistant = "claude" | "gemini" | "codex";
+export type CodexRuntimeBackend = "app" | "cliTmux" | "unknown";
+export type RuntimeOwnership = "managed" | "observed";
+export type RuntimeEvidence =
+  | "userConfirmed"
+  | "boardCreated"
+  | "tmuxBinding"
+  | "appServerSource"
+  | "cliMetadata"
+  | "unknown";
+export type TelemetryQuality = "precise" | "limited" | "unknown";
+export type CodexLifecyclePhase =
+  | "queued"
+  | "launching"
+  | "running"
+  | "waiting"
+  | "inReview"
+  | "done"
+  | "unknown";
+export type CodexLifecycleWaitReason =
+  | "input"
+  | "approval"
+  | "ordinaryStop"
+  | "fault"
+  | "disconnected"
+  | "launchUncertain"
+  | "unknown";
+
+export interface CodexRuntimeState {
+  cardId: string;
+  lifecycle: {
+    phase: CodexLifecyclePhase;
+    waitReason?: CodexLifecycleWaitReason;
+    telemetryQuality: TelemetryQuality;
+  };
+  updatedAt: string;
+}
+
+export interface CodexRuntimeProvenance {
+  backend: CodexRuntimeBackend;
+  ownership: RuntimeOwnership;
+  evidence: RuntimeEvidence;
+  telemetryQuality: TelemetryQuality;
+  observedAt?: string;
+}
+
+export interface CodexExecutionBinding {
+  backend: CodexRuntimeBackend;
+  ownership: RuntimeOwnership;
+  evidence: RuntimeEvidence;
+  telemetryQuality: TelemetryQuality;
+  threadId?: string;
+  sessionId?: string;
+  tmuxSessionName?: string;
+  boundAt?: string;
+}
+
+export interface CodexBoardSettings {
+  runtime: CodexRuntimeBackend;
+  maxConcurrency: number;
+}
 
 export interface SessionLink {
   sessionId: string;
@@ -124,6 +184,10 @@ export interface Link {
   sortOrder?: number;
   assistant?: CodingAssistant;
   isLaunching?: boolean;
+  /// Cross-platform display/binding metadata written by the Swift app.
+  /// Lifecycle snapshots and launch leases live in codex-runtime-state.json
+  /// and are intentionally not part of the CLI's writable model.
+  executionBinding?: CodexExecutionBinding;
 }
 
 export interface TmuxSession {
@@ -154,6 +218,7 @@ export interface Settings {
   hasCompletedOnboarding?: boolean;
   defaultAssistant?: CodingAssistant;
   enabledAssistants?: CodingAssistant[];
+  codexBoard?: CodexBoardSettings;
 }
 
 export interface SessionContext {
@@ -173,6 +238,9 @@ export interface CardSummary {
   column: KanbanColumn;
   project?: string;
   assistant?: CodingAssistant;
+  executionBinding?: CodexExecutionBinding;
+  lifecycle?: CodexRuntimeState["lifecycle"];
+  needsAttention?: boolean;
   sessionId?: string;
   tmuxSession?: string;
   tmuxAlive: boolean;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,9 @@ The fix: a lightweight Elm/Redux-style store that serializes all state mutations
 
 ## Core Components
 
-### `AppState` (struct)
-Single source of truth. All board data lives here.
+### `AppState` (`@Observable`)
+Single UI source of truth. Durable Codex leases and lifecycle snapshots are
+owned by a separate actor-backed store and projected into `AppState`.
 
 ```
 AppState
@@ -17,6 +18,7 @@ AppState
 ├── sessions: [String: Session]        // sessionId → Session
 ├── activityMap: [String: ActivityState] // sessionId → activity
 ├── tmuxSessions: Set<String>          // live tmux session names
+├── codexRuntimeStates: [String: CardRuntimeState] // UI projection cache
 ├── selectedCardId: String?
 ├── selectedProjectPath: String?
 ├── configuredProjects: [Project]
@@ -46,6 +48,7 @@ Side effects declared by the reducer, executed asynchronously by `EffectHandler`
 - `createTmuxSession`, `killTmuxSession` — terminal management
 - `deleteSessionFile`, `cleanupTerminalCache` — cleanup
 - `updateSessionIndex` — session metadata
+- `upsertCodexRuntimeState`, `rekeyCodexRuntimeState` — Codex sidecar state
 
 ### `BoardStore` (`@Observable @MainActor`)
 The main store that ties it all together:
@@ -60,6 +63,25 @@ func dispatch(_ action: Action) {
 ```
 
 Also has `reconcile()` — async method that does full discovery (sessions, tmux, worktrees, PRs) and dispatches `.reconciled(result)`.
+
+## Codex runtime ownership
+
+Codex has two backends—App Server and CLI + tmux—but both feed one canonical
+lifecycle. `CodexRuntimeStateStore` is the durable authority for launch leases,
+execution bindings, lifecycle watermarks and recovery. Its file is separate
+from `links.json` because older TypeScript and Rust clients rewrite that shared
+file and cannot safely own high-consistency state.
+
+`CodexBoardCoordinator` owns live runtime adapters, serialized FIFO scheduling,
+App Server notification/request streams and the authenticated hook inbox. It
+persists lifecycle changes before notifying SwiftUI. `AppState.codexRuntimeStates`
+is only the render/projection cache used to derive the five lanes and global
+attention strip.
+
+Imported App threads receive structured status during reconciliation. Managed
+tasks persist a launch lease before any external side effect. Card merges emit a
+`rekeyCodexRuntimeState` effect so a binding or lease cannot be orphaned under a
+deleted card ID.
 
 ## Key Files
 
@@ -126,7 +148,7 @@ This is NOT TCA (Point-Free's The Composable Architecture). Key differences:
 | Effect cancellation | Simple Tasks | Sophisticated effect lifecycle |
 | Navigation state | `@State` in views | Managed in reducer |
 | Package dependency | None | `swift-composable-architecture` |
-| Code size | ~400 lines | Framework |
+| Code size | Project-local implementation | Framework |
 
 For our use case (single-screen app, ~25 actions, core problem = race conditions), the lightweight approach gives the same guarantees without the learning curve.
 

--- a/docs/codex-board.md
+++ b/docs/codex-board.md
@@ -1,0 +1,102 @@
+# Codex session board
+
+Kanban Code can organize Codex work as a five-stage workflow:
+
+1. Backlog
+2. In Progress
+3. Waiting
+4. In Review
+5. Done
+
+The selected runtime applies to the whole board. Existing work is never migrated
+or terminated when the mode changes; only the inactive runtime's queued tasks
+pause. All Sessions remains available as a separate searchable history.
+
+## Runtime modes
+
+### Codex App
+
+Requirements:
+
+- macOS 26
+- Codex.app, for opening a specific thread
+- a compatible `codex` executable with the `app-server` capability
+
+Managed tasks use App Server thread and turn identifiers. The board can open a
+thread with `codex://threads/<thread-id>`. The deep link is navigation only;
+permission and user-input requests remain bound to the App Server connection
+that issued them.
+
+### Codex CLI + tmux
+
+Requirements:
+
+- macOS 26
+- Codex CLI
+- tmux
+
+Each managed task keeps a stable Codex session binding and a persistent tmux
+session. Opening the task reconnects to that tmux session. Switching the board
+to Codex App does not stop it.
+
+## Automatic movement
+
+Kanban Code stores normalized lifecycle state separately from `links.json` in
+`~/.kanban-code/codex-runtime-state.json`. This prevents older CLI or Windows
+writers from accidentally erasing launch leases or event watermarks.
+
+- queued → Backlog
+- launching or running → In Progress
+- permission, input, ordinary stop, fault, disconnect or uncertain launch → Waiting
+- explicit `review-ready` lifecycle signal → In Review
+- human acceptance, or every linked pull request merged → Done
+
+A normal turn stopping does not mean that its output is ready for review. A
+closed but unmerged pull request does not complete a card. Tasks without GitHub
+links can still enter In Review through the structured review-ready signal and
+finish through human acceptance.
+
+Manual lifecycle corrections remain authoritative until a newer comparable
+event arrives. Ambiguous or conflicting event sources are shown as limited
+telemetry instead of being presented as precise state.
+
+## Attention strip
+
+The attention strip is global: it includes actionable Waiting sessions from
+both runtimes and every project, even when their cards are hidden by the current
+board or project filter. Approval and input requests sort ahead of faults,
+ordinary stops and disconnects. Running, queued and plain In Review sessions do
+not appear there.
+
+## Local files and security
+
+App Server and hook payloads are treated as untrusted input. Event size and
+schema are validated; event text is never executed as a shell command. Managed
+launches use a durable attempt identifier and capability-bound lifecycle events
+to reduce accidental or cross-session event forgery.
+
+Codex authentication remains owned by Codex. Kanban Code does not copy Codex
+tokens into settings, card records or lifecycle events. The resolved Codex
+executable is retained as an absolute path, capability-probed, and rejected when
+it resolves inside the active project.
+
+Important local paths:
+
+- `~/.kanban-code/links.json` — cross-platform card/link metadata
+- `~/.kanban-code/codex-runtime-state.json` — Swift-owned lifecycle and leases
+- `~/.kanban-code/codex-lifecycle-inbox/` — bounded lifecycle event inbox
+- `~/.kanban-code/settings.json` — board runtime and concurrency setting
+
+## Degraded operation and recovery
+
+If lifecycle hooks are not authorized, imported tasks remain visible but use
+limited telemetry. Filesystem modification time alone is never considered proof
+of Waiting, In Review or Done.
+
+If a launch or resume acknowledgement is lost, Kanban Code keeps the task in an
+uncertain Waiting state and offers retry/open actions. It does not automatically
+repeat a potentially successful external side effect.
+
+To change runtime or concurrency, open Settings → General → Codex Board. The
+diagnostic rows show Codex desktop navigation, App Server, Codex CLI and tmux
+availability plus the resolved executable and version.

--- a/docs/plans/2026-07-18-001-feat-codex-session-kanban-plan.md
+++ b/docs/plans/2026-07-18-001-feat-codex-session-kanban-plan.md
@@ -27,7 +27,7 @@ deepened: 2026-07-18
 - **Durability and compatibility:** lifecycle、launch lease 与 watermark 独立保存在 Swift-owned runtime store；CLI 只读投影该状态；Swift、TypeScript 与 Rust 的共享 settings/link schema 保持向后兼容，Windows writer 保留未知字段。
 - **App Server realization:** 实现复用 Codex 自带的 `app-server daemon start` + `app-server proxy`，由 Codex daemon 在 UI 生命周期之外持有 runtime；没有重复实现规划草案中的自定义 SMAppService/socket/token companion。客户端仍提供请求关联、allowlist、大小限制、重连和 thread rehydration。
 - **Hook realization:** bundle 内的 lifecycle helper 带 SHA-256 manifest，安装时验证并使用每次 launch 的 capability 绑定 card/session/generation；拒绝安装时保持只读导入和 limited telemetry。
-- **Verification:** `swift build`、879 个 Swift tests、CLI build + 279 tests、Web build + 72 tests、完整 `.app` archive、helper manifest、deep codesign 与 zip integrity 已在本机通过。Rust 工具链本机不可用，`cargo fmt --check` 与 `cargo test --lib` 由新增 Windows CI job 执行。
+- **Verification:** `swift build`、879 个 Swift tests、CLI build + 279 tests、Web build + 72 tests、完整 `.app` archive、helper manifest、deep codesign 与 zip integrity 已在本机通过。Rust compatibility tests 使用隔离在 `/tmp` 的工具链执行；新增 Windows CI job 重跑 `cargo test --lib`。上游 Rust tree 尚未整体通过当前 rustfmt，因此本 PR 不新增一个必然被基线格式阻塞的全仓 format gate。
 - **Credential-gated follow-up:** Developer ID 签名、公证、托管更新和远程通知继续按 Scope Boundaries 延后；本 PR 产出 ad-hoc signed、可复现的本地 archive。
 
 ---

--- a/docs/plans/2026-07-18-001-feat-codex-session-kanban-plan.md
+++ b/docs/plans/2026-07-18-001-feat-codex-session-kanban-plan.md
@@ -1,0 +1,507 @@
+---
+title: Codex Session Kanban - Plan
+type: feat
+date: 2026-07-18
+topic: codex-session-kanban
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+deepened: 2026-07-18
+---
+
+# Codex Session Kanban - Plan
+
+## Goal Capsule
+
+- **Objective:** 构建一个公开开源的 macOS 26 App，以看板级运行模式管理 Codex App 或 Codex CLI + tmux sessions，让用户无需反复切换即可发现正在运行和等待确认的工作。
+- **Product authority:** 本文中的产品行为来自已确认的用户选择；Codex 能力边界以官方文档为准，tmux 工作流以参考项目现有实现为依据。
+- **Execution profile:** Deep、high-risk integration；以现有 `AppState`/`Reducer`/`Effect` 架构为唯一写入路径，兼容迁移现有 `links.json`，用可注入 fake 隔离真实 Codex/tmux 依赖。
+- **Tail ownership:** 本次 LFG 流程负责计划实现、简化、独立代码审查、测试、提交、创建 PR 与跟进 CI；除外部凭据、上游权限或产品范围冲突外不回退给用户。
+- **Stop conditions:** 仅在官方协议与已确认产品行为实质冲突、数据迁移不可安全回滚、需要用户凭据/签名身份，或上游仓库拒绝推送且无可用 fork 权限时停止。
+- **Open blockers:** 无产品范围阻塞项；规划默认值与兼容策略已在 Planning Contract 中解析。
+
+## Implementation Outcome
+
+- **Delivered:** 看板级 App / CLI + tmux 模式、五列 runtime 投影、跨模式注意力条、最近 App thread 导入、自动领取与并发限制、稳定 binding、审批/输入响应、结构化 review-ready、人工完成/继续修改、非 GitHub 手动待评审、PR 全部合并后完成，以及 App thread / tmux 原 session 打开动作。
+- **Durability and compatibility:** lifecycle、launch lease 与 watermark 独立保存在 Swift-owned runtime store；CLI 只读投影该状态；Swift、TypeScript 与 Rust 的共享 settings/link schema 保持向后兼容，Windows writer 保留未知字段。
+- **App Server realization:** 实现复用 Codex 自带的 `app-server daemon start` + `app-server proxy`，由 Codex daemon 在 UI 生命周期之外持有 runtime；没有重复实现规划草案中的自定义 SMAppService/socket/token companion。客户端仍提供请求关联、allowlist、大小限制、重连和 thread rehydration。
+- **Hook realization:** bundle 内的 lifecycle helper 带 SHA-256 manifest，安装时验证并使用每次 launch 的 capability 绑定 card/session/generation；拒绝安装时保持只读导入和 limited telemetry。
+- **Verification:** `swift build`、879 个 Swift tests、CLI build + 279 tests、Web build + 72 tests、完整 `.app` archive、helper manifest、deep codesign 与 zip integrity 已在本机通过。Rust 工具链本机不可用，`cargo fmt --check` 与 `cargo test --lib` 由新增 Windows CI job 执行。
+- **Credential-gated follow-up:** Developer ID 签名、公证、托管更新和远程通知继续按 Scope Boundaries 延后；本 PR 产出 ad-hoc signed、可复现的本地 archive。
+
+---
+
+## Product Contract
+
+> Product Contract 的需求与已确认决策保持不变；Planning Contract 只解析实现方式、迁移、验证和风险。依赖假设会在官方实现证据要求时收紧，但不改变产品行为。
+
+### Summary
+
+提供一个可在 Codex App 与 Codex CLI + tmux 两种运行模式间切换的五列任务看板。
+当前模式决定五列中显示和调度的任务类型，顶部提醒条跨模式集中显示所有等待人工处理的 sessions。
+
+### Problem Frame
+
+当多个 Codex App 与 Codex CLI sessions 并行运行时，用户必须反复切换任务或终端查看状态，也容易忘记哪个 session 正在等待确认。
+现有会话列表展示的是对话历史，不是以人工注意力为中心的工作队列；用户因此承担了持续轮询、记忆分支关系和手动整理状态的成本。
+
+### Key Decisions
+
+- **Codex App 模式采用混合 session 管理。** 看板创建的任务由 App Server 精确管理，现有 Codex App sessions 通过导入与 Hooks 接入。`(session-settled: user-directed — chosen over independent-only or companion-only operation: existing Codex App sessions must remain visible while board-created tasks need precise lifecycle control)`
+- **运行类型属于整个看板。** 用户在 Codex App 与 Codex CLI + tmux 之间选择当前模式，而不是为每张卡片单独选择。`(session-settled: user-directed — chosen over per-task runtime selection or automatic fallback: one runtime per board keeps launch, resume, and navigation behavior coherent)`
+- **切换模式只改变当前工作视图和后续调度。** 另一类型的 sessions 保留在“全部 Sessions”，切换不得迁移、重启或终止它们。`(session-settled: user-directed — chosen over requiring an empty board or migrating existing sessions: switching must preserve in-flight work without mixing runtimes in the five columns)`
+- **顶部注意力提醒跨两种模式。** 即使某个 session 不属于当前看板模式，它等待人工处理时仍必须出现在提醒条中。`(session-settled: user-approved — chosen over filtering alerts to the current runtime: hiding inactive-mode attention requests would recreate the core missed-confirmation problem)`
+- **作为公开开源 App 发布。** 产品允许延续参考项目的 AGPL 路线，并把安装、升级和兼容诊断视为正式体验。`(session-settled: user-directed — chosen over a personal-only tool or closed-source product: the app should be publicly distributable and open source)`
+- **使用经典五列看板并增加顶部等待提醒。** 完整生命周期保持可见，等待人工处理的 sessions 同时聚合到页面顶部。`(session-settled: user-directed — chosen over an inbox-first dashboard or focused split view: users need both the full workflow and an unmistakable attention queue)`
+- **自动领取受并发上限控制。** 当前运行模式的新建任务先排队，出现空闲执行槽位时自动启动。`(session-settled: user-directed — chosen over unlimited immediate launch or manual-only start: automation must remain predictable under parallel load)`
+- **仅将最近活跃 sessions 转成工作卡。** 更早的记录保留在“全部 Sessions”中供搜索。`(session-settled: user-directed — chosen over turning every historical session into a board card or requiring manual import: history must not overwhelm the working board)`
+- **待评审表示交付物等待人工验收。** 该状态不依赖 GitHub，也不由一次普通 push 决定。`(session-settled: user-directed — chosen over PR-only or push-based review entry: some useful Codex tasks are not associated with GitHub)`
+- **Codex 使用结构化信号声明可评审。** 普通 turn 停止或自然语言完成表述不能单独触发待评审。`(session-settled: user-directed — chosen over natural-language classification or treating every stopped turn as review-ready: review transitions must be reliable)`
+- **人工验收提供完成与继续修改。** 继续修改将反馈发送到原 session，并恢复进行中状态。`(session-settled: user-directed — chosen over PR-merge-only completion or manual card dragging: non-GitHub work needs a complete review loop)`
+- **首版仅支持 macOS 26。** 复用参考项目的平台能力，优先交付核心工作流。`(session-settled: user-directed — chosen over macOS 15 or macOS 14 compatibility: the first release should minimize compatibility work)`
+- **首要指标是等待项可见性。** 约 10 个并行 sessions 时，用户应在几秒内发现全部等待确认项。`(session-settled: user-directed — chosen over maximum throughput or onboarding speed as the primary metric: missed attention requests are the core pain)`
+- **通过用户授权安装全局 Codex Hooks 或轻量插件。** 看板外创建的现有与未来 sessions 也应获得结构化生命周期信号。`(session-settled: user-directed — chosen over observation-only import or file and language inference: external sessions need trustworthy status transitions)`
+
+### Actors
+
+- A1. **Codex 用户：** 同时管理多个本地 Codex sessions，查看注意力队列并执行人工验收。
+- A2. **看板 App：** 管理当前运行模式、创建任务、调度并发、聚合生命周期事件、计算卡片状态并提供导航。
+- A3. **Codex runtime：** Codex App session 或运行在 tmux 中的 Codex CLI session，负责执行工作、请求输入或权限，并在交付物准备好时发出结构化信号。
+- A4. **可选 Git 提供方：** 为代码任务补充分支、PR、CI 和合并状态，但不决定任务是否能够进入待评审。
+
+### Requirements
+
+**Runtime mode and session intake**
+
+- R1. App 必须提供 Codex App 与 Codex CLI + tmux 两种看板级运行模式，并持续显示当前模式。
+- R2. 五列看板必须只显示当前运行模式的工作卡，另一类型的 sessions 必须保留在可搜索的“全部 Sessions”中。
+- R3. 切换运行模式不得迁移、重启或终止任何已有 session，并且只影响后续任务调度和五列展示。
+- R4. App 必须根据可验证的运行证据识别导入 session 的类型；证据不足时必须标记类型待确认并允许用户纠正。
+- R5. 首次接入时，App 必须将当前模式下最近活跃且未归档的 sessions 转换为工作卡，并将更早的 sessions 保留在“全部 Sessions”中。
+
+**Task creation and queue**
+
+- R6. 用户必须能够在待办列新建任务，并提供启动 Codex 所需的任务描述和本地工作区；任务自动继承当前看板模式。
+- R7. 当前模式的新建任务必须进入自动队列，并仅在并发上限存在空闲槽位时启动。
+- R8. 看板启动的 Codex App 任务必须绑定稳定 thread 标识；Codex CLI 任务必须绑定稳定 Codex session 与 tmux session，使后续状态、反馈和打开动作始终回到原任务。
+
+**Lifecycle and attention**
+
+- R9. 两种运行模式的工作卡必须共用待办、进行中、等待、待评审和完成五个自动状态。
+- R10. Codex App 模式必须使用 App Server 生命周期；Codex CLI 模式必须结合 tmux 生命周期与 Codex 结构化事件；外部 sessions 必须优先使用经用户授权的全局 Hooks 或轻量插件事件。
+- R11. 所有等待人工输入、权限确认或故障处理的 sessions 必须出现在顶部注意力提醒条，即使它们不属于当前运行模式；属于当前模式的卡片还必须进入等待列。
+- R12. 普通 turn 停止但未发出可评审信号时，卡片必须进入等待，而不是被误判为完成或待评审。
+- R13. Codex 发出的结构化可评审信号必须使卡片进入待评审，无论运行模式或任务是否关联 GitHub。
+- R14. 事件覆盖不完整的外部 session 必须显示“状态受限”，App 不得将推测状态伪装为精确状态。
+- R15. App 必须保留手动纠正卡片状态的逃生口，并在下一次明确生命周期事件后恢复自动流转。
+
+**Review and completion**
+
+- R16. 待评审卡片必须提供“完成”和“继续修改”两种人工验收操作。
+- R17. “继续修改”必须通过对应运行模式将用户反馈发送到原 Codex session，并使卡片回到进行中。
+- R18. 如果代码任务存在 PR，卡片必须展示其评审证据；PR 合并可以自动使卡片进入完成，但 PR 不是进入待评审的前提。
+
+**Navigation and onboarding**
+
+- R19. 卡片和注意力提醒必须提供模式匹配的打开动作：Codex App session 跳转到对应 Codex thread，Codex CLI session 打开或连接对应 tmux 终端。
+- R20. 首次启动和模式切换必须检查所选模式的运行条件，并在安装全局 Hooks 或轻量插件前取得用户明确授权。
+- R21. 用户拒绝安装 Hooks 时，App 必须继续提供只读 session 导入，并明确说明两种模式下自动状态能力的降级范围。
+- R22. App 必须以可公开分发的开源 macOS 26 应用交付，并针对 Codex App、Codex CLI 和 tmux 的依赖缺失或版本不兼容提供可操作诊断。
+
+主界面保持完整流程，同时将等待项提升为独立注意力入口：
+
+```mermaid
+flowchart TB
+  AppRuntime["Codex App sessions"]
+  CliRuntime["Codex CLI + tmux sessions"]
+  Mode["Current board runtime mode"]
+  Alert["Global attention strip"]
+  Board["Five-column board"]
+  All["All Sessions"]
+  Backlog["Backlog"]
+  Running["In Progress"]
+  Waiting["Waiting"]
+  Review["In Review"]
+  Done["Done"]
+  AppRuntime --> Alert
+  CliRuntime --> Alert
+  Mode --> Board
+  Board --> Backlog
+  Board --> Running
+  Board --> Waiting
+  Board --> Review
+  Board --> Done
+  AppRuntime --> All
+  CliRuntime --> All
+```
+
+### Key Flows
+
+- F1. **First launch and import**
+  - **Trigger:** A1 首次启动 App。
+  - **Actors:** A1、A2、A3。
+  - **Steps:** App 检查两种模式的环境；用户选择看板运行模式和是否授权 Hooks；App 导入当前模式的最近活跃 sessions；其他 sessions 进入“全部 Sessions”。
+  - **Outcome:** 五列只包含当前模式的工作，其他 sessions 保持可查，其状态能力清晰可见。
+  - **Covered by:** R1、R2、R4、R5、R10、R20、R21、R22。
+- F2. **Create and auto-claim a task**
+  - **Trigger:** A1 在待办中新建任务。
+  - **Actors:** A1、A2、A3。
+  - **Steps:** 卡片继承当前运行模式并进入队列；空闲槽位出现；App 通过对应后端创建 Codex session；卡片进入进行中。
+  - **Outcome:** 任务无需再次点击即可开始，同时不突破并发上限。
+  - **Covered by:** R6、R7、R8、R9。
+- F3. **Handle an attention request**
+  - **Trigger:** 任一运行模式中的 Codex 请求权限、用户输入或在未交付时停止。
+  - **Actors:** A1、A2、A3。
+  - **Steps:** session 出现在全局提醒条；若属于当前模式，卡片同时进入等待列；A1 打开对应 Codex App thread 或 tmux 终端；继续后卡片返回进行中。
+  - **Outcome:** 等待项不会因其他 session 活动或看板模式切换而被遗漏。
+  - **Covered by:** R9、R11、R12、R19。
+- F4. **Review and revise**
+  - **Trigger:** Codex 发出结构化可评审信号。
+  - **Actors:** A1、A2、A3、A4。
+  - **Steps:** 卡片进入待评审；App 展示现有交付物和可选 PR 证据；A1 选择完成或继续修改。
+  - **Outcome:** 完成使卡片关闭；继续修改将反馈送回原 session 并恢复执行。
+  - **Covered by:** R13、R16、R17、R18。
+- F5. **Recover from limited telemetry**
+  - **Trigger:** 外部 session 已存在，但尚未触发授权后的生命周期事件。
+  - **Actors:** A1、A2、A3。
+  - **Steps:** App 导入 session 并标记状态或类型受限；用户可纠正类型；下一次提交、恢复或 Hook 事件后，App 切换为精确自动状态。
+  - **Outcome:** App 保留可见性，同时避免错误承诺状态准确性。
+  - **Covered by:** R4、R5、R10、R14、R15、R21。
+- F6. **Switch board runtime mode**
+  - **Trigger:** A1 将看板从 Codex App 切换到 Codex CLI + tmux，或反向切换。
+  - **Actors:** A1、A2、A3。
+  - **Steps:** App 检查目标模式依赖；五列切换到目标类型；原模式 sessions 保留在“全部 Sessions”；所有等待项继续出现在全局提醒条。
+  - **Outcome:** 用户可以改变工作方式而不迁移或中断已有 session，也不会失去等待项可见性。
+  - **Covered by:** R1、R2、R3、R11、R20。
+
+两种运行模式共用事件驱动的生命周期，GitHub 仅提供可选证据：
+
+```mermaid
+stateDiagram-v2
+  [*] --> Backlog: create task
+  Backlog --> InProgress: queue slot available
+  InProgress --> Waiting: approval, input, failure, or ordinary stop
+  Waiting --> InProgress: user continues
+  InProgress --> InReview: structured review-ready signal
+  InReview --> InProgress: continue with feedback
+  InReview --> Done: user accepts
+  InReview --> Done: linked PR merges
+```
+
+### Acceptance Examples
+
+- AE1. **Covers R6, R7, R9.** Given 看板处于 Codex CLI + tmux 模式且并发上限已占满，when 用户连续新建多个任务，then 新卡继承 CLI 模式并保持在待办队列，槽位释放后按顺序自动启动。
+- AE2. **Covers R11, R12, R19.** Given 看板处于 Codex App 模式，而一个 CLI session 请求权限，when 事件到达，then 该 session 在几秒内出现在全局提醒条，但不混入当前五列，且用户可一次操作打开对应 tmux 终端。
+- AE3. **Covers R13, R16.** Given 一个没有 GitHub 仓库的任务，when 任一运行模式中的 Codex 发出结构化可评审信号，then 卡片进入待评审并提供完成与继续修改操作。
+- AE4. **Covers R14, R21.** Given 用户拒绝安装 Hooks，when App 导入外部 session，then session 显示状态受限，不声称能准确识别等待确认。
+- AE5. **Covers R17.** Given 用户在待评审卡片选择继续修改并输入反馈，when 反馈成功发送，then 反馈通过原运行模式送回原 session，且卡片进入进行中。
+- AE6. **Covers R18.** Given 卡片关联的 PR 已合并，when Git 状态刷新，then 卡片自动进入完成；没有 PR 的卡片仍可通过人工验收完成。
+- AE7. **Covers R2, R3, R11.** Given 两种模式都有 sessions 且部分正在运行，when 用户切换看板模式，then 五列只展示目标模式，原模式 sessions 继续运行并保留在“全部 Sessions”，其等待项仍可进入全局提醒条。
+- AE8. **Covers R4.** Given 一个导入 session 缺少足以区分 App 与 CLI 的证据，when 导入完成，then App 标记类型待确认并允许用户纠正，而不是静默猜测。
+- AE9. **Covers R15.** Given 自动状态被错误事件影响，when 用户手动纠正卡片状态，then 修正立即生效，并仅在下一次明确生命周期事件到达后恢复自动权威。
+
+### Success Criteria
+
+- 约 10 个 Codex App 与 CLI sessions 并行时，所有等待人工处理的 sessions 在事件发生后几秒内出现在顶部提醒条，不受当前看板模式影响。
+- 五列看板中不会混入另一运行模式的卡片，切换模式不会中断已有工作。
+- 正常的待办、执行、等待、评审、修改和完成路径不要求用户手动拖动卡片。
+- 用户从任何等待提醒进入对应 Codex App thread 或 tmux 终端只需一次操作。
+- 普通 turn 停止不会被误判为可评审，缺少完整事件的 session 不会显示虚假的精确状态。
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- 手机、Apple Watch、Pushover 或其他远程通知。
+- macOS 15 及以下兼容。
+- 远程执行、跨设备同步和多人协作。
+- 面向非 macOS 平台的客户端。
+
+**Outside this product's identity**
+
+- 将看板扩展为完整的 Codex 对话或代码审查客户端；深度交互继续回到对应 Codex App thread 或 tmux 终端。
+- 将 GitHub 设为任务生命周期的必需依赖。
+- 在同一个五列看板中混合 Codex App 与 Codex CLI 卡片；跨模式可见性由“全部 Sessions”和全局提醒条承担。
+- 将正在运行或已有历史的 session 自动迁移到另一运行模式。
+
+### Dependencies / Assumptions
+
+- Codex App 模式要求 Codex 桌面端用于导航，同时要求可访问且兼容、能运行 `app-server` 的 Codex CLI executable；Codex CLI + tmux 模式要求 Codex CLI 与 tmux。选择对应模式时必须通过实际 capability probe，而不能只检查应用是否存在。
+- Codex App Server 能为看板创建的任务提供 thread、turn、等待状态和事件流。
+- Codex CLI 能在 tmux 中可靠启动、恢复和接收用户输入，tmux session 能在 App 导航期间保持运行。
+- Codex Hooks 能为用户授权的 App 与 CLI 外部 sessions 提供 session、turn、权限请求和停止事件。
+- Codex 桌面端继续支持使用 thread 标识打开本地 session 的 deep link。
+- 外部 session 在 Hook 安装前已运行时，完整遥测可能要等下一次提交、恢复或生命周期事件。
+- Git 分支和 PR 元数据是可选增强；不可用时不得阻断核心任务流。
+
+## Planning Contract
+
+### Assumptions
+
+- 现有安装默认使用 **Codex CLI + tmux** 模式以保持当前行为；新安装在 onboarding 中明确选择。看板模式是全局偏好，不跟随项目筛选器切换。
+- 默认全局托管并发上限为 **3**，首版允许在设置中修改但不做按项目覆盖。`launching` 与精确确认的 `running` 托管任务跨两种 runtime 共同占槽；断线或遥测未知的 managed task 在 rehydration 证明已停止前继续占槽。外部观察型、明确的审批/输入/Stop/故障等待、待评审与完成任务不占槽。
+- 切换模式后，旧模式已经运行的任务继续运行，旧模式仍在待办队列的任务暂停自动领取；切回该模式后恢复 FIFO 调度。这样不会在五列不可见时静默启动新工作。
+- “最近活跃”复用现有 `SessionTimeoutSettings.activeThresholdMinutes = 1440`，即默认 24 小时；已归档 thread、手动归档卡片和更早历史只进入“全部 Sessions”。
+- runtime 分类证据优先级为：用户确认 > 看板创建绑定 > 活跃 tmux 绑定 > App Server `sourceKinds`/稳定元数据 > 已知 CLI 元数据 > unknown。证据冲突时保持“类型待确认”，不静默翻转用户确认。
+- `codex://threads/<thread-id>` 已由官方文档确认可以打开对应本地 thread；它只作为导航能力，不能假设 Codex 桌面端能接管另一个 App Server 连接持有的审批 RPC。
+- 托管 App Server thread 的权限审批和用户输入由看板提供最小响应控件，深度对话仍跳回 Codex App。首版不会自动批准权限，也不会根据普通 Stop 或自然语言自动完成。
+- 非 GitHub 任务通过版本化本地 lifecycle signal 声明 `review-ready`；若 runtime 无法安装或调用该能力，保留手动“标记待评审”逃生口并显示状态受限。
+- 完成卡片不终止 session；终止执行仍是独立动作。单 PR 卡片只有该 PR `merged` 才可自动完成；多 PR 卡片必须所有相关 PR 均已合并。`closed` 但未合并不能自动完成。
+
+### Key Technical Decisions
+
+- **KTD1 — Runtime provenance 与 assistant 分离。** 新增持久化的 Codex execution backend（App、CLI + tmux、unknown）、ownership（managed、observed）、evidence 与 telemetry quality；`CodingAssistant.codex` 继续只描述 assistant，不承担运行来源。旧 `links.json` 缺字段时解码为 unknown，再由可靠证据补齐。该决策落实 R1–R5、R8、AE8，并继承“运行类型属于整个看板”的 session-settled 决策。
+- **KTD2 — 持久化 canonical lifecycle，而不是用瞬时 activity 推列。** 每张任务卡保存规范化 lifecycle snapshot、attention reason、最后明确事件 watermark、launch attempt 和手动纠正 watermark。跨来源事件按 launch generation、稳定 turn identity 和同一 turn 内语义优先级形成 partial order，ingestion sequence 仅作最终 tie-breaker；缺少可比较 provenance 的事件不得清除高权威状态，而应标记 telemetry conflicted/limited。列是 lifecycle 的纯投影；PR 仅作为证据，普通 Stop 投影为 Waiting，只有 `review-ready` 投影为 In Review。拒绝继续扩展 `AssignColumn` 的 mtime/PR 启发式，因为它无法去重、恢复或表达精度。落实 R9–R18、AE3、AE4、AE6、AE9。
+- **KTD3 — 所有 runtime 经统一 port/action/effect 驱动。** Core 定义发现、启动/恢复、发送反馈、打开原 session、获取快照、订阅事件和能力诊断的 runtime port。App Server 与 CLI + tmux adapter 共享 contract tests；SwiftUI 不直接写持久化或启动进程。落实 F2–F6，并保持 `AppState` + `Reducer` + `EffectHandler` 单一权威。
+- **KTD4 — App Server 由独立 companion 持有，UI 使用可重连的 JSON-RPC client。** launchd/SMAppService 管理的用户级 companion 持有 `codex app-server` 子进程、request correlation、server notifications/requests 与重连状态；macOS UI 通过受本地文件权限和随机配对 token 保护的 IPC 连接，退出 UI 不终止运行中的 turn。App Server 元数据优先于文件系统，文件发现仅作内容与旧版本 fallback。审批请求通过显式用户动作响应，deep link 是 best-effort 打开。拒绝把一次性进程调用、UI-owned child 或 JSONL mtime 当作 App Server 状态。
+- **KTD5 — Hooks 与 App Server 统一进入版本化事件 inbox。** 新增最小 helper 接收 hook stdin 或显式 `review-ready` 命令，将经过 schema 验证的事件原子写入本地 inbox；BoardStore 按 event ID、session/thread、turn 与 launch generation 去重并持久化 cursor。安装器合并现有配置、验证信任/版本、支持卸载和受限降级，不把事件内容拼接成 shell。
+- **KTD6 — 启动采用 Swift-owned durable lease 和确定性恢复。** launch lease、lifecycle snapshot 与 event watermark 存放在独立的 Swift-owned runtime-state store，按 card ID 关联，不与 CLI/Windows 会整体重写的 `links.json` 共写。队列先持久化 backend/attempt/lease，再执行外部副作用并绑定稳定 thread、Codex session 与 tmux ID。重启时先对账；无法证明成功或失败的 attempt 进入 Waiting/launch-uncertain，由用户重试，禁止无条件重复创建或杀死同名 tmux。
+- **KTD7 — 看板投影与全局注意力投影分离。** 五列只从当前 board backend 的 cards 派生；attention 从所有 project/backend 中处于 Waiting 且仍有用户输入、权限审批、普通 Stop 或故障处理原因的 sessions 派生，不受模式或项目筛选。In Review 本身不进入提醒条，除非同时存在独立未解决的 waiting reason。`.allSessions` 继续作为存储归档状态，但从第六列移出，复用搜索基础设施提供单独入口。落实 R2、R3、R11、AE2、AE7。
+- **KTD8 — Continue 以 runtime acknowledgement 为提交点。** 待评审中发送反馈时保留 In Review 与 busy 状态；App Server 收到 `turn/start` 或 `turn/steer` 成功响应、CLI 完成原 session resume 与 paste 后才进入 In Progress。审批 waiting 只能响应审批或打开原 session，不能把普通反馈盲发到终端。落实 R16、R17、AE5。
+- **KTD9 — 向后兼容跨 Swift/TypeScript/Rust 共享文件。** 展示/绑定字段全部 optional/backward-decodable；高一致性的 lease/lifecycle/watermark 只写 Swift-owned runtime-state store。CLI 类型与 fixtures 同步；Windows 首版不增加 UI，但 Rust round-trip 必须通过 flattened unknown-field map 保留未识别的 per-link 属性。迁移前保留旧文件的可读性，任一 writer 失败不得清空设置、卡片或 runtime state。
+
+### High-Level Technical Design
+
+以下设计是边界和数据流草图，具体类型拆分可在实现中按现有命名调整，但不得绕过 reducer/effect 或改变 Product Contract。
+
+```mermaid
+flowchart LR
+  UI["SwiftUI: mode picker, attention, five lanes, all sessions"]
+  Store["BoardStore / Reducer"]
+  Projection["Lifecycle + board projections"]
+  Queue["Durable queue coordinator"]
+  Port["Codex runtime port"]
+  App["App Server adapter"]
+  CLI["CLI + tmux adapter"]
+  Inbox["Validated lifecycle event inbox"]
+  Hooks["Codex hooks / review-ready helper"]
+  Persist["links.json + settings + event cursor"]
+
+  UI --> Store
+  Store --> Projection
+  Store --> Queue
+  Queue --> Port
+  Port --> App
+  Port --> CLI
+  App --> Inbox
+  Hooks --> Inbox
+  CLI --> Inbox
+  Inbox --> Store
+  Store --> Persist
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Launching: selected mode and slot available
+  Launching --> Running: stable runtime binding persisted
+  Launching --> Waiting: failed or uncertain launch
+  Running --> Waiting: approval, input, stop, fault, disconnect
+  Waiting --> Running: explicit newer resume or response acknowledgement
+  Running --> Review: versioned review-ready event
+  Waiting --> Review: newer review-ready event
+  Review --> Running: continue feedback acknowledged
+  Review --> Done: human complete or merged PR
+  Waiting --> Done: human correction only
+```
+
+App Server 的 server request 不能仅靠导航解决：
+
+```mermaid
+sequenceDiagram
+  participant S as Scheduler
+  participant A as App Server adapter
+  participant C as codex app-server
+  participant R as Reducer
+  participant U as User
+
+  S->>A: start/resume managed task
+  A->>C: thread/start or resume, turn/start
+  C-->>A: thread/turn IDs and status events
+  A-->>R: normalized running event
+  C-->>A: approval/input request
+  A-->>R: waiting(reason, request ID)
+  R-->>U: global attention action
+  U->>R: approve/deny/input or open thread
+  R->>A: explicit response
+  A->>C: server-request response
+  C-->>A: resumed/status event
+  A-->>R: normalized running event
+```
+
+### Implementation Units
+
+#### U1 — Migration-safe runtime and lifecycle domain
+
+- **Depends on:** none.
+- **Traces:** R1–R5, R8–R15, F1, F5, F6, AE4, AE8, AE9, KTD1, KTD2, KTD9.
+- **Files:** `Sources/KanbanCodeCore/Domain/Entities/Link.swift`, `Session.swift`, `ActivityState.swift`, `ManualOverrides.swift`, `CodingAssistant.swift`, new domain files for execution backend/lifecycle event; `Sources/KanbanCodeCore/Infrastructure/SettingsStore.swift`, `CoordinationStore.swift`, new Swift-owned runtime-state store; `cli/src/types.ts` and persistence fixtures; `windows/src-tauri/src/coordination_store.rs` and Rust round-trip tests.
+- **Approach:** add optional persisted execution binding, ownership/evidence/telemetry and manual confirmation fields to shared cards, while lifecycle snapshot, attention reason, launch lease and event/manual watermarks live in a separately versioned Swift-owned store. Preserve decoding of every existing fixture and unknown future enum value. Windows preserves unknown per-link JSON properties via a flattened map. Default existing installs to CLI board preference while existing Codex cards remain unknown until evidence resolves them.
+- **Test scenarios:** old link/settings fixtures decode without data loss; new fields round-trip; unknown enum values degrade to unknown/limited; a CLI or Windows card move/rename cannot erase runtime-state or unknown macOS fields; user-confirmed runtime outranks conflicting discovery; stale lifecycle event cannot clear a newer manual correction; a newer authoritative event can.
+- **Observable result:** existing users open the upgraded app with cards intact, and every Codex card can represent precise, limited or ambiguous runtime/lifecycle without overclaiming.
+
+#### U2 — Canonical lifecycle reducer and board projections
+
+- **Depends on:** U1.
+- **Traces:** R2, R3, R9–R18, F3–F6, AE2, AE3, AE6, AE7, AE9, KTD2, KTD7.
+- **Files:** new lifecycle reducer/projector under `Sources/KanbanCodeCore/UseCases/`; `Sources/KanbanCodeCore/UseCases/AssignColumn.swift`, `CardReconciler.swift`, `BoardStore.swift`; `Sources/KanbanCodeCore/Domain/Entities/KanbanCodeCard.swift`; `Tests/KanbanCodeCoreTests/AssignColumnTests.swift`, `CardLifecycleTests.swift`, `ReducerTests.swift`, `CardReconcilerTests.swift`, new projection tests.
+- **Approach:** normalize external events into one reducer with idempotency and ordering; derive column, attention and telemetry badges from persisted lifecycle. Fix reconciler to retain `Session.assistant` and runtime evidence. Remove “PR + stopped = In Review”; only merged PR or human acceptance completes. Split mode-filtered lanes from global attention and keep All Sessions outside the five lanes.
+- **Test scenarios:** duplicate/out-of-order App Server and Hook events; cross-source events use generation/turn/semantic precedence and incomparable events mark telemetry conflicted without clearing higher authority; ordinary Stop remains Waiting; review-ready then duplicated Stop remains In Review; closed-unmerged PR is not Done; a single merged PR is Done; one merged plus one open or closed-unmerged PR remains incomplete; inactive-mode Waiting with an unresolved attention reason appears in attention/All Sessions while queued, running and plain In Review do not; mode switch never mutates or terminates bindings; archived/deleted imports do not resurrect.
+- **Observable result:** automatic movement is deterministic, restart-safe and faithful to the five product states.
+
+#### U3 — App Server client, discovery authority and managed approvals
+
+- **Depends on:** U1, U2.
+- **Traces:** R4, R5, R8, R10–R14, R17, R19–R22, F1–F5, AE2–AE5, KTD3, KTD4, KTD8.
+- **Files:** new `CodexAppServerClient`, companion executable, IPC transport and adapter under `Sources/KanbanCodeCore/Adapters/Codex/` and `Sources/`; new runtime ports under `Sources/KanbanCodeCore/Domain/Ports/`; `CodexSessionDiscovery.swift`, `CompositeSessionDiscovery.swift`, `DependencyChecker.swift`; `Package.swift`, `Makefile`; App Server/IPC fakes and tests under `Tests/KanbanCodeCoreTests/Codex/`.
+- **Approach:** a launchd/SMAppService-managed companion owns `codex app-server`; unsigned development builds can use an explicitly launched companion with the same IPC contract, never a UI-owned child. The Unix socket and 256-bit random pairing token live under a user-owned runtime directory with directory mode `0700` and token mode `0600`; the companion verifies same UID plus constant-time token equality and refuses insecure permissions. Resolve and retain an absolute Codex executable path outside the active project, launch without a shell from a fixed trusted working directory and a documented environment allowlist, and show the resolved path/version/signature status in diagnostics. Re-probe identity and `app-server` capability before use; reject project-local shadowing and require explicit user confirmation for a changed or nonstandard unsigned path rather than silently switching binaries. Reuse Codex-managed authentication without copying tokens into settings, links, inbox or fixtures; redact auth fields and secret environment keys, rotate local logs at 10 MB/7 days, and treat auth failure as capability degradation. Implement initialize/list/resume/start/turn start/steer, streamed status, allowlisted server request methods, reconnect and list-based rehydration; correlate responses to outbound request IDs and clear pending maps on process generation change. Approval UI uses trusted native app chrome, displays exact request type, command/resource, workspace, thread and sandbox scope available from the protocol, binds to the pending request ID plus launch generation, revalidates immediately before sending and defaults to deny on mismatch. Merge App Server and filesystem discovery by stable thread ID with explicit authority; preserve limited fallback when protocol/version is unavailable.
+- **Test scenarios:** interleaved responses/notifications; unknown server-request method and unmatched response rejection; request timeout and process exit; UI quit/relaunch preserves an active companion turn and pending request; companion restart rehydrates threads but rejects previous-generation requests; SMAppService registration and explicit development companion fallback; IPC refuses wrong token, wrong UID and insecure token permissions; source-kind classification and ambiguous conflict; stale/mismatched approval defaults to deny and assistant content cannot render approval chrome; executable resolution rejects project-local shadowing and re-probes changed paths; authentication material never reaches persisted records or rotating logs; deep-link navigation is independent from RPC response; feedback acknowledgement targets the same thread; missing desktop app, missing executable or failed protocol initialization yields actionable degraded capability.
+- **Observable result:** managed Codex App tasks have stable thread IDs and precise lifecycle, while imported threads remain visible with honest capability labels.
+
+#### U4 — Codex lifecycle inbox, hook installer and review-ready helper
+
+- **Depends on:** U1, U2.
+- **Traces:** R10, R13–R15, R20–R22, F1, F4, F5, AE3, AE4, AE9, KTD5.
+- **Files:** new lifecycle helper executable target in `Package.swift` and `Sources/`; `Makefile` and release packaging; new inbox/store under `Sources/KanbanCodeCore/Adapters/Codex/`; `Sources/KanbanCodeCore/Adapters/ClaudeCode/HookManager.swift` or a Codex-specific installer; `CodingAssistant.swift`, `DependencyChecker.swift`; `cli/src/hooks.ts`, `cli/src/codex-runtime.test.ts`; `HookManagerTests.swift` and new lifecycle inbox tests.
+- **Approach:** define a versioned local event envelope capped at 1 MB/event and 10,000 queued events with atomic append and rotation. Each managed launch receives a 256-bit `SecRandomCopyBytes` per-attempt capability stored only with its Swift-owned lease; reducer acceptance requires constant-time capability comparison plus task/session/generation binding. This limits unrelated-process forgery but does not claim protection from a process that already controls the same user account. Review-ready remains non-authorizing and can only request human review. Bundle the helper, verify it against the packaged manifest/hash, atomically install the authorized version under `~/.kanban-code/bin`, and point hooks at that stable path; installation rejects downgrade/tampered payloads while preserving restrictive directory, binary and backup permissions. Merge Codex hook config without overwriting user config, capability-probe version/trust, validate bindings, rotate retention, and allow uninstall. Inject task/session context into board-launched App and CLI work so signals bind to the current attempt.
+- **Test scenarios:** packaged-app install/upgrade/uninstall preserves unrelated config and invokes the verified stable helper path; downgrade/tampered helper rejection; authorization refusal retains read-only import; malformed, over-1-MB, queue-overflow, stale, replayed, cross-session and missing-capability events are ignored with diagnostics; duplicate event IDs are idempotent; App and CLI transports produce the same normalized review-ready; Stop never produces review-ready; old Codex trust-modal behavior reports limited capability.
+- **Observable result:** both runtimes can emit trustworthy review-ready and external sessions degrade visibly instead of being guessed.
+
+#### U5 — Durable auto-claim scheduler and dual-runtime launch effects
+
+- **Depends on:** U1, U2, U3, U4.
+- **Traces:** R3, R6–R10, R17, F2, F6, AE1, AE5, AE7, KTD3, KTD6, KTD8.
+- **Files:** new queue coordinator under `Sources/KanbanCodeCore/UseCases/`; `BoardStore.swift`, `LaunchSession.swift`, `BackgroundOrchestrator.swift`; runtime adapters; `Sources/KanbanCode/ContentView+Launch.swift`, `NewTaskDialog.swift`; scheduler, launch-flow and reducer tests.
+- **Approach:** move auto-start ownership from SwiftUI to a serialized Core coordinator. Validate the global concurrency setting in `1...32`, persist queued/launching lease before effects, claim FIFO within selected mode and global capacity, pause inactive-mode queued work, and release slots only on precise non-running states. A disconnect or telemetry-unknown managed task retains its lease until rehydration proves the turn stopped. Board-created tmux sessions use a reserved `kanban-code-<card-id>-<generation>` namespace and runtime-state ownership tag; reconciliation must verify both before matching. Reuse `LaunchSession`/`TmuxAdapter` for CLI without destructive uncertain retry; App mode starts a thread/turn through U3. Continue resumes the exact binding and commits state only after acknowledgement; after a 30-second acknowledgement timeout it enters resume-uncertain with preserved feedback, retry and open-original actions.
+- **Test scenarios:** capacity 3, bounds 1/32 and FIFO; rapid capacity changes trigger one atomic scheduling pass; simultaneous refresh claims each card once; switching mode pauses hidden queue but does not stop running work; running work across modes counts globally; transient disconnect never frees capacity before reconciliation; external observed sessions do not consume slots; tmux namespace collision without matching ownership tag is rejected; launch failure releases slot; crash at lease, thread-created, tmux-created and pre-binding boundaries recovers without duplicate execution; lost Continue acknowledgement becomes resume-uncertain without duplicating feedback.
+- **Observable result:** Backlog tasks auto-run predictably in either mode without UI presence, duplication or hidden oversubscription.
+
+#### U6 — Attention-first five-column UI and All Sessions vertical slice
+
+- **Depends on:** U2.
+- **Traces:** R1–R5, R11, R14, R19, F1, F3, F5, F6, AE2, AE4, AE7, AE8, KTD7.
+- **Files:** `Sources/KanbanCode/ContentView.swift`, `BoardView.swift`, `CardView.swift`, `ColumnView.swift`, `CardDetailView.swift`, `SearchOverlay.swift`, `NewTaskDialog.swift`; new `AttentionStrip.swift` and runtime-mode UI helpers; navigation/accessibility tests under `Tests/KanbanCodeTests/` and Core projection tests.
+- **Approach:** deliver the primary attention value before managed App scheduling: add toolbar board-mode picker, show exactly five lanes from the mode projection, expose All Sessions as searchable sheet/list and render existing/observed lifecycle with honest telemetry badges. Define an `AttentionItem` presentation contract with session title, runtime, project, reason, age, telemetry quality, primary action and secondary open action; deduplicate by session/request, prioritize permission/input before faults, stops and disconnects, keep failed/expired actions visible with recovery copy, and use a compact fixed-height keyboard-navigable list with total count. The mode picker shows per-runtime running and paused-queue counts, warns that the departing queue pauses, and links to filtered All Sessions while nonempty. Runtime correction is a labeled detail/All Sessions menu showing evidence; when correction removes a card from the board, show a confirmation with destination and Open in All Sessions. Mode-managed new tasks are Codex-only: replace the per-task assistant picker with a read-only Codex/current-runtime summary; preserve pre-existing Claude/Gemini cards as legacy CLI items in All Sessions.
+- **Accessibility contract:** logical focus order runs mode picker → attention items → lanes; runtime/telemetry badges expose VoiceOver labels and values; open, type-correct and attention actions have named accessibility actions and keyboard activation; focus restores after resolution/failure and new attention arrival is announced.
+- **Test scenarios:** inactive-mode approval remains in attention but not lanes; project filter does not hide global attention; attention priority/dedup/count/pending-error behavior remains scannable with ten mixed items; queued/running/plain In Review do not enter attention; type correction reprojects and explains the destination; deep-link URL encodes thread ID and failure surfaces fallback; five lanes never append All Sessions; keyboard/VoiceOver semantics and focus restoration are present.
+- **Observable result:** at roughly 10 sessions the user can identify every waiting item within seconds and open the correct runtime with one action.
+
+#### U7 — Onboarding, settings, diagnostics and compatibility UX
+
+- **Depends on:** U3, U4, U5, U6.
+- **Traces:** R1, R5, R7, R20–R22, F1, F6, AE1, AE4, KTD9.
+- **Files:** `Sources/KanbanCode/OnboardingWizard.swift`, `SettingsView.swift`; `Sources/KanbanCodeCore/Infrastructure/SettingsStore.swift`, `DependencyChecker.swift`; `Makefile`; settings/dependency/onboarding and bundle-metadata tests; README documentation.
+- **Approach:** separate status rows for Codex desktop navigation, compatible Codex executable/App Server protocol, companion registration/dev fallback, Codex CLI execution, tmux and lifecycle Hooks; request authorization before config mutation; show partial-install and trust-probe failures; expose board mode, bounded max concurrency and recent-window setting; preserve use of the available runtime when another is unavailable. Define Hook-refusal degradation explicitly: App imports may use App Server discovery/status when available, CLI imports use tmux plus session-file evidence, all affected cards show unknown/limited telemetry, and filesystem mtime alone cannot infer Waiting, In Review or Done. Set packaged `LSMinimumSystemVersion` to `26.0`. Document capability matrix, resolved executable path, privacy/local files and recovery/uninstall.
+- **Test scenarios:** fresh install selects either mode; App mode requires both desktop navigation and successful `app-server` protocol initialization; existing install defaults CLI without losing settings; target mode unavailable rejects switch with actionable diagnostic; Hook refusal/partial failure preserves the specified read-only discovery paths and never infers lifecycle from mtime; settings unknown fields survive; concurrency change triggers exactly one scheduling pass; built bundle declares macOS 26 minimum.
+- **Observable result:** users can understand what automation is precise, degraded or unavailable before trusting the board.
+
+#### U9 — Managed runtime actions and review/approval integration
+
+- **Depends on:** U3, U4, U5, U6.
+- **Traces:** R6–R10, R12–R19, F2–F4, AE1, AE3, AE5, AE6, KTD3, KTD4, KTD8.
+- **Files:** `Sources/KanbanCode/AttentionStrip.swift`, `CardDetailView.swift`, `ContentView+Launch.swift`, `NewTaskDialog.swift`; `BoardStore.swift`; runtime action state helpers and UI/Core integration tests.
+- **Approach:** layer managed launch, request-bound approval/input, Complete and Continue onto U6's observed-session UI. Use one recoverable action-state model: preserve input drafts until acknowledgement, disable only the submitted action while pending, show inline progress and request-scoped errors, retry idempotently, and restore focus to the unresolved item on failure. Approval actions display exact trusted request context and revalidate request/generation before response; review feedback targets the original session and moves only after backend acknowledgement.
+- **Test scenarios:** App approval/input and CLI open/resume use reason-specific actions; stale request denial and duplicate action suppression; Continue failure preserves draft and In Review; acknowledged Continue moves to In Progress; Complete does not terminate session; keyboard and VoiceOver actions expose the same behavior as pointer controls.
+- **Observable result:** the early attention slice becomes the complete managed App/CLI workflow without changing its presentation or lifecycle source of truth.
+
+#### U8 — End-to-end verification, docs and release evidence
+
+- **Depends on:** U1–U7, U9.
+- **Traces:** all requirements, flows and acceptance examples.
+- **Files:** integration suites in `Tests/KanbanCodeCoreTests/` and `Tests/KanbanCodeTests/`; CLI and Windows round-trip tests; `Makefile` packaging assertions; `README.md`, `docs/` capability/recovery notes; PR body and screenshots where practical.
+- **Approach:** run fake-backed deterministic CI plus opt-in local real-runtime smoke tests. Exercise first launch, import, queue, attention, approval, review/continue, PR merge, mode switching and restart. Produce a reproducible macOS `.app` and downloadable archive in CI, verify launch from the packaged artifact, and document first install plus manual upgrade. Record known App Server/Hook version boundaries; Developer ID signing, notarization and automatic hosted updates remain credential-gated rather than blocking the unsigned distributable artifact.
+- **Test scenarios:** full App-mode and CLI-mode happy paths; mixed-mode attention; Hook denied; App Server disconnect/reconnect; app restart during launch; ordinary Stop; non-GitHub review; merged and closed-unmerged PR; deep-link and tmux open actions; packaged `.app` contains companion/helpers, declares macOS 26 and launches in a clean test location.
+- **Observable result:** the PR contains a reproducible installable artifact and evidence for the core lifecycle, with hardware/local-environment-only smoke and credential-gated signing status clearly labeled.
+
+### System-Wide Impact
+
+- **Persistence and migration:** `links.json` gains optional display/binding fields consumed by Swift and typed by CLI, while launch/lifecycle/watermark state is isolated in a Swift-owned store that other writers cannot clobber. Migration is lazy and backward-compatible. Settings decoding must remain field-isolated so a future enum value cannot wipe projects. Lifecycle inbox and cursor require bounded storage, atomic writes and local-user-only permissions.
+- **State authority:** `BoardStore.swift` remains the active macOS authority; legacy `BoardState.swift` is not extended except where an existing compatibility test requires it. UI changes dispatch actions only. Reconciliation discovers resources but does not independently assign product lifecycle.
+- **Process lifecycle:** a user-level companion owns the restartable App Server child; the UI app owns only an authenticated same-UID local client and existing tmux presentation. IPC socket/token live in a `0700` runtime directory and the token is `0600`. UI termination must not kill user work. Reconnect reconciles stable IDs before scheduling. Child stdout/stderr must be drained to avoid deadlock; rotating 10 MB/7-day logs redact prompt, event, authentication and secret environment payloads.
+- **Security and approvals:** Hook payloads and App Server notifications are untrusted local input. Validate size/schema/source binding and per-attempt capability; never execute event text. The capability limits accidental/cross-session forgery but is not a boundary against full same-user compromise. Permission requests are human-only, display protocol-derived scope in trusted app chrome, bind to a current request/generation, revalidate before response and require an explicit click; mismatch or uncertainty denies, with no automatic allow fallback. Codex authentication remains Codex-managed and is never persisted or logged by the board.
+- **Performance:** roughly 10 sessions is the primary target, but event processing should be O(events + cards) per batch, projections cached by `AppState.rebuildCards`, App Server list paginated, and UI updates coalesced to avoid rendering every raw notification.
+- **GitHub behavior:** PR discovery remains optional. Replace current “any closed/merged means all done” behavior for automatic completion with “all relevant PRs merged” or explicit human completion. Multiple PR evidence remains display-only until the lifecycle reducer decides Done.
+- **Cross-platform:** Windows and web/CLI readers must tolerate optional fields; Windows writers must round-trip unknown per-link fields and cannot write the Swift-owned runtime-state store. macOS UI is the only v1 feature surface; no Windows runtime-mode UI is required.
+- **Operations:** diagnostics must distinguish dependency missing, protocol incompatible, hook unauthorized, hook trust blocked, disconnected and limited telemetry. These are product states, not generic errors.
+
+### Risks and Mitigations
+
+- **App Server approval ownership:** deep linking may not transfer a request held by this App Server process. Mitigation: implement minimal explicit server-request responses in the board and treat deep link only as navigation; cover with fake protocol tests and an opt-in real-runtime spike before declaring precise support.
+- **Protocol drift:** App Server and Hooks can evolve. Mitigation: capability negotiation, tolerant decoders, versioned event schema, fixture-based contract tests and visible limited mode instead of silent fallback.
+- **Duplicate launches after crash:** external side effects can succeed before persistence. Mitigation: durable attempt IDs, deterministic tmux names, thread/session reconciliation and uncertain-launch waiting rather than automatic destructive retry.
+- **False lifecycle precision:** imported sessions may lack source or Hook history. Mitigation: explicit telemetry quality, evidence precedence, unknown classification and user correction that survives stale events.
+- **Hook trust/config damage:** Codex versions may show interactive trust prompts and users may already have hooks. Mitigation: merge/backup/rollback config, probe actual behavior, require authorization and support uninstall.
+- **Hidden work after mode switch:** inactive-mode running work remains active while lanes hide it. Mitigation: global attention, All Sessions visibility, global concurrency accounting and pause of inactive-mode queued cards.
+- **Scope/PR size:** the feature crosses domain, adapters, scheduler and UI. Mitigation: keep each unit buildable and testable, commit by unit, prefer adapter fakes, and stop adding adjacent Windows/remote-notification work.
+
+### Verification Contract
+
+**Automated gates**
+
+- `swift build` succeeds for all SwiftPM products, including companion/helper targets; the packaged app bundles/signs required executables and declares `LSMinimumSystemVersion = 26.0`.
+- `swift test` passes existing and new Core/UI logic tests with no dependence on a running Codex App, live tmux or user home session data.
+- From `cli/`, the repository's pinned package-manager install/check/test commands pass after shared types/hook changes.
+- `git diff --check` reports no whitespace errors; no generated build artifacts or user-local lifecycle data are committed.
+
+**Contract suites**
+
+- Both runtime adapters pass one shared behavior suite for discover, start, bind, wait, continue, review-ready, open and recover, with backend-specific capability assertions.
+- Lifecycle table tests cover duplicate, out-of-order, stale-generation and conflicting-source events, plus manual watermark behavior and telemetry degradation.
+- Scheduler tests use a deterministic clock and fake runtimes to prove capacity, FIFO, mode switching, slot release and crash recovery.
+- Persistence fixtures prove old Swift/CLI records decode and round-trip without loss; future/unknown enum values degrade safely.
+
+**Integration and smoke gates**
+
+- Fake App Server integration validates JSON-RPC multiplexing, server requests, disconnect/reconnect and rehydration.
+- Fake tmux/runtime integration validates same-session resume, non-destructive uncertain recovery and feedback acknowledgement.
+- SwiftUI-facing tests validate five-lane filtering, global attention, All Sessions entry and mode-aware navigation helpers.
+- When a compatible local Codex/tmux environment exists, run an opt-in smoke matrix and record results in the PR; absence of that environment is documented, not hidden as a passed test.
+
+### Definition of Done
+
+- All Product Contract requirements map to at least one implemented and verified unit; every acceptance example has an automated or explicitly documented smoke assertion.
+- Existing cards/settings migrate without loss, and ambiguous/limited state is visible rather than guessed.
+- A new task in either selected mode is durably queued, auto-claimed within capacity, bound to its original session and recoverable after app restart.
+- Waiting items from both modes appear in the global strip within the next event-processing cycle, independent of board/project filters.
+- Ordinary Stop never enters In Review; structured review-ready does so without GitHub; Continue targets the same session and only advances after acknowledgement.
+- A single merged PR, or all relevant PRs on a multi-PR card, can complete a card; any open or closed-unmerged relevant PR prevents automatic completion; human Complete works for non-GitHub tasks.
+- Five columns show only the selected mode, All Sessions remains searchable, and switching modes does not migrate, restart or terminate existing sessions.
+- App threads open via the documented `codex://threads/<thread-id>` form with fallback diagnostics; CLI cards reconnect to their tmux/session.
+- CI produces a reproducible installable `.app` archive containing the companion/helpers, and documentation covers first install plus manual upgrade; missing Developer ID credentials only mark signing/notarization as unavailable.
+- Automated gates pass, code-review findings at actionable severity are resolved or explicitly documented, branch is pushed and a PR is created with verification evidence.
+
+### Open Questions
+
+**Resolved During Planning**
+
+- 默认并发上限为 3，可全局配置；跨模式托管运行计数，外部观察 session 不计数。
+- 最近活跃复用现有 24 小时设置。
+- 看板模式为全局偏好；现有安装默认 CLI + tmux。
+- 手动纠正由 lifecycle watermark 保护，仅更新的明确事件恢复自动权威。
+- review-ready 使用版本化本地事件 schema；不同 backend 可有不同 transport，但共享 reducer 语义。
+- inactive-mode 已运行任务继续，待办队列暂停，切回恢复。
+
+**Deferred Beyond This Feature PR**
+
+- Developer ID 签名、公证、Sparkle/自动更新通道与长期安装包托管；本 PR 仍必须产出可复现的未签名 `.app` archive 和手动升级说明。
+- 远程通知、跨设备状态、Windows UI 和多人协作。
+
+**Implementation-time capability check**
+
+- 用当前安装的 Codex 版本验证：桌面 deep link 是否只能导航，还是也能观察/处理由独立 App Server 连接持有的请求。无论结果如何，最小 board approval response 仍是安全基线；测试结果只调整 capability 文案，不改变产品范围。
+
+### Sources / Research
+
+- `README.md`：参考项目的卡片、reconciler、GitHub、通知和自动列流转概览。
+- `Sources/KanbanCodeCore/Adapters/Codex/CodexSessionDiscovery.swift`：现有 Codex session 文件发现能力。
+- `Sources/KanbanCodeCore/Adapters/Codex/CodexActivityDetector.swift`：现有基于文件修改时间的 Codex 状态推断及其局限。
+- `Sources/KanbanCodeCore/Domain/Entities/CodingAssistant.swift`：Codex CLI 的启动、恢复和 tmux 交互参数。
+- `Sources/KanbanCodeCore/UseCases/LaunchSession.swift`：在 tmux 中启动与恢复 coding assistant session 的现有流程。
+- `Sources/KanbanCode/NewTaskDialog.swift`：参考项目当前的新任务 assistant 选择与默认值记忆方式。
+- `Sources/KanbanCodeCore/UseCases/AssignColumn.swift`：参考项目当前的自动列分配规则。
+- `Sources/KanbanCodeCore/Domain/Entities/Link.swift`：Card 与 session、worktree、PR 等资源的聚合关系。
+- [Codex App Server](https://learn.chatgpt.com/docs/app-server)：thread、turn、审批、等待状态和事件流。
+- [Codex Hooks](https://learn.chatgpt.com/docs/hooks)：生命周期事件、权限请求、用户提交和停止事件。
+- [ChatGPT desktop app commands](https://learn.chatgpt.com/docs/reference/commands#deep-links)：`codex://` session deep links。
+- `LICENSE`：参考项目的 AGPLv3 许可边界。

--- a/docs/solutions/architecture-patterns/cross-client-json-evolution.md
+++ b/docs/solutions/architecture-patterns/cross-client-json-evolution.md
@@ -1,0 +1,25 @@
+# Evolving JSON Safely Across Swift, TypeScript and Rust Clients
+
+## Problem
+
+`links.json` is read and rewritten by clients released on different schedules.
+A whole-file writer with an older schema can silently erase fields introduced
+by a newer client, even when its own edit is unrelated.
+
+## Durable pattern
+
+- Keep shared `Link` additions optional and decode unknown enum values safely.
+- TypeScript upserts merge the existing raw object with the typed update.
+- Rust records flatten unknown per-link fields and preserve them during upsert.
+- Put leases, watermarks and other high-consistency state in a single-owner
+  sidecar (`codex-runtime-state.json`) instead of the shared whole-file model.
+- Cover every writer with round-trip tests that start from a future-shaped
+  fixture, perform an old-client update, and assert unknown fields survive.
+
+## Why this boundary works
+
+Display and navigation metadata benefits from broad cross-client visibility and
+can tolerate optional fields. Launch ownership and lifecycle ordering cannot
+tolerate last-writer-wins loss, so Swift owns that state behind an actor and
+other clients read it without writing it. The CLI may project the sidecar into
+its output, but never persists lifecycle mutations.

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/windows/src-tauri/src/card_reconciler.rs
+++ b/windows/src-tauri/src/card_reconciler.rs
@@ -275,5 +275,6 @@ fn new_discovered_link(session: &Session) -> Link {
         api_service_id: None,
         browser_tabs: None,
         card_runtime: None,
+        extra_fields: Default::default(),
     }
 }

--- a/windows/src-tauri/src/coordination_store.rs
+++ b/windows/src-tauri/src/coordination_store.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use std::path::PathBuf;
 use tokio::fs;
 
@@ -196,6 +197,11 @@ pub struct Link {
     /// asks once.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub card_runtime: Option<CardRuntime>,
+    /// Fields introduced by another Kanban Code client that this build does
+    /// not understand yet. Keeping them flattened prevents a Windows
+    /// rename/move/upsert from erasing newer macOS card metadata.
+    #[serde(default, flatten)]
+    pub extra_fields: Map<String, Value>,
 }
 
 fn default_assistant() -> String {
@@ -283,6 +289,7 @@ impl Link {
             api_service_id: None,
             browser_tabs: None,
             card_runtime: None,
+            extra_fields: Map::new(),
         }
     }
 
@@ -397,7 +404,14 @@ impl CoordinationStore {
     pub async fn upsert_link(&self, link: &Link) -> Result<()> {
         let mut links = self.read_links().await?;
         if let Some(idx) = links.iter().position(|l| l.id == link.id) {
-            links[idx] = link.clone();
+            let mut replacement = link.clone();
+            for (key, value) in &links[idx].extra_fields {
+                replacement
+                    .extra_fields
+                    .entry(key.clone())
+                    .or_insert_with(|| value.clone());
+            }
+            links[idx] = replacement;
         } else {
             links.push(link.clone());
         }
@@ -581,6 +595,7 @@ impl CoordinationStore {
             api_service_id: None,
             browser_tabs: None,
             card_runtime: None,
+            extra_fields: Map::new(),
         };
         self.upsert_link(&link).await?;
         Ok(link)
@@ -1103,9 +1118,86 @@ mod tests {
             api_service_id: None,
             browser_tabs: None,
             card_runtime: None,
+            extra_fields: Map::new(),
         };
         let json = serde_json::to_string(&link).unwrap();
         assert!(!json.contains("browserTabs"), "absent tab list must not write the key");
         assert!(!json.contains("cardRuntime"), "unpicked runtime must not write the key");
+    }
+
+    async fn inject_unknown_mac_fields(base: &std::path::Path, card_id: &str) {
+        let path = base.join("links.json");
+        let data = std::fs::read(&path).unwrap();
+        let mut root: Value = serde_json::from_slice(&data).unwrap();
+        let card = root["links"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|card| card["id"] == card_id)
+            .unwrap();
+        let object = card.as_object_mut().unwrap();
+        object.insert(
+            "executionBinding".into(),
+            serde_json::json!({
+                "backend": "app",
+                "ownership": "managed",
+                "evidence": "boardCreated",
+                "telemetryQuality": "precise",
+                "threadId": "thread_123"
+            }),
+        );
+        object.insert(
+            "futureMacField".into(),
+            serde_json::json!({"nested": [1, {"kept": true}]}),
+        );
+        std::fs::write(&path, serde_json::to_vec_pretty(&root).unwrap()).unwrap();
+    }
+
+    fn assert_unknown_mac_fields(link: &Link) {
+        assert_eq!(
+            link.extra_fields["executionBinding"]["threadId"],
+            "thread_123"
+        );
+        assert_eq!(link.extra_fields["futureMacField"]["nested"][1]["kept"], true);
+    }
+
+    #[tokio::test]
+    async fn unknown_mac_fields_survive_rename_and_move() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        let card = mk_card(&store, Some("before")).await;
+        inject_unknown_mac_fields(&base, &card.id).await;
+
+        store.rename_link(&card.id, "after").await.unwrap();
+        store.move_card(&card.id, "in_progress").await.unwrap();
+
+        let links = store.read_links().await.unwrap();
+        let stored = links.iter().find(|link| link.id == card.id).unwrap();
+        assert_eq!(stored.name.as_deref(), Some("after"));
+        assert_eq!(stored.column, "in_progress");
+        assert_unknown_mac_fields(stored);
+
+        let raw = std::fs::read_to_string(base.join("links.json")).unwrap();
+        assert!(!raw.contains("extraFields"), "unknown keys must remain flattened");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn upsert_preserves_unknown_mac_fields_missing_from_replacement() {
+        let base = tmp_base();
+        let store = CoordinationStore::new(Some(base.clone()));
+        let card = mk_card(&store, Some("before")).await;
+        inject_unknown_mac_fields(&base, &card.id).await;
+
+        let mut replacement = store.read_links().await.unwrap().remove(0);
+        replacement.name = Some("replacement".into());
+        replacement.extra_fields.clear();
+        store.upsert_link(&replacement).await.unwrap();
+
+        let links = store.read_links().await.unwrap();
+        let stored = links.iter().find(|link| link.id == card.id).unwrap();
+        assert_eq!(stored.name.as_deref(), Some("replacement"));
+        assert_unknown_mac_fields(stored);
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/windows/src-tauri/src/merge_ops.rs
+++ b/windows/src-tauri/src/merge_ops.rs
@@ -186,6 +186,7 @@ mod tests {
             api_service_id: None,
             browser_tabs: None,
             card_runtime: None,
+            extra_fields: Default::default(),
         }
     }
 

--- a/windows/src-tauri/src/settings_store.rs
+++ b/windows/src-tauri/src/settings_store.rs
@@ -227,6 +227,42 @@ impl APIService {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CodexRuntimeBackend {
+    App,
+    CliTmux,
+    Unknown,
+}
+
+impl Default for CodexRuntimeBackend {
+    fn default() -> Self {
+        Self::CliTmux
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexBoardSettings {
+    #[serde(default)]
+    pub runtime: CodexRuntimeBackend,
+    #[serde(default = "default_codex_concurrency")]
+    pub max_concurrency: u32,
+}
+
+fn default_codex_concurrency() -> u32 {
+    3
+}
+
+impl Default for CodexBoardSettings {
+    fn default() -> Self {
+        Self {
+            runtime: CodexRuntimeBackend::default(),
+            max_concurrency: default_codex_concurrency(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
@@ -272,6 +308,10 @@ pub struct Settings {
     /// default service. Matches macOS Settings.defaultAPIServiceIds.
     #[serde(default)]
     pub default_api_service_ids: HashMap<String, String>,
+    /// Byte-compatible with macOS Settings.codexBoard so a Windows write does
+    /// not erase the selected runtime or scheduler capacity.
+    #[serde(default)]
+    pub codex_board: CodexBoardSettings,
 }
 
 impl Settings {

--- a/windows/src/types/index.ts
+++ b/windows/src/types/index.ts
@@ -299,6 +299,13 @@ export interface APIService {
  *  lowercase variant name). */
 export type CardRuntime = "windows" | "wsl";
 
+export type CodexRuntimeBackend = "app" | "cliTmux" | "unknown";
+
+export interface CodexBoardSettings {
+  runtime: CodexRuntimeBackend;
+  maxConcurrency: number;
+}
+
 export interface Settings {
   projects: Project[];
   globalView: GlobalViewSettings;
@@ -320,6 +327,8 @@ export interface Settings {
   apiServices?: APIService[];
   /** Per-assistant default APIService id (assistant id → service id). */
   defaultAPIServiceIds?: Record<string, string>;
+  /** Codex board runtime selection and global launch capacity. */
+  codexBoard?: CodexBoardSettings;
 }
 
 /** Mirrors macOS APIService.needsSeparator — a `--` separator before the


### PR DESCRIPTION
## Summary

Codex work can now be managed as an attention-first task board instead of a collection of sessions that must be polled one by one. Users choose a board-wide Codex App or Codex CLI + tmux runtime, create queued tasks that are claimed automatically within a configurable concurrency limit, and see work move through Backlog, In Progress, Waiting, In Review, and Done from runtime evidence.

The board also imports recent Codex App threads, keeps inactive-runtime sessions searchable, and surfaces approval, input, stop, and failure states in a global attention strip even when a different runtime or project is selected. Review no longer depends on GitHub: a structured `review-ready` signal or explicit manual action enters review, feedback returns to the original session, human acceptance completes non-code work, and linked code work completes automatically only after all relevant PRs merge.

Session-settled decisions carried from planning: runtime selection is board-wide (user-directed, over per-card selection); cross-runtime attention remains global (user-approved); In Review is delivery-based rather than GitHub-dependent (user-directed); and CLI + tmux remains a first-class runtime alongside Codex App (user-directed).

## Workflow

```mermaid
flowchart LR
  Q["Backlog queue"] -->|"capacity available"| R["In Progress"]
  R -->|"approval, input, stop, fault"| W["Waiting + global attention"]
  W -->|"response acknowledged"| R
  R -->|"structured or manual review-ready"| V["In Review"]
  V -->|"continue with feedback"| R
  V -->|"human accepts or every PR merges"| D["Done"]
```

## Design decisions

| Concern | Decision | Reviewer-relevant effect |
| --- | --- | --- |
| Runtime ownership | App Server and CLI + tmux implement one runtime port | Launch, feedback, discovery, navigation, and recovery share lifecycle semantics without hiding backend capability differences. |
| Restart safety | Launch leases, bindings, lifecycle snapshots, and event watermarks live in a Swift-owned runtime-state file | A CLI or Windows write to `links.json` cannot erase execution state, and a crash does not blindly duplicate a task. |
| Event conflicts | Lifecycle events use generation, turn, sequence, semantic precedence, and source authority | Duplicate or delayed Stop events cannot rewind Review; incomparable evidence degrades telemetry instead of claiming false precision. |
| App Server lifetime | The client uses Codex's `app-server daemon start` and `app-server proxy` | Active App turns outlive the SwiftUI connection while the client can reconnect, rehydrate threads, and rebind notifications. |
| External lifecycle trust | The bundled helper is hash-verified and managed launches receive per-attempt capabilities | Review-ready events are bound to the intended card/session/generation; rejecting hook installation leaves honest read-only/limited import. |
| Shared files | New settings/link fields are optional and Rust writers retain unknown JSON | Existing Swift, CLI, web, and Windows clients continue to round-trip the shared data safely. |

The UI adds a runtime picker, current-runtime five-lane projection, All Sessions entry, telemetry/runtime badges, global attention actions, request-bound approval/input dialogs, and one-click navigation. Codex App cards use the documented `codex://threads/<thread-id>` deep link; CLI cards reconnect to their tmux session. The lifecycle helper and SHA-256 manifest are included in the signed app archive, and onboarding/settings expose runtime probes, hook authorization, and concurrency controls.

## Validation

- `swift build` — all app, core, and lifecycle-helper products built successfully.
- `swift test` — 879 tests passed, including App Server multiplexing/reconnect, scheduler overlap, lifecycle ordering, inbox authorization, runtime persistence, discovery, and UI projection suites.
- `pnpm run build && pnpm test` in `cli/` — 279 tests passed, including read-only projection of Swift-owned Codex state.
- `pnpm run build` and `NODE_OPTIONS=--localstorage-file=/tmp/kanban-code-web-localstorage.json pnpm test` in `web/` — production build succeeded and 72 tests passed. The option works around Node 26's experimental global `localStorage`; CI uses Node 24.
- `CI=true make archive PNPM=/opt/homebrew/bin/pnpm` — produced `KanbanCode.app` and `KanbanCode-0.1.1-macos.zip`; the helper was executable and matched its manifest, deep code-sign verification passed, and the zip reported no errors.
- The installed Codex 0.144.1 executable accepted `app-server daemon start`, `app-server proxy`, and JSON-schema generation used to verify approval/input request shapes.
- An isolated Rust 1.97.1 toolchain under `/tmp` ran `cargo test --manifest-path windows/src-tauri/Cargo.toml --lib` — 123 tests passed. The new Windows CI job repeats `cargo test --lib`; it intentionally does not add a whole-tree rustfmt gate because the upstream Rust baseline is not currently rustfmt-clean.

## Boundaries

- Developer ID signing, notarization, hosted updates, and remote/mobile notifications remain credential- or roadmap-gated; the archive is ad-hoc signed for reproducible local validation.
- Deep-link URL construction and fallback handling are covered, but end-user navigation still depends on a compatible installed Codex desktop app.
- Sessions that predate lifecycle hooks remain visible with limited telemetry until a trustworthy App Server/hook event arrives.

## New concepts

### Partial-order lifecycle reconciliation

Runtime events do not form one perfectly ordered stream: App Server notifications, hooks, tmux observations, and human actions can arrive late or without the same identifiers. This change models event authority as a partial order instead of sorting every event by wall-clock time.

| Evidence relationship | Result |
| --- | --- |
| Same launch generation and turn | Sequence and lifecycle semantics decide which state is newer. |
| Newer launch generation | The new attempt wins regardless of delayed events from the old attempt. |
| Explicit acknowledged human action | Accept, Continue, approval response, or manual review is authoritative for that attempt. |
| Sources cannot be compared safely | Keep the precise state and mark telemetry limited/conflicted. |

For example, `review-ready` followed by a delayed ordinary Stop stays In Review, while an acknowledged Continue returns the same binding to In Progress. This pattern is useful when several observers describe one workflow but no single source provides a total order; it is unnecessary for a transactional stream with one authoritative sequence.
