### PR TITLE
fix(terminal): show IME/dictation marked text in the embedded terminal

### DIFF
--- a/LocalPackages/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/LocalPackages/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -137,6 +137,11 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     var cellDimension: CellDimension!
     var caretView: CaretView!
     public var terminal: Terminal!
+
+    /// Marked (uncommitted) text from an input source (IME, dictation, etc.).
+    private var markedTextStorage: NSAttributedString?
+    private var markedSelectedRange: NSRange = NSRange(location: NSNotFound, length: 0)
+    private var markedTextOverlay: NSTextField?
     private var progressBarView: TerminalProgressBarView?
     private var progressReportTimer: Timer?
     private var lastProgressValue: UInt8?
@@ -1161,6 +1166,9 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     }
     
     func insertText(_ string: Any, replacementRange: NSRange, isPaste: Bool) {
+        markedTextStorage = nil
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
+        updateMarkedTextOverlay()
         if let str = string as? NSString {
             if !terminal.keyboardEnhancementFlags.isEmpty {
                 if isPaste, terminal.bracketedPasteMode {
@@ -1199,7 +1207,61 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        switch string {
+        case let attributed as NSAttributedString:
+            markedTextStorage = attributed.length > 0 ? attributed : nil
+        case let plain as String:
+            markedTextStorage = plain.isEmpty ? nil : NSAttributedString(string: plain)
+        default:
+            markedTextStorage = nil
+        }
+        markedSelectedRange = selectedRange
         kittyIsComposing = true
+        updateMarkedTextOverlay()
+    }
+
+    /// Shows or hides a floating overlay that previews in-progress marked text
+    /// (e.g. dictation hypotheses or IME composition) at the current cursor position.
+    private func updateMarkedTextOverlay() {
+        guard let markedTextStorage, markedTextStorage.length > 0 else {
+            markedTextOverlay?.removeFromSuperview()
+            markedTextOverlay = nil
+            return
+        }
+
+        let overlay: NSTextField
+        if let existing = markedTextOverlay {
+            overlay = existing
+        } else {
+            overlay = NSTextField(labelWithString: "")
+            overlay.isBezeled = false
+            overlay.isEditable = false
+            overlay.drawsBackground = true
+            overlay.backgroundColor = nativeBackgroundColor.withAlphaComponent(0.9)
+            overlay.wantsLayer = true
+            overlay.layer?.cornerRadius = 3
+            addSubview(overlay, positioned: .above, relativeTo: nil)
+            markedTextOverlay = overlay
+        }
+
+        // Style the text to match the terminal font/colors with an underline.
+        let displayString = NSMutableAttributedString(attributedString: markedTextStorage)
+        let fullRange = NSRange(location: 0, length: displayString.length)
+        displayString.addAttributes([
+            .font: font,
+            .foregroundColor: nativeForegroundColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ], range: fullRange)
+        overlay.attributedStringValue = displayString
+
+        // Position at the caret.
+        overlay.sizeToFit()
+        overlay.frame.origin = caretView.frame.origin
+
+        // Clamp to view bounds so the overlay doesn't extend off-screen.
+        if overlay.frame.maxX > bounds.maxX {
+            overlay.frame.origin.x = max(0, bounds.maxX - overlay.frame.width)
+        }
     }
 
     private func kittyEncoder() -> KittyKeyboardEncoder {
@@ -1572,54 +1634,62 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     
     // NSTextInputClient protocol implementation
     open func unmarkText() {
+        markedTextStorage = nil
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
         kittyIsComposing = false
+        updateMarkedTextOverlay()
     }
-    
+
     // NSTextInputClient protocol implementation
     open func selectedRange() -> NSRange {
-        guard let selection = self.selection, selection.active else {
-            // This means "no selection":
-            return NSRange.empty
+        if let selection = self.selection, selection.active {
+            let displayBuffer = terminal.displayBuffer
+            var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
+            var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
+            if startLocation > endLocation {
+                swap(&startLocation, &endLocation)
+            }
+            let length = endLocation - startLocation
+            if length > 0 {
+                return NSRange(location: startLocation, length: length)
+            }
         }
-        
-        let displayBuffer = terminal.displayBuffer
-        var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
-        var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
-        if startLocation > endLocation {
-            swap(&startLocation, &endLocation)
-        }
-        let length = endLocation - startLocation
-        if length == 0 {
-            return NSRange.empty
-        }
-        return NSRange(location: startLocation, length: endLocation - startLocation)
+        // Return the cursor position as a zero-length selection (insertion point).
+        // The input system needs a valid location to anchor dictation and IME input.
+        let cursorLocation = terminal.buffer.y * terminal.cols + terminal.buffer.x
+        return NSRange(location: cursorLocation, length: 0)
     }
-    
+
     // NSTextInputClient protocol implementation
     open func markedRange() -> NSRange {
-        print ("markedRange: This should return the actual range from the selection")
-        
-        // This means "no marked" - when we fix, we should address
-        return NSRange.empty
+        guard let marked = markedTextStorage else {
+            return NSRange.empty
+        }
+        return NSRange(location: 0, length: marked.length)
     }
-    
+
     // NSTextInputClient protocol implementation
     open func hasMarkedText() -> Bool {
-        // print ("hasMarkedText: This should return the actual range from the selection")
-        // TODO
-        return false
+        markedTextStorage != nil
     }
-    
+
     // NSTextInputClient protocol implementation
     open func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
-        print ("Attribuetd string")
+        // Return the marked text when the requested range overlaps it.
+        if let marked = markedTextStorage, range.location != NSNotFound, range.location < marked.length {
+            let clampedLength = min(range.length, marked.length - range.location)
+            if clampedLength > 0 {
+                let clampedRange = NSRange(location: range.location, length: clampedLength)
+                actualRange?.pointee = clampedRange
+                return marked.attributedSubstring(from: clampedRange)
+            }
+        }
         return nil
     }
-    
+
     // NSTextInputClient Protocol implementation
     open func validAttributesForMarkedText() -> [NSAttributedString.Key] {
-        // TODO print ("validAttributesForMarkedText: This should return the actual range from the selection")
-        return []
+        [.underlineStyle, .markedClauseSegment, .glyphInfo]
     }
     
     // NSTextInputClient protocol implementation

--- a/LocalPackages/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
+++ b/LocalPackages/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift
@@ -1252,16 +1252,28 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
             .foregroundColor: nativeForegroundColor,
             .underlineStyle: NSUnderlineStyle.single.rawValue,
         ], range: fullRange)
+        // The clause being converted right now carries a thick underline, which
+        // is how every other macOS text view shows where an IME conversion is
+        // pointing. Without it a multi-clause Japanese composition gives no clue
+        // which part the space bar is about to change.
+        if let activeClause = fullRange.intersection(markedSelectedRange), activeClause.length > 0 {
+            displayString.addAttribute(
+                .underlineStyle, value: NSUnderlineStyle.thick.rawValue, range: activeClause)
+        }
         overlay.attributedStringValue = displayString
 
         // Position at the caret.
         overlay.sizeToFit()
         overlay.frame.origin = caretView.frame.origin
 
-        // Clamp to view bounds so the overlay doesn't extend off-screen.
-        if overlay.frame.maxX > bounds.maxX {
-            overlay.frame.origin.x = max(0, bounds.maxX - overlay.frame.width)
-        }
+        // Clamp to view bounds so the overlay doesn't extend off-screen. It is
+        // taller than the caret it is placed on, so a composition on the top
+        // row runs past the top edge the same way a long one runs past the
+        // right edge.
+        overlay.frame.origin.x = min(
+            max(bounds.minX, overlay.frame.origin.x), max(bounds.minX, bounds.maxX - overlay.frame.width))
+        overlay.frame.origin.y = min(
+            max(bounds.minY, overlay.frame.origin.y), max(bounds.minY, bounds.maxY - overlay.frame.height))
     }
 
     private func kittyEncoder() -> KittyKeyboardEncoder {
@@ -1643,9 +1655,13 @@ open class TerminalView: NSView, NSTextInputClient, NSUserInterfaceValidations, 
     // NSTextInputClient protocol implementation
     open func selectedRange() -> NSRange {
         if let selection = self.selection, selection.active {
+            // A row's offset is a count of the cells before it, so it scales
+            // with the width of a row and not with how many rows there are.
+            // Anywhere but a square terminal the two disagree, and the range
+            // handed to the input system points at the wrong cell.
             let displayBuffer = terminal.displayBuffer
-            var startLocation = (selection.start.row * displayBuffer.rows) + selection.start.col
-            var endLocation = (selection.end.row * displayBuffer.rows) + selection.end.col
+            var startLocation = (selection.start.row * displayBuffer.cols) + selection.start.col
+            var endLocation = (selection.end.row * displayBuffer.cols) + selection.end.col
             if startLocation > endLocation {
                 swap(&startLocation, &endLocation)
             }


### PR DESCRIPTION
## Problem

Typing with a CJK IME (Japanese/Chinese/Korean) in a card's embedded terminal shows nothing while composing: the pre-edit (marked) text is invisible and the candidate window opens at the screen corner instead of the caret. Text only appears after the conversion is committed. macOS dictation hypotheses are affected the same way.

## Cause

The vendored SwiftTerm predates upstream's NSTextInputClient fix (migueldeicaza/SwiftTerm#501). `setMarkedText` only toggles `kittyIsComposing` and never renders the composition, and `hasMarkedText` / `markedRange` / `attributedSubstring(forProposedRange:)` are stubs, so AppKit has nothing to anchor the candidate window to.

## Fix

Port the upstream implementation into the vendored copy (touches only `LocalPackages/SwiftTerm/Sources/SwiftTerm/Mac/MacTerminalView.swift`):

- marked text is rendered as a floating overlay at the caret position, styled with the terminal font/colors and an underline
- `markedRange` / `hasMarkedText` / `attributedSubstring` / `validAttributesForMarkedText` are implemented so the candidate window anchors at the caret
- `selectedRange` falls back to the cursor position as a zero-length insertion point, which the input system needs to anchor composition
- marked state is cleared on `insertText` / `unmarkText`

## Testing

- Built and ran locally (macOS 26, Japanese Kana IME): composition shows inline with an underline at the caret, the candidate window opens at the caret, and committed text reaches the pty exactly as before.
- English typing and paste behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
